### PR TITLE
Improve local CI testing config

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,7 +65,11 @@ jobs:
             "test": {
               "mixin": [
                 "coverage-pytest"
-              ]
+              ],
+              "executor": "sequential",
+              "retest-until-pass": 2,
+              "ctest-args": ["-LE", "xfail"],
+              "pytest-args": ["-m", "not xfail"]
             }
           }
     - name: Make sure tracing instrumentation is available


### PR DESCRIPTION
By using the `colcon test` arguments that are used on ci.ros2.org: `--executor sequential --retest-until-pass 2 --ctest-args -LE xfail --pytest-args -m "not xfail"`. Retesting a second time when a test fails should reduce flakyness.

Signed-off-by: Christophe Bedard <bedard.christophe@gmail.com>