### PR TITLE
Fix memory leak in tracetools::get_symbol()

### DIFF
--- a/test_tracetools/test/test_utils.cpp
+++ b/test_tracetools/test/test_utils.cpp
@@ -37,54 +37,62 @@ public:
   }
 };
 
-/*
-   Testing symbol resolution for std::function object created from a function pointer.
+/**
+ * Testing symbol resolution for std::function object created from a function pointer.
  */
 TEST(TestUtils, valid_symbol_funcptr) {
   std::function<void(std::shared_ptr<int>)> f = &function_shared;
-  EXPECT_STREQ(tracetools::get_symbol(f), "function_shared(std::shared_ptr<int>)") <<
+  char * symbol = tracetools::get_symbol(f);
+  EXPECT_STREQ(symbol, "function_shared(std::shared_ptr<int>)") <<
     "invalid symbol";
+  std::free(symbol);
 }
 
-/*
-   Testing get_symbol_funcptr from a null pointer.
+/**
+ * Testing get_symbol_funcptr from a null pointer.
  */
 TEST(TestUtils, invalid_get_symbol_funcptr) {
-  EXPECT_STREQ(tracetools::detail::get_symbol_funcptr(nullptr), TRACETOOLS_SYMBOL_UNKNOWN);
+  EXPECT_EQ(tracetools::detail::get_symbol_funcptr(nullptr), nullptr);
 }
 
-/*
-   Testing symbol resolution for std::function object created from a lambda.
+/**
+ * Testing symbol resolution for std::function object created from a lambda.
  */
 TEST(TestUtils, valid_symbol_lambda) {
   std::function<int(int)> l = [](int num) {return num + 1;};
+  char * symbol = tracetools::get_symbol(l);
   EXPECT_STREQ(
-    tracetools::get_symbol(l),
+    symbol,
     "TestUtils_valid_symbol_lambda_Test::TestBody()::{lambda(int)#1}") <<
     "invalid symbol";
+  std::free(symbol);
 }
 
-/*
-   Testing symbol resolution lambdas with capture.
+/**
+ * Testing symbol resolution lambdas with capture.
  */
 TEST(TestUtils, valid_symbol_lambda_capture) {
   int num = 1;
 
   auto l = [ = ]() {return num + 1;};
+  char * symbol = tracetools::get_symbol(l);
   EXPECT_STREQ(
-    tracetools::get_symbol(l),
+    symbol,
     "TestUtils_valid_symbol_lambda_capture_Test::TestBody()::{lambda()#1}") <<
     "invalid symbol";
+  std::free(symbol);
 
   auto m = [&](int other_num) {return num + other_num;};
+  symbol = tracetools::get_symbol(m);
   EXPECT_STREQ(
-    tracetools::get_symbol(m),
+    symbol,
     "TestUtils_valid_symbol_lambda_capture_Test::TestBody()::{lambda(int)#2}") <<
     "invalid symbol";
+  std::free(symbol);
 }
 
-/*
-   Testing symbol resolution for std::function object created from std::bind.
+/**
+ * Testing symbol resolution for std::function object created from std::bind.
  */
 TEST(TestUtils, valid_symbol_bind) {
   SomeClassWithCallback scwc;
@@ -94,12 +102,13 @@ TEST(TestUtils, valid_symbol_bind) {
     std::placeholders::_1,
     std::placeholders::_2
   );
+  char * symbol = tracetools::get_symbol(fscwc);
   EXPECT_STREQ(
-    tracetools::get_symbol(
-      fscwc),
+    symbol,
     "std::_Bind<void (SomeClassWithCallback::*(SomeClassWithCallback*, "
     "std::_Placeholder<1>, std::_Placeholder<2>))(int, std::__cxx11::basic_string"
     "<char, std::char_traits<char>, std::allocator<char> >)>")
     <<
     "invalid symbol";
+  std::free(symbol);
 }

--- a/tracetools/include/tracetools/utils.hpp
+++ b/tracetools/include/tracetools/utils.hpp
@@ -20,9 +20,6 @@
 
 #include "tracetools/config.h"
 
-/// Default symbol, used when address resolution fails.
-#define TRACETOOLS_SYMBOL_UNKNOWN "UNKNOWN"
-
 #ifndef TRACETOOLS_DISABLED
 
 namespace tracetools
@@ -33,28 +30,30 @@ namespace detail
 
 /// Demangle symbol string.
 /**
- * Internal function.
+ * \param[in] mangled the pointer to the mangled symbol string
+ * \return the demangled symbol, or nullptr if demangling failed. The caller is responsible for
+ * deallocating this memory using free.
  */
-const char * demangle_symbol(const char * mangled);
+char * demangle_symbol(const char * mangled);
 
-/// Get symbol string from function pointer.
+/// Get demangled symbol string from function pointer.
 /**
- * Internal function.
+ * \param[in] funcptr the function pointer
+ * \return the demangled symbol, or nullptr if the pointer could not be matched to a shared object
+ * or if demangling failed. The caller is responsible for deallocating this memory using free.
  */
-const char * get_symbol_funcptr(void * funcptr);
+char * get_symbol_funcptr(const void * funcptr);
 
 }  // namespace detail
 
