### PR TITLE
Remove deprecated context_names parameter

### DIFF
--- a/tracetools_launch/tracetools_launch/action.py
+++ b/tracetools_launch/tracetools_launch/action.py
@@ -114,11 +114,6 @@ class Trace(Action):
         context_fields:
             Union[Iterable[SomeSubstitutionsType], Dict[str, Iterable[SomeSubstitutionsType]]]
             = names.DEFAULT_CONTEXT,
-        context_names:
-            Optional[
-                Union[Iterable[SomeSubstitutionsType], Dict[str, Iterable[SomeSubstitutionsType]]]
-            ]
-            = None,
         **kwargs,
     ) -> None:
         """
@@ -144,7 +139,6 @@ class Trace(Action):
             if it's a list or a set, the context fields are enabled for both kernel and userspace;
             if it's a dictionary: { domain type string -> context fields list }
                 with the domain type string being either 'kernel' or 'userspace'
-        :param context_names: DEPRECATED, use context_fields instead
         """
         super().__init__(**kwargs)
         self.__logger = logging.get_logger(__name__)
@@ -155,11 +149,6 @@ class Trace(Action):
         self.__trace_directory = None
         self.__events_ust = [normalize_to_list_of_substitutions(x) for x in events_ust]
         self.__events_kernel = [normalize_to_list_of_substitutions(x) for x in events_kernel]
-        # Use value from deprecated param if it is provided
-        # TODO(christophebedard) remove context_names param in Rolling after Humble release
-        if context_names is not None:
-            context_fields = context_names
-            self.__logger.warning('context_names parameter is deprecated, use context_fields')
         self.__context_fields = \
             {
                 domain: [normalize_to_list_of_substitutions(field) for field in fields]
@@ -191,11 +180,6 @@ class Trace(Action):
 
     @property
     def context_fields(self):
-        return self.__context_fields
-
-    @property
-    def context_names(self):
-        self.__logger.warning('context_names parameter is deprecated, use context_fields')
         return self.__context_fields
 
     @classmethod
@@ -286,10 +270,6 @@ class Trace(Action):
         if context_fields is not None:
             kwargs['context_fields'] = cls._parse_cmdline(context_fields, parser) \
                 if context_fields else []
-        context_names = entity.get_attr('context-names', optional=True)
-        if context_names is not None:
-            kwargs['context_names'] = cls._parse_cmdline(context_names, parser) \
-                if context_names else []
 
         return cls, kwargs
 

--- a/tracetools_trace/tracetools_trace/tools/lttng_impl.py
+++ b/tracetools_trace/tracetools_trace/tools/lttng_impl.py
@@ -25,7 +25,6 @@ from typing import Optional
 from typing import Set
 from typing import Tuple
 from typing import Union
-import warnings
 
 import lttng
 
@@ -72,7 +71,6 @@ def setup(
     ros_events: Union[List[str], Set[str]] = DEFAULT_EVENTS_ROS,
     kernel_events: Union[List[str], Set[str]] = [],
     context_fields: Union[List[str], Set[str], Dict[str, List[str]]] = DEFAULT_CONTEXT,
-    context_names: Optional[Union[List[str], Set[str], Dict[str, List[str]]]] = None,
     channel_name_ust: str = 'ros2',
     channel_name_kernel: str = 'kchan',
 ) -> Optional[str]:
@@ -91,17 +89,10 @@ def setup(
     :param context_fields: the names of context fields to enable
         if it's a list or a set, the context fields are enabled for both kernel and userspace;
         if it's a dictionary: { domain type string -> context fields list }
-    :param context_names: DEPRECATED, use context_fields instead
     :param channel_name_ust: the UST channel name
     :param channel_name_kernel: the kernel channel name
     :return: the full path to the trace directory, or `None` if initialization failed
     """
-    # Use value from deprecated param if it is provided
-    # TODO(christophebedard) remove context_names param in Rolling after Humble release
-    if context_names is not None:
-        context_fields = context_names
-        warnings.warn('context_names parameter is deprecated, use context_fields', stacklevel=4)
-
     # Check if there is a session daemon running
     if lttng.session_daemon_alive() == 0:
         # Otherwise spawn one and check if it worked

--- a/tracetools_trace/tracetools_trace/trace.py
+++ b/tracetools_trace/tracetools_trace/trace.py
@@ -68,7 +68,7 @@ def init(
     else:
         print('kernel tracing disabled')
     if len(context_fields) > 0:
-        print(f'context ({len(context_fields)} names)')
+        print(f'context ({len(context_fields)} fields)')
         if display_list:
             print_names_list(context_fields)
 


### PR DESCRIPTION
Closes #37

The `context_names` parameter was deprecated and replaced with `context_fields` in Rolling before the Humble release, so we can remove it now.

I've also changed "names" to "fields" in a printed message.

Signed-off-by: Christophe Bedard <christophe.bedard@apex.ai>