### PR TITLE
Enable 'continue-on-error' for sanity checks job too

### DIFF
--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -10,6 +10,7 @@ on:
 jobs:
   tracing:
     runs-on: ubuntu-22.04
+    continue-on-error: ${{ matrix.build-type == 'binary' }}
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Follow-up to #9, I missed this.

Signed-off-by: Christophe Bedard <bedard.christophe@gmail.com>