### PR TITLE
Explicitly link against dl for dladdr()

### DIFF
--- a/tracetools/CMakeLists.txt
+++ b/tracetools/CMakeLists.txt
@@ -81,6 +81,10 @@ if(TRACETOOLS_LTTNG_ENABLED)
     target_link_libraries(${PROJECT_NAME} "-rdynamic")
   endif()
 endif()
+if(NOT TRACETOOLS_DISABLED)
+  # Explicitly linking against dl for dladdr() seems to be required for RHEL
+  target_link_libraries(${PROJECT_NAME} "${CMAKE_LINK_LIBRARY_FLAG}dl")
+endif()
 
 if(NOT TRACETOOLS_DISABLED)
   # Only use output/binary include directory


### PR DESCRIPTION
Fix regression introduced by #43 on RHEL.

It looks like we need to explicitly link against dl on RHEL. Note that, if `TRACETOOLS_LTTNG_ENABLED`, LTTng's link flags already include `-ldl`.

Signed-off-by: Christophe Bedard <bedard.christophe@gmail.com>