### PR TITLE
5.0.0

### DIFF
--- a/ros2trace/package.xml
+++ b/ros2trace/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>ros2trace</name>
-  <version>4.1.0</version>
+  <version>5.0.0</version>
   <description>The trace command for ROS 2 command line tools.</description>
   <maintainer email="bedard.christophe@gmail.com">Christophe Bedard</maintainer>
   <maintainer email="ingo.luetkebohle@de.bosch.com">Ingo Lütkebohle</maintainer>

--- a/ros2trace/setup.py
+++ b/ros2trace/setup.py
@@ -5,7 +5,7 @@ package_name = 'ros2trace'
 
 setup(
     name=package_name,
-    version='4.1.0',
+    version='5.0.0',
     packages=find_packages(exclude=['test']),
     data_files=[
         ('share/' + package_name, ['package.xml']),

--- a/test_tracetools/CHANGELOG.rst
+++ b/test_tracetools/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package test_tracetools
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* Update tracing to C++17. (`#33 <https://github.com/ros2/ros2_tracing/issues/33>`_)
+* Contributors: Chris Lalancette
+
 4.0.0 (2022-01-20)
 ------------------
 * Introduce constants for tracepoint names

--- a/test_tracetools/CHANGELOG.rst
+++ b/test_tracetools/CHANGELOG.rst
@@ -2,8 +2,8 @@
 Changelog for package test_tracetools
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+5.0.0 (2023-02-14)
+------------------
 * Update tracing to C++17. (`#33 <https://github.com/ros2/ros2_tracing/issues/33>`_)
 * Contributors: Chris Lalancette
 

--- a/test_tracetools/package.xml
+++ b/test_tracetools/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>test_tracetools</name>
-  <version>4.1.0</version>
+  <version>5.0.0</version>
   <description>Tests for the tracetools package.</description>
   <maintainer email="bedard.christophe@gmail.com">Christophe Bedard</maintainer>
   <maintainer email="ingo.luetkebohle@de.bosch.com">Ingo Luetkebohle</maintainer>

--- a/test_tracetools_launch/package.xml
+++ b/test_tracetools_launch/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>test_tracetools_launch</name>
-  <version>4.1.0</version>
+  <version>5.0.0</version>
   <description>Tests for the tracetools_launch package.</description>
   <maintainer email="bedard.christophe@gmail.com">Christophe Bedard</maintainer>
   <maintainer email="ingo.luetkebohle@de.bosch.com">Ingo Luetkebohle</maintainer>

--- a/test_tracetools_launch/setup.py
+++ b/test_tracetools_launch/setup.py
@@ -5,7 +5,7 @@ package_name = 'test_tracetools_launch'
 
 setup(
     name=package_name,
-    version='4.1.0',
+    version='5.0.0',
     packages=find_packages(exclude=['test']),
     data_files=[
         ('share/' + package_name, ['package.xml']),

--- a/tracetools/CHANGELOG.rst
+++ b/tracetools/CHANGELOG.rst
@@ -2,8 +2,8 @@
 Changelog for package tracetools
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+5.0.0 (2023-02-14)
+------------------
 * Update tracing to C++17. (`#33 <https://github.com/ros2/ros2_tracing/issues/33>`_)
 * Contributors: Chris Lalancette
 

--- a/tracetools/CHANGELOG.rst
+++ b/tracetools/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package tracetools
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* Update tracing to C++17. (`#33 <https://github.com/ros2/ros2_tracing/issues/33>`_)
+* Contributors: Chris Lalancette
+
 4.1.0 (2022-03-29)
 ------------------
 * Install headers to include/${PROJECT_NAME}

--- a/tracetools/package.xml
+++ b/tracetools/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>tracetools</name>
-  <version>4.1.0</version>
+  <version>5.0.0</version>
   <description>Tracing wrapper for ROS 2.</description>
   <maintainer email="bedard.christophe@gmail.com">Christophe Bedard</maintainer>
   <maintainer email="ingo.luetkebohle@de.bosch.com">Ingo Luetkebohle</maintainer>

--- a/tracetools_launch/CHANGELOG.rst
+++ b/tracetools_launch/CHANGELOG.rst
@@ -2,8 +2,8 @@
 Changelog for package tracetools_launch
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+5.0.0 (2023-02-14)
+------------------
 * Remove deprecated context_names parameter (`#38 <https://github.com/ros2/ros2_tracing/issues/38>`_)
 * Contributors: Christophe Bedard
 

--- a/tracetools_launch/CHANGELOG.rst
+++ b/tracetools_launch/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package tracetools_launch
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* Remove deprecated context_names parameter (`#38 <https://github.com/ros2/ros2_tracing/issues/38>`_)
+* Contributors: Christophe Bedard
+
 4.0.0 (2022-01-20)
 ------------------
 * Disable kernel tracing by default

--- a/tracetools_launch/package.xml
+++ b/tracetools_launch/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>tracetools_launch</name>
-  <version>4.1.0</version>
+  <version>5.0.0</version>
   <description>Launch integration for tracing.</description>
   <maintainer email="bedard.christophe@gmail.com">Christophe Bedard</maintainer>
   <maintainer email="ingo.luetkebohle@de.bosch.com">Ingo Luetkebohle</maintainer>

--- a/tracetools_launch/setup.py
+++ b/tracetools_launch/setup.py
@@ -7,7 +7,7 @@ package_name = 'tracetools_launch'
 
 setup(
     name=package_name,
-    version='4.1.0',
+    version='5.0.0',
     packages=find_packages(exclude=['test']),
     data_files=[
         ('share/' + package_name, ['package.xml']),

--- a/tracetools_read/package.xml
+++ b/tracetools_read/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>tracetools_read</name>
-  <version>4.1.0</version>
+  <version>5.0.0</version>
   <description>Tools for reading traces.</description>
   <maintainer email="bedard.christophe@gmail.com">Christophe Bedard</maintainer>
   <maintainer email="ingo.luetkebohle@de.bosch.com">Ingo Luetkebohle</maintainer>

--- a/tracetools_read/setup.py
+++ b/tracetools_read/setup.py
@@ -5,7 +5,7 @@ package_name = 'tracetools_read'
 
 setup(
     name=package_name,
-    version='4.1.0',
+    version='5.0.0',
     packages=find_packages(exclude=['test']),
     data_files=[
         ('share/' + package_name, ['package.xml']),

--- a/tracetools_test/package.xml
+++ b/tracetools_test/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>tracetools_test</name>
-  <version>4.1.0</version>
+  <version>5.0.0</version>
   <description>Utilities for tracing-related tests.</description>
   <maintainer email="bedard.christophe@gmail.com">Christophe Bedard</maintainer>
   <maintainer email="ingo.luetkebohle@de.bosch.com">Ingo Luetkebohle</maintainer>

--- a/tracetools_test/setup.py
+++ b/tracetools_test/setup.py
@@ -5,7 +5,7 @@ package_name = 'tracetools_test'
 
 setup(
     name=package_name,
-    version='4.1.0',
+    version='5.0.0',
     packages=find_packages(exclude=['test']),
     data_files=[
         ('share/' + package_name, ['package.xml']),

--- a/tracetools_trace/CHANGELOG.rst
+++ b/tracetools_trace/CHANGELOG.rst
@@ -2,8 +2,8 @@
 Changelog for package tracetools_trace
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+5.0.0 (2023-02-14)
+------------------
 * Replace distutils.version.StrictVersion with packaging.version.Version (`#42 <https://github.com/ros2/ros2_tracing/issues/42>`_)
 * Remove deprecated context_names parameter (`#38 <https://github.com/ros2/ros2_tracing/issues/38>`_)
 * Contributors: Christophe Bedard

--- a/tracetools_trace/CHANGELOG.rst
+++ b/tracetools_trace/CHANGELOG.rst
@@ -2,6 +2,12 @@
 Changelog for package tracetools_trace
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* Replace distutils.version.StrictVersion with packaging.version.Version (`#42 <https://github.com/ros2/ros2_tracing/issues/42>`_)
+* Remove deprecated context_names parameter (`#38 <https://github.com/ros2/ros2_tracing/issues/38>`_)
+* Contributors: Christophe Bedard
+
 4.0.0 (2022-01-20)
 ------------------
 * Disable kernel tracing by default

--- a/tracetools_trace/package.xml
+++ b/tracetools_trace/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>tracetools_trace</name>
-  <version>4.1.0</version>
+  <version>5.0.0</version>
   <description>Tools for setting up tracing sessions.</description>
   <maintainer email="bedard.christophe@gmail.com">Christophe Bedard</maintainer>
   <maintainer email="ingo.luetkebohle@de.bosch.com">Ingo Luetkebohle</maintainer>

--- a/tracetools_trace/setup.py
+++ b/tracetools_trace/setup.py
@@ -5,7 +5,7 @@ package_name = 'tracetools_trace'
 
 setup(
     name=package_name,
-    version='4.1.0',
+    version='5.0.0',
     packages=find_packages(exclude=['test']),
     data_files=[
         ('share/' + package_name, ['package.xml']),


### PR DESCRIPTION
This PR releases 5.0.0.

Note that I chose a major bump because the set of changes since 4.1.0 includes the removal of an API.

Once this is approved and merged, I will tag and release the package for Rolling.