-/// Get symbol from an std::function object.
+/// Get demangled symbol from an std::function object.
 /**
- * If function address resolution or symbol demangling fails,
- * this will return a string that starts with \ref TRACETOOLS_SYMBOL_UNKNOWN.
- *
  * \param[in] f the std::function object
- * \return the symbol, or a placeholder
+ * \return the symbol, or nullptr if the symbol could not be retrieved or if demangling failed. The
+ * caller is responsible for deallocating this memory using free.
  */
 template<typename T, typename ... U>
-const char * get_symbol(std::function<T(U...)> f)
+char * get_symbol(std::function<T(U...)> f)
 {
   typedef T (fnType)(U...);
   fnType ** fnPointer = f.template target<fnType *>();
@@ -67,15 +66,16 @@ const char * get_symbol(std::function<T(U...)> f)
   return detail::demangle_symbol(f.target_type().name());
 }
 
-/// Get symbol from a function-related object.
+/// Get demangled symbol from a function-related object.
 /**
  * Fallback meant for lambdas with captures.
  *
  * \param[in] l a generic object
- * \return the symbol
+ * \return the symbol, or nullptr if demangling failed. The caller is responsible for deallocating
+ * this memory using free.
  */
 template<typename L>
-const char * get_symbol(L && l)
+char * get_symbol(L && l)
 {
   return detail::demangle_symbol(typeid(l).name());
 }

--- a/tracetools/src/utils.cpp
+++ b/tracetools/src/utils.cpp
@@ -16,10 +16,9 @@
 
 #ifndef TRACETOOLS_DISABLED
 
-#ifdef TRACETOOLS_LTTNG_ENABLED
 #include <dlfcn.h>
 #include <cxxabi.h>
-#endif
+
 #include "tracetools/utils.hpp"
 
 namespace tracetools
@@ -28,33 +27,20 @@ namespace tracetools
 namespace detail
 {
 
-const char * demangle_symbol(const char * mangled)
+char * demangle_symbol(const char * mangled)
 {
-#ifdef TRACETOOLS_LTTNG_ENABLED
-  char * demangled = nullptr;
-  int status;
-  demangled = abi::__cxa_demangle(mangled, NULL, 0, &status);
-  // Use demangled symbol if possible
-  const char * demangled_val = (status == 0 ? demangled : mangled);
-  return demangled_val != 0 ? demangled_val : TRACETOOLS_SYMBOL_UNKNOWN "_demangling_failed";
-#else
-  (void)mangled;
-  return "DISABLED__demangle_symbol";
-#endif
+  int status = 1;
+  char * demangled = abi::__cxa_demangle(mangled, NULL, NULL, &status);
+  return status == 0 ? demangled : nullptr;
 }
 
-const char * get_symbol_funcptr(void * funcptr)
+char * get_symbol_funcptr(const void * funcptr)
 {
-#ifdef TRACETOOLS_LTTNG_ENABLED
   Dl_info info;
   if (dladdr(funcptr, &info) == 0) {
-    return TRACETOOLS_SYMBOL_UNKNOWN;
+    return nullptr;
   }
   return demangle_symbol(info.dli_sname);
-#else
-  (void)funcptr;
-  return "DISABLED__get_symbol_funcptr";
-#endif
 }
 
 }  // namespace detail


### PR DESCRIPTION
Fixes #34

`tracetools::get_symbol()` is used to get a demangled symbol from a function pointer or `std::function` object. This is used to associate a human-readable string to a callback in the trace data. To do symbol demangling, it calls [`abi::__cxa_demangle()`, which returns a pointer that must be freed by the caller](https://gcc.gnu.org/onlinedocs/libstdc++/libstdc++-html-USERS-4.3/a01696.html). This was never freed. The best solution would be to use a limited size buffer on the stack and never allocate. However, while `abi::__cxa_demangle` _can_ accept a pre-allocated buffer, it cannot be on the stack, since `abi::__cxa_demangle` expands it using `realloc` if it is not long enough.

Since the pointer to the demangled symbol must be freed, the problem is that `tracetools::get_symbol()` was returning a pointer to a literal when something failed (e.g., demangling, or mapping from function pointer to shared object), so we couldn't always `free()` the return value. There's no real use to returning anything other than `nullptr` when something fails.

Changes:

* Change `tracetools::get_symbol()` to return `char *` instead of `const char *`, and to return `nullptr` when something fails
   * Do the same for the underlying/internal functions.
   * Document that the return value should be freed by the caller.
* Change `get_symbol_funcptr(void * funcptr)` to `get_symbol_funcptr(const void * funcptr)`, since that's more appropriate
* Remove the `#ifdef TRACETOOLS_LTTNG_ENABLED` conditions in `tracetools::detail::{demangle_symbol,get_symbol_funcptr}`, since there's no real need to do anything different if `TRACETOOLS_LTTNG_ENABLED` is defined. These functions shouldn't be called in that case anyway.
* Update corresponding test (`test_tracetools`'s `test_utils`)

This PR breaks ABI and requires the following downstream changes:

* Update calls to `tracetools::get_symbol()` to free the memory
   * Downstream callers could use the new `TRACEPOINT_ENABLED()` and `DO_TRACEPOINT()` macros (#46) to avoid allocating memory when the tracepoint is disabled

Downstream PR:

* https://github.com/ros2/rclcpp/pull/2104

Signed-off-by: Christophe Bedard <christophe.bedard@apex.ai>