### PR TITLE
Enable document generation using rosdoc2 for ament_python pkgs

### DIFF
--- a/tracetools_launch/package.xml
+++ b/tracetools_launch/package.xml
@@ -16,6 +16,8 @@
   <depend>launch_ros</depend>
   <depend>tracetools_trace</depend>
 
+  <exec_depend>launch</exec_depend>
+
   <test_depend>ament_copyright</test_depend>
   <test_depend>ament_flake8</test_depend>
   <test_depend>ament_mypy</test_depend>

--- a/tracetools_launch/package.xml
+++ b/tracetools_launch/package.xml
@@ -12,11 +12,9 @@
   <url type="bugtracker">https://github.com/ros2/ros2_tracing/issues</url>
   <author email="fixed-term.christophe.bourquebedard@de.bosch.com">Christophe Bedard</author>
 
-  <depend>launch</depend>
-  <depend>launch_ros</depend>
-  <depend>tracetools_trace</depend>
-
   <exec_depend>launch</exec_depend>
+  <exec_depend>launch_ros</exec_depend>
+  <exec_depend>tracetools_trace</exec_depend>
 
   <test_depend>ament_copyright</test_depend>
   <test_depend>ament_flake8</test_depend>

--- a/tracetools_trace/tracetools_trace/tools/lttng_impl.py
+++ b/tracetools_trace/tracetools_trace/tools/lttng_impl.py
@@ -42,7 +42,7 @@ def get_version() -> Optional[Version]:
 
     :return: the version as a Version object, or `None` if it cannot be extracted
     """
-    doc_lines = lttng.__doc__.split('\n')
+    doc_lines = str(lttng.__doc__).split('\n')
     filtered_doc_lines: List[str] = list(filter(None, doc_lines))
     if len(filtered_doc_lines) == 0:
         return None

--- a/tracetools_trace/tracetools_trace/trace.py
+++ b/tracetools_trace/tracetools_trace/trace.py
@@ -42,7 +42,7 @@ def init(
 
     :param session_name: the name of the session
     :param base_path: the path to the directory in which to create the tracing session directory,
-    or `None` for default
+        or `None` for default
     :param ros_events: list of ROS events to enable
     :param kernel_events: list of kernel events to enable
     :param context_fields: list of context fields to enable


### PR DESCRIPTION
Fix missing `exec_depends` in `package.xmls` and docstrings to generate documentation without any warnings using `autodoc`

>Note: Without explictly casting `lttng.__doc__` to string, `autodoc` cannot infer it's type since dep modules are not imported.