### PR TITLE
Change repo URL to GitHub & default branch to rolling

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -130,6 +130,5 @@ trigger_gen_docs:
   stage: report
   only:
     refs:
-      - master
-      - foxy
+      - rolling
   trigger: ros-tracing/ros2_tracing-api

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # ros2_tracing
 
-[![pipeline status](https://gitlab.com/ros-tracing/ros2_tracing/badges/master/pipeline.svg)](https://gitlab.com/ros-tracing/ros2_tracing/commits/master)
-[![codecov](https://codecov.io/gl/ros-tracing/ros2_tracing/branch/master/graph/badge.svg)](https://codecov.io/gl/ros-tracing/ros2_tracing)
+[![GitHub CI](https://github.com/ros2/ros2_tracing/actions/workflows/test.yml/badge.svg?branch=rolling)](https://github.com/ros2/ros2_tracing/actions/workflows/test.yml)
+[![codecov](https://codecov.io/gh/ros2/ros2_tracing/branch/rolling/graph/badge.svg)](https://codecov.io/gh/ros2/ros2_tracing)
 
 Tracing tools for ROS 2.
 
@@ -13,7 +13,7 @@ It also provides [tools to configure tracing](#tracing) through [a launch action
 `ros2_tracing` currently only supports the [LTTng](https://lttng.org/) tracer.
 Consequently, it currently only supports Linux.
 
-**Note**: make sure to use the right branch, depending on the ROS 2 distro: [use `master` for Rolling, `galactic` for Galactic, etc.](https://docs.ros.org/en/rolling/Contributing/Developer-Guide.html#branches)
+**Note**: make sure to use the right branch, depending on the ROS 2 distro: [use `rolling` for Rolling, `galactic` for Galactic, etc.](https://docs.ros.org/en/rolling/The-ROS2-Project/Contributing/Developer-Guide.html#branches)
 
 ## Publications & presentations
 
@@ -38,9 +38,9 @@ If you use or refer to `ros2_tracing`, please cite:
 ```
 </details>
 
-Also, check out the ROS World 2021 presentation titled "Tracing ROS 2 with ros2_tracing" ([video](https://vimeo.com/652633418), [slides](https://gitlab.com/ros-tracing/ros2_tracing/-/raw/master/doc/2021-10-20_ROS_World_2021_-_Tracing_ROS_2_with_ros2_tracing.pdf)).
+Also, check out the ROS World 2021 presentation titled "Tracing ROS 2 with ros2_tracing" ([video](https://vimeo.com/652633418), [slides](https://github.com/ros2/ros2_tracing/blob/rolling/doc/2021-10-20_ROS_World_2021_-_Tracing_ROS_2_with_ros2_tracing.pdf)).
 Reference:
-* C. Bédard, "Tracing ROS 2 with ros2_tracing," in *ROS World 2021*. Open Robotics, October 2021. [Online]. Available: https://vimeo.com/652633418, [(pdf)](https://gitlab.com/ros-tracing/ros2_tracing/-/raw/master/doc/2021-10-20_ROS_World_2021_-_Tracing_ROS_2_with_ros2_tracing.pdf)
+* C. Bédard, "Tracing ROS 2 with ros2_tracing," in *ROS World 2021*. Open Robotics, October 2021. [Online]. Available: https://vimeo.com/652633418, [(pdf)](https://github.com/ros2/ros2_tracing/blob/rolling/doc/2021-10-20_ROS_World_2021_-_Tracing_ROS_2_with_ros2_tracing.pdf)
 
 ## Tutorials & demos
 
@@ -75,7 +75,7 @@ To enable tracing:
     * If you rely on the ROS 2 binaries (Debian packages, release binaries, or prerelease binaries), you will need to clone this repo into your workspace and build at least up to `tracetools`:
         ```
         $ cd src/
-        $ git clone https://gitlab.com/ros-tracing/ros2_tracing.git
+        $ git clone https://github.com/ros2/ros2_tracing.git
         $ cd ../
         $ colcon build --packages-up-to tracetools
         ```

--- a/doc/design_ros_2.md
+++ b/doc/design_ros_2.md
@@ -1,6 +1,6 @@
 # `ros2_tracing`
 
-Design document for the general ROS 2 instrumentation, tracing, and analysis effort, which includes [`ros2_tracing`](https://gitlab.com/ros-tracing/ros2_tracing), a collection of flexible tracing tools and multipurpose instrumentation for ROS 2.
+Design document for the general ROS 2 instrumentation, tracing, and analysis effort, which includes [`ros2_tracing`](https://github.com/ros2/ros2_tracing), a collection of flexible tracing tools and multipurpose instrumentation for ROS 2.
 
 **Table of contents**
 1. [Introduction](#introduction)

--- a/instrumented.repos
+++ b/instrumented.repos
@@ -2,16 +2,16 @@ repositories:
   ros2/rcl:
     type: git
     url: https://github.com/ros2/rcl.git
-    version: master
+    version: rolling
   ros2/rclcpp:
     type: git
     url: https://github.com/ros2/rclcpp.git
-    version: master
+    version: rolling
   ros2/rmw_cyclonedds:
     type: git
     url: https://github.com/ros2/rmw_cyclonedds.git
-    version: master
+    version: rolling
   ros2/rmw_fastrtps:
     type: git
     url: https://github.com/ros2/rmw_fastrtps.git
-    version: master
+    version: rolling

--- a/ros2trace/package.xml
+++ b/ros2trace/package.xml
@@ -8,8 +8,8 @@
   <maintainer email="ingo.luetkebohle@de.bosch.com">Ingo Lütkebohle</maintainer>
   <license>Apache 2.0</license>
   <url type="website">https://index.ros.org/p/ros2trace/</url>
-  <url type="repository">https://gitlab.com/ros-tracing/ros2_tracing</url>
-  <url type="bugtracker">https://gitlab.com/ros-tracing/ros2_tracing/-/issues</url>
+  <url type="repository">https://github.com/ros2/ros2_tracing</url>
+  <url type="bugtracker">https://github.com/ros2/ros2_tracing/issues</url>
   <author email="fixed-term.christophe.bourquebedard@de.bosch.com">Christophe Bedard</author>
 
   <depend>ros2cli</depend>

--- a/ros2trace/setup.py
+++ b/ros2trace/setup.py
@@ -24,7 +24,7 @@ setup(
     ),
     author='Christophe Bedard',
     author_email='fixed-term.christophe.bourquebedard@de.bosch.com',
-    url='https://gitlab.com/ros-tracing/ros2_tracing',
+    url='https://github.com/ros2/ros2_tracing',
     keywords=[],
     description='The trace command for ROS 2 command line tools.',
     long_description=(

--- a/test_tracetools/package.xml
+++ b/test_tracetools/package.xml
@@ -7,9 +7,9 @@
   <maintainer email="bedard.christophe@gmail.com">Christophe Bedard</maintainer>
   <maintainer email="ingo.luetkebohle@de.bosch.com">Ingo Luetkebohle</maintainer>
   <license>Apache 2.0</license>
-  <url type="website">https://gitlab.com/ros-tracing/ros2_tracing</url>
-  <url type="repository">https://gitlab.com/ros-tracing/ros2_tracing</url>
-  <url type="bugtracker">https://gitlab.com/ros-tracing/ros2_tracing/-/issues</url>
+  <url type="website">https://github.com/ros2/ros2_tracing</url>
+  <url type="repository">https://github.com/ros2/ros2_tracing</url>
+  <url type="bugtracker">https://github.com/ros2/ros2_tracing/issues</url>
   <author email="fixed-term.christophe.bourquebedard@de.bosch.com">Christophe Bedard</author>
 
   <buildtool_depend>ament_cmake</buildtool_depend>

--- a/test_tracetools_launch/package.xml
+++ b/test_tracetools_launch/package.xml
@@ -7,9 +7,9 @@
   <maintainer email="bedard.christophe@gmail.com">Christophe Bedard</maintainer>
   <maintainer email="ingo.luetkebohle@de.bosch.com">Ingo Luetkebohle</maintainer>
   <license>Apache 2.0</license>
-  <url type="website">https://gitlab.com/ros-tracing/ros2_tracing</url>
-  <url type="repository">https://gitlab.com/ros-tracing/ros2_tracing</url>
-  <url type="bugtracker">https://gitlab.com/ros-tracing/ros2_tracing/-/issues</url>
+  <url type="website">https://github.com/ros2/ros2_tracing</url>
+  <url type="repository">https://github.com/ros2/ros2_tracing</url>
+  <url type="bugtracker">https://github.com/ros2/ros2_tracing/issues</url>
   <author email="fixed-term.christophe.bourquebedard@de.bosch.com">Christophe Bedard</author>
 
   <test_depend>ament_copyright</test_depend>

--- a/test_tracetools_launch/setup.py
+++ b/test_tracetools_launch/setup.py
@@ -23,7 +23,7 @@ setup(
     ),
     author='Christophe Bedard',
     author_email='fixed-term.christophe.bourquebedard@de.bosch.com',
-    url='https://gitlab.com/ros-tracing/ros2_tracing',
+    url='https://github.com/ros2/ros2_tracing',
     keywords=[],
     description='Tests for the tracetools_launch package.',
     license='Apache 2.0',

--- a/tracetools/Doxyfile
+++ b/tracetools/Doxyfile
@@ -1,7 +1,7 @@
 # All settings not listed here will use the Doxygen default values.
 
 PROJECT_NAME           = "tracetools"
-PROJECT_NUMBER         = master
+PROJECT_NUMBER         = rolling
 PROJECT_BRIEF          = "Tracing tools and instrumentation for ROS 2"
 
 INPUT                  = ./include

--- a/tracetools/QUALITY_DECLARATION.md
+++ b/tracetools/QUALITY_DECLARATION.md
@@ -51,7 +51,7 @@ All merge requests must have at least one peer review.
 
 All merge requests must pass CI on Ubuntu amd64.
 
-Nightly results for all [tier 1 platforms as defined in REP-2000](https://www.ros.org/reps/rep-2000.html#support-tiers) can be found here (note that only the tagged release used in the [`ros2.repos`](https://github.com/ros2/ros2/blob/master/ros2.repos) file is tested nightly):
+Nightly results for all [tier 1 platforms as defined in REP-2000](https://www.ros.org/reps/rep-2000.html#support-tiers) can be found here (note that only the tagged release used in the [`ros2.repos`](https://github.com/ros2/ros2/blob/rolling/ros2.repos) file is tested nightly):
 * [linux-aarch64_release](https://ci.ros2.org/view/nightly/job/nightly_linux-aarch64_release/lastBuild/testReport/tracetools/)
 * [linux-amd64_release](https://ci.ros2.org/view/nightly/job/nightly_linux_release/lastBuild/testReport/tracetools/)
 * [macos_release](https://ci.ros2.org/view/nightly/job/nightly_osx_release/lastBuild/testReport/tracetools/)
@@ -111,7 +111,7 @@ This includes:
 
 Changes are required to make a best effort to keep or increase coverage before being accepted, but decreases are allowed if properly justified and accepted by reviewers.
 
-Current coverage statistics can be viewed [on codecov.io](https://codecov.io/gl/ros-tracing/ros2_tracing) or in the [results of the latest `coverage` CI job](https://gitlab.com/ros-tracing/ros2_tracing/pipelines/latest).
+Current coverage statistics can be viewed [on codecov.io](https://codecov.io/gh/ros2/ros2_tracing) or in the [results of the latest `coverage` CI job](https://github.com/ros2/ros2_tracing/actions).
 
 `tracetools` might not reach the 95% goal because it uses `#ifdef` in case LTTng is not installed, but, when using and enabling LTTng, the line coverage is above 95%.
 

--- a/tracetools/package.xml
+++ b/tracetools/package.xml
@@ -8,8 +8,8 @@
   <maintainer email="ingo.luetkebohle@de.bosch.com">Ingo Luetkebohle</maintainer>
   <license>Apache 2.0</license>
   <url type="website">https://index.ros.org/p/tracetools/</url>
-  <url type="repository">https://gitlab.com/ros-tracing/ros2_tracing</url>
-  <url type="bugtracker">https://gitlab.com/ros-tracing/ros2_tracing/-/issues</url>
+  <url type="repository">https://github.com/ros2/ros2_tracing</url>
+  <url type="bugtracker">https://github.com/ros2/ros2_tracing/issues</url>
   <author email="ingo.luetkebohle@de.bosch.com">Ingo Lütkebohle</author>
   <author email="fixed-term.christophe.bourquebedard@de.bosch.com">Christophe Bedard</author>
 

--- a/tracetools_launch/package.xml
+++ b/tracetools_launch/package.xml
@@ -8,8 +8,8 @@
   <maintainer email="ingo.luetkebohle@de.bosch.com">Ingo Luetkebohle</maintainer>
   <license>Apache 2.0</license>
   <url type="website">https://index.ros.org/p/tracetools_launch/</url>
-  <url type="repository">https://gitlab.com/ros-tracing/ros2_tracing</url>
-  <url type="bugtracker">https://gitlab.com/ros-tracing/ros2_tracing/-/issues</url>
+  <url type="repository">https://github.com/ros2/ros2_tracing</url>
+  <url type="bugtracker">https://github.com/ros2/ros2_tracing/issues</url>
   <author email="fixed-term.christophe.bourquebedard@de.bosch.com">Christophe Bedard</author>
 
   <depend>launch</depend>

--- a/tracetools_launch/setup.py
+++ b/tracetools_launch/setup.py
@@ -26,7 +26,7 @@ setup(
     ),
     author='Christophe Bedard',
     author_email='fixed-term.christophe.bourquebedard@de.bosch.com',
-    url='https://gitlab.com/ros-tracing/ros2_tracing',
+    url='https://github.com/ros2/ros2_tracing',
     keywords=[],
     description='Launch integration for tracing.',
     long_description=(

--- a/tracetools_read/package.xml
+++ b/tracetools_read/package.xml
@@ -8,8 +8,8 @@
   <maintainer email="ingo.luetkebohle@de.bosch.com">Ingo Luetkebohle</maintainer>
   <license>Apache 2.0</license>
   <url type="website">https://index.ros.org/p/tracetools_read/</url>
-  <url type="repository">https://gitlab.com/ros-tracing/ros2_tracing</url>
-  <url type="bugtracker">https://gitlab.com/ros-tracing/ros2_tracing/-/issues</url>
+  <url type="repository">https://github.com/ros2/ros2_tracing</url>
+  <url type="bugtracker">https://github.com/ros2/ros2_tracing/issues</url>
   <author email="fixed-term.christophe.bourquebedard@de.bosch.com">Christophe Bedard</author>
 
   <exec_depend>python3-babeltrace</exec_depend>

--- a/tracetools_read/setup.py
+++ b/tracetools_read/setup.py
@@ -23,7 +23,7 @@ setup(
     ),
     author='Christophe Bedard',
     author_email='fixed-term.christophe.bourquebedard@de.bosch.com',
-    url='https://gitlab.com/ros-tracing/ros2_tracing',
+    url='https://github.com/ros2/ros2_tracing',
     keywords=[],
     description='Tools for reading traces.',
     license='Apache 2.0',

--- a/tracetools_test/package.xml
+++ b/tracetools_test/package.xml
@@ -8,8 +8,8 @@
   <maintainer email="ingo.luetkebohle@de.bosch.com">Ingo Luetkebohle</maintainer>
   <license>Apache 2.0</license>
   <url type="website">https://index.ros.org/p/tracetools_test/</url>
-  <url type="repository">https://gitlab.com/ros-tracing/ros2_tracing</url>
-  <url type="bugtracker">https://gitlab.com/ros-tracing/ros2_tracing/-/issues</url>
+  <url type="repository">https://github.com/ros2/ros2_tracing</url>
+  <url type="bugtracker">https://github.com/ros2/ros2_tracing/issues</url>
   <author email="fixed-term.christophe.bourquebedard@de.bosch.com">Christophe Bedard</author>
 
   <depend>launch</depend>

--- a/tracetools_test/setup.py
+++ b/tracetools_test/setup.py
@@ -23,7 +23,7 @@ setup(
     ),
     author='Christophe Bedard',
     author_email='fixed-term.christophe.bourquebedard@de.bosch.com',
-    url='https://gitlab.com/ros-tracing/ros2_tracing',
+    url='https://github.com/ros2/ros2_tracing',
     keywords=[],
     description='Utilities for tracing-related tests.',
     license='Apache 2.0',

--- a/tracetools_trace/package.xml
+++ b/tracetools_trace/package.xml
@@ -8,8 +8,8 @@
   <maintainer email="ingo.luetkebohle@de.bosch.com">Ingo Luetkebohle</maintainer>
   <license>Apache 2.0</license>
   <url type="website">https://index.ros.org/p/tracetools_trace/</url>
-  <url type="repository">https://gitlab.com/ros-tracing/ros2_tracing</url>
-  <url type="bugtracker">https://gitlab.com/ros-tracing/ros2_tracing/-/issues</url>
+  <url type="repository">https://github.com/ros2/ros2_tracing</url>
+  <url type="bugtracker">https://github.com/ros2/ros2_tracing/issues</url>
   <author email="fixed-term.christophe.bourquebedard@de.bosch.com">Christophe Bedard</author>
 
   <exec_depend>python3-lttng</exec_depend>

--- a/tracetools_trace/setup.py
+++ b/tracetools_trace/setup.py
@@ -23,7 +23,7 @@ setup(
     ),
     author='Christophe Bedard',
     author_email='fixed-term.christophe.bourquebedard@de.bosch.com',
-    url='https://gitlab.com/ros-tracing/ros2_tracing',
+    url='https://github.com/ros2/ros2_tracing',
     keywords=[],
     description='Tools for setting up tracing sessions.',
     long_description=(

--- a/tracetools_trace/tracetools_trace/tools/lttng.py
+++ b/tracetools_trace/tracetools_trace/tools/lttng.py
@@ -80,7 +80,7 @@ def is_lttng_installed() -> bool:
     """
     message_doc = (
         'Cannot trace. See documentation at: '
-        'https://gitlab.com/ros-tracing/ros2_tracing'
+        'https://github.com/ros2/ros2_tracing'
     )
     system = platform.system()
     if 'Linux' != system:

--- a/tracetools_trace/tracetools_trace/tools/lttng_impl.py
+++ b/tracetools_trace/tracetools_trace/tools/lttng_impl.py
@@ -123,7 +123,7 @@ def setup(
                 "    'ros2 trace' command: cannot use '-k' option\n"
                 "    'Trace' action: cannot set 'events_kernel'/'events-kernel' list\n"
                 '  install the kernel tracer, e.g., on Ubuntu, install lttng-modules-dkms\n'
-                '  see: https://gitlab.com/ros-tracing/ros2_tracing#building'
+                '  see: https://github.com/ros2/ros2_tracing#building'
             )
             return None
 

--- a/tracing.repos
+++ b/tracing.repos
@@ -1,8 +1,8 @@
 repositories:
-  ros-tracing/ros2_tracing:
+  ros2/ros2_tracing:
     type: git
-    url: https://gitlab.com/ros-tracing/ros2_tracing.git
-    version: master
+    url: https://github.com/ros2/ros2_tracing.git
+    version: rolling
   tracetools_analysis:
     type: git
     url: https://gitlab.com/ros-tracing/tracetools_analysis.git


### PR DESCRIPTION
And update other relevant links.

For the move from GitLab to GitHub, see: https://gitlab.com/ros-tracing/ros2_tracing/-/issues/144#move-checklist

Signed-off-by: Christophe Bedard <christophe.bedard@apex.ai>