### PR TITLE
Mirror rolling to master

### DIFF
--- a/.github/workflows/mirror-rolling-to-master.yaml
+++ b/.github/workflows/mirror-rolling-to-master.yaml
@@ -1,0 +1,13 @@
+name: Mirror rolling to master
+
+on:
+  push:
+    branches: [ rolling ]
+
+jobs:
+  mirror-to-master:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: zofrex/mirror-branch@v1
+      with:
+        target-branch: master


### PR DESCRIPTION
Relates to: https://gitlab.com/ros-tracing/ros2_tracing/-/issues/144

See: https://discourse.ros.org/t/change-default-branch-name-to-rolling-in-ros-2-core/26009

This exact same file is used by all other repos, e.g.: https://github.com/ros2/rclcpp/blob/b953bdddf8de213b4a051ecf2d668dad65ff9f89/.github/workflows/mirror-rolling-to-master.yaml

Signed-off-by: Christophe Bedard <christophe.bedard@apex.ai>