### PR TITLE
Disable binary test CI job

### DIFF
--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -17,7 +17,7 @@ jobs:
         distro:
           - rolling
         build-type:
-          # - binary
+          - binary
           - source
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -17,7 +17,7 @@ jobs:
         distro:
           - rolling
         build-type:
-          - binary
+          # - binary
           - source
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -23,7 +23,7 @@ jobs:
     - uses: actions/checkout@v3
       with:
         path: ws/src/ros2/ros2_tracing
-    - uses: ros-tooling/setup-ros@master
+    - uses: ros-tooling/setup-ros@christophebedard/ubuntu-prefer-system-packages
       with:
         required-ros-distributions: ${{ matrix.build-type == 'binary' && matrix.distro || '' }}
         use-ros2-testing: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,12 +14,12 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # # Normal build with LTTng installed (binary)
-          # - os: ubuntu-22.04
-          #   distro: rolling
-          #   build-type: binary
-          #   lttng: lttng-enabled
-          #   instrumentation: instrumentation-enabled
+          # Normal build with LTTng installed (binary)
+          - os: ubuntu-22.04
+            distro: rolling
+            build-type: binary
+            lttng: lttng-enabled
+            instrumentation: instrumentation-enabled
           # Normal build with LTTng installed (source)
           - os: ubuntu-22.04
             distro: rolling

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,12 +14,12 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # Normal build with LTTng installed (binary)
-          - os: ubuntu-22.04
-            distro: rolling
-            build-type: binary
-            lttng: lttng-enabled
-            instrumentation: instrumentation-enabled
+          # # Normal build with LTTng installed (binary)
+          # - os: ubuntu-22.04
+          #   distro: rolling
+          #   build-type: binary
+          #   lttng: lttng-enabled
+          #   instrumentation: instrumentation-enabled
           # Normal build with LTTng installed (source)
           - os: ubuntu-22.04
             distro: rolling

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,7 +42,7 @@ jobs:
       ROS2_REPOS_FILE_URL: 'https://raw.githubusercontent.com/ros2/ros2/${{ matrix.distro }}/ros2.repos'
     steps:
     - uses: actions/checkout@v3
-    - uses: ros-tooling/setup-ros@master
+    - uses: ros-tooling/setup-ros@christophebedard/ubuntu-prefer-system-packages
       with:
         required-ros-distributions: ${{ matrix.build-type == 'binary' && matrix.distro || '' }}
         use-ros2-testing: true


### PR DESCRIPTION
The nightly binary jobs have started failing a week or so ago.

See https://github.com/ros-tooling/action-ros-ci/issues/768

Signed-off-by: Christophe Bedard <christophe.bedard@apex.ai>