### PR TITLE
Disable tracing on macOS

### DIFF
--- a/test_tracetools/CMakeLists.txt
+++ b/test_tracetools/CMakeLists.txt
@@ -13,7 +13,7 @@ endif()
 
 find_package(ament_cmake REQUIRED)
 
-if(WIN32)
+if(WIN32 OR APPLE)
   set(DISABLED_DEFAULT ON)
 else()
   set(DISABLED_DEFAULT OFF)

--- a/tracetools/CMakeLists.txt
+++ b/tracetools/CMakeLists.txt
@@ -15,7 +15,7 @@ endif()
 
 find_package(ament_cmake_ros REQUIRED)
 
-if(WIN32)
+if(WIN32 OR APPLE)
   set(DISABLED_DEFAULT ON)
   set(STATUS_CHECKING_TOOL_DEFAULT OFF)
 else()


### PR DESCRIPTION
Fixes #52

Prior to #31, `tracetools` tried to look for LTTng-UST on macOS and Linux, and just disabled tracing if it wasn't found. However, LTTng-UST is now required. Just like we do for Windows, just disable tracing and don't try to look for LTTng on macOS.