### PR TITLE
Use binaries from pre-release/testing apt repository

### DIFF
--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -24,6 +24,7 @@ jobs:
     - uses: ros-tooling/setup-ros@master
       with:
         required-ros-distributions: ${{ matrix.build-type == 'binary' && matrix.distro || '' }}
+        use-ros2-testing: true
     - name: Pre-build (source)
       run: |
         cd $GITHUB_WORKSPACE/ws

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,6 +43,7 @@ jobs:
     - uses: ros-tooling/setup-ros@master
       with:
         required-ros-distributions: ${{ matrix.build-type == 'binary' && matrix.distro || '' }}
+        use-ros2-testing: true
     - name: Install LTTng
       run: |
         sudo apt-get update


### PR DESCRIPTION
Otherwise binary jobs can fail if breaking-ish changes are introduced, since we still build part of the code from source.

Signed-off-by: Christophe Bedard <christophe.bedard@apex.ai>