### PR TITLE
Add GitHub CI config

### DIFF
--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -1,0 +1,21 @@
+name: DCO
+on:
+  pull_request:
+  push:
+    branches:
+      - rolling
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.x
+      uses: actions/setup-python@v1
+      with:
+        python-version: '3.x'
+    - name: Check DCO
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        pip3 install -U dco-check
+        dco-check --verbose

--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -1,0 +1,77 @@
+name: Sanity checks
+on:
+  # TODO remove the line below
+  pull_request:
+  push:
+    branches:
+      - rolling
+  schedule:
+    - cron: "0 5 * * *"
+jobs:
+  tracing:
+    runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        distro:
+          - rolling
+        build-type:
+          - binary
+          - source
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        path: ws/src/ros2/ros2_tracing
+    - uses: ros-tooling/setup-ros@master
+      with:
+        required-ros-distributions: ${{ matrix.build-type == 'binary' && matrix.distro || '' }}
+    - name: Pre-build (source)
+      run: |
+        cd $GITHUB_WORKSPACE/ws
+        vcs import src/ --input https://raw.githubusercontent.com/ros2/ros2/${{ matrix.distro }}/ros2.repos --skip-existing
+        vcs log -l1 src/
+        rosdep update
+        rosdep install -r --from-paths src --ignore-src -y --rosdistro ${{ matrix.distro }} --skip-keys "fastcdr rti-connext-dds-6.0.1 urdfdom_headers"
+        colcon build --packages-up-to tracetools ros2run ros2launch demo_nodes_cpp tracetools_launch test_tracetools
+      if: matrix.build-type == 'source'
+    - name: Install other dependencies (binary)
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y -q ros-${{ matrix.distro }}-*tracetools*
+      if: matrix.build-type == 'binary'
+    - name: Verify that tracing is disabled (binary)
+      run: |
+        source /opt/ros/${{ matrix.distro }}/setup.bash
+        (! ros2 run tracetools status)
+      if: matrix.build-type == 'binary'
+    - name: Verify that tracing is disabled (source)
+      run: |
+        cd $GITHUB_WORKSPACE/ws
+        source install/setup.bash
+        (! ros2 run tracetools status)
+      if: matrix.build-type == 'source'
+    - name: Install LTTng
+      run: |
+        sudo apt-get update
+        sudo apt-get install -q -y lttng-tools liblttng-ust-dev python3-lttng python3-babeltrace python3-pandas
+    - name: Build tracetools (binary)
+      run: |
+        cd $GITHUB_WORKSPACE/ws
+        source /opt/ros/${{ matrix.distro }}/setup.bash
+        colcon build --packages-up-to tracetools test_tracetools
+      if: matrix.build-type == 'binary'
+    - name: Build tracetools (source)
+      run: |
+        cd $GITHUB_WORKSPACE/ws
+        colcon build --packages-up-to tracetools --cmake-force-configure
+      if: matrix.build-type == 'source'
+    - name: Make sure tracing instrumentation is available
+      run: |
+        cd $GITHUB_WORKSPACE/ws
+        source install/setup.bash
+        ros2 run tracetools status
+    - name: Generate trace and make sure it is not empty
+      run: |
+        cd $GITHUB_WORKSPACE/ws
+        source install/setup.bash
+        ros2 launch tracetools_launch example.launch.py
+        babeltrace ~/.ros/tracing/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,83 @@
+name: ros2_tracing
+on:
+  pull_request:
+  push:
+    branches:
+      - rolling
+  schedule:
+    - cron: "0 5 * * *"
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          # Normal build with LTTng installed (binary)
+          - os: ubuntu-22.04
+            distro: rolling
+            build-type: binary
+            lttng: lttng-enabled
+            instrumentation: instrumentation-enabled
+          # Normal build with LTTng installed (source)
+          - os: ubuntu-22.04
+            distro: rolling
+            build-type: source
+            lttng: lttng-enabled
+            instrumentation: instrumentation-enabled
+          # Build with LTTng installed but tracing disabled
+          - os: ubuntu-22.04
+            distro: rolling
+            build-type: source
+            lttng: lttng-enabled
+            instrumentation: instrumentation-disabled
+          # Normal build without LTTng being installed
+          - os: ubuntu-22.04
+            distro: rolling
+            build-type: source
+            lttng: lttng-disabled
+            instrumentation: instrumentation-enabled
+    env:
+      ROS2_REPOS_FILE_URL: 'https://raw.githubusercontent.com/ros2/ros2/${{ matrix.distro }}/ros2.repos'
+    steps:
+    - uses: actions/checkout@v3
+    - uses: ros-tooling/setup-ros@master
+      with:
+        required-ros-distributions: ${{ matrix.build-type == 'binary' && matrix.distro || '' }}
+    - name: Install LTTng
+      run: |
+        sudo apt-get update
+        sudo apt-get install -q -y lttng-tools liblttng-ust-dev python3-lttng python3-babeltrace python3-pandas
+      if: endsWith(matrix.lttng, '-enabled')
+    - uses: ros-tooling/action-ros-ci@master
+      with:
+        package-name: ros2trace test_tracetools test_tracetools_launch tracetools tracetools_launch tracetools_read tracetools_test tracetools_trace
+        target-ros2-distro: ${{ matrix.distro }}
+        vcs-repo-file-url: ${{ matrix.build-type == 'source' && env.ROS2_REPOS_FILE_URL || '' }}
+        extra-cmake-args: ${{ endsWith(matrix.instrumentation, '-disabled') && '-DTRACETOOLS_DISABLED=ON' || '' }}
+        colcon-defaults: |
+          {
+            "build": {
+              "mixin": [
+                "coverage-gcc",
+                "coverage-pytest"
+              ]
+            },
+            "test": {
+              "mixin": [
+                "coverage-pytest"
+              ]
+            }
+          }
+    - name: Make sure tracing instrumentation is available
+      run: |
+        source ros_ws/install/setup.bash
+        ./ros_ws/build/tracetools/status
+      if: endsWith(matrix.lttng, '-enabled') && endsWith(matrix.instrumentation, '-enabled')
+    - name: Make sure tracing instrumentation is disabled
+      run: |
+        source ros_ws/install/setup.bash
+        (! ./ros_ws/build/tracetools/status)
+      if: endsWith(matrix.lttng, '-disabled') || endsWith(matrix.instrumentation, '-disabled')
+    - uses: codecov/codecov-action@v3
+      with:
+        files: ros_ws/lcov/total_coverage.info,ros_ws/coveragepy/.coverage

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -123,7 +123,7 @@ dco:
   image: $BASE_IMAGE_ID:$DISTRO-base
   script:
     - pip3 install -U dco-check
-    - dco-check --verbose
+    - dco-check --verbose --default-branch $DISTRO
 
 # Trigger docs generation
 trigger_gen_docs:

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,5 @@
 fixes:
   - "/builds/ros-tracing/ros2_tracing/::"
   - "/builds/ros-tracing/ros2_tracing/install/tracetools/::tracetools/"
+  - "/home/runner/work/ros2_tracing/ros2_tracing/ros_ws/src/ros2_tracing/::"
+  - "/home/runner/work/ros2_tracing/ros2_tracing/ros_ws/install/tracetools/::tracetools/"


### PR DESCRIPTION
This PR configures a GitHub workflow that matches the existing GitLab CI: https://gitlab.com/ros-tracing/ros2_tracing/-/blob/b695e4e367fb6e250d3147ab6b851b25a0e50299/.gitlab-ci.yml. It builds `ros2_tracing` with/without LTTng and with/without tracing being disabled, and checks if the tracing instrumentation is indeed available (or not).

The "sanity checks" workflow makes sure that the tracing instrumentation can be enabled when starting from a default source build or a binary installation, as explained in the build instructions in the README: https://github.com/ros2/ros2_tracing#building. This will also be documented on docs.ros.org, see: https://github.com/ros2/ros2_documentation/pull/2877.