### PR TITLE
Replace deprecated spin_until_future_complete

### DIFF
--- a/test_tracetools/src/test_lifecycle_client.cpp
+++ b/test_tracetools/src/test_lifecycle_client.cpp
@@ -268,7 +268,7 @@ int main(int argc, char ** argv)
 
   std::shared_future<void> script = std::async(
     std::launch::async, std::bind(cycle_through_states, client_node));
-  exec.spin_until_future_complete(script);
+  exec.spin_until_complete(script);
 
   rclcpp::shutdown();
 


### PR DESCRIPTION
Replace deprecated `spin_until_future_complete` with `spin_until_complete`

Signed-off-by: Hubert Liberacki <hliberacki@gmail.com>

action-ros-ci-repos-override: https://gist.githubusercontent.com/christophebedard/11821dfe3c6bc30740424e3f1aadc00a/raw/c89766f8e94f902dc1845a774eb0073f7eabcf10/ros2.repos