### PR TITLE
Disable fail-fast in CI configs

### DIFF
--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -11,6 +11,7 @@ jobs:
   tracing:
     runs-on: ubuntu-22.04
     strategy:
+      fail-fast: false
       matrix:
         distro:
           - rolling

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,9 @@ on:
 jobs:
   test:
     runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ matrix.build-type == 'binary' }}
     strategy:
+      fail-fast: false
       matrix:
         include:
           # Normal build with LTTng installed (binary)


### PR DESCRIPTION
Possible alternative to #8. This should allow other jobs to keep running (and not get cancelled) even if the binary jobs fail. Hopefully the binary jobs somehow fix themselves soon.

Signed-off-by: Christophe Bedard <christophe.bedard@apex.ai>