### PR TITLE
Improve 'ros2 trace' command error handling & add end-to-end tests

### DIFF
--- a/ros2trace/package.xml
+++ b/ros2trace/package.xml
@@ -20,7 +20,13 @@
   <test_depend>ament_mypy</test_depend>
   <test_depend>ament_pep257</test_depend>
   <test_depend>ament_xmllint</test_depend>
+  <test_depend>launch</test_depend>
+  <test_depend>launch_ros</test_depend>
   <test_depend>python3-pytest</test_depend>
+  <test_depend>ros2run</test_depend>
+  <test_depend>test_tracetools</test_depend>
+  <test_depend>tracetools</test_depend>
+  <test_depend>tracetools_read</test_depend>
 
   <export>
     <build_type>ament_python</build_type>

--- a/ros2trace/ros2trace/command/trace.py
+++ b/ros2trace/ros2trace/command/trace.py
@@ -16,8 +16,7 @@
 
 from ros2cli.command import CommandExtension
 from tracetools_trace.tools import args
-from tracetools_trace.trace import fini
-from tracetools_trace.trace import init
+from tracetools_trace.trace import trace
 
 
 class TraceCommand(CommandExtension):
@@ -27,16 +26,4 @@ class TraceCommand(CommandExtension):
         args.add_arguments(parser)
 
     def main(self, *, parser, args):
-        if not init(
-            session_name=args.session_name,
-            base_path=args.path,
-            ros_events=args.events_ust,
-            kernel_events=args.events_kernel,
-            context_fields=args.context_fields,
-            display_list=args.list,
-        ):
-            return 1
-        fini(
-            session_name=args.session_name,
-        )
-        return 0
+        return trace(args)

--- a/ros2trace/test/ros2trace/test_trace.py
+++ b/ros2trace/test/ros2trace/test_trace.py
@@ -1,0 +1,351 @@
+# Copyright 2023 Apex.AI, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import shutil
+import subprocess
+import tempfile
+from typing import Dict
+from typing import List
+from typing import Optional
+from typing import Tuple
+import unittest
+
+from launch import LaunchDescription
+from launch import LaunchService
+from launch_ros.actions import Node
+from tracetools_trace.tools import tracepoints
+from tracetools_trace.tools.lttng import is_lttng_installed
+
+
+def are_tracepoints_included() -> bool:
+    """
+    Check if tracing instrumentation is enabled and if tracepoints are included.
+
+    :return: True if tracepoints are included, False otherwise
+    """
+    if not is_lttng_installed():
+        return False
+    process = subprocess.run(
+        ['ros2', 'run', 'tracetools', 'status'],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        encoding='utf-8',
+    )
+    return 0 == process.returncode
+
+
+@unittest.skipIf(not is_lttng_installed(minimum_version='2.9.0'), 'LTTng is required')
+class TestROS2TraceCLI(unittest.TestCase):
+
+    def __init__(self, *args) -> None:
+        super().__init__(
+            *args,
+        )
+
+    def setUp(self) -> None:
+        # Make sure there are no existing tracing sessions before running a test
+        self.assertNoTracingSession()
+
+    def tearDown(self) -> None:
+        # Make sure there are no leftover tracing sessions after running a test
+        # Even if running 'ros2 trace' fails, we do not want any lingering tracing session
+        self.assertNoTracingSession()
+
+    def assertNoTracingSession(self) -> None:
+        output = self.run_lttng_list()
+        # If there is no session daemon, then there are no tracing sessions
+        no_session_daemon_available = 'No session daemon is available' in output
+        if no_session_daemon_available:
+            return
+        # Starting from LTTng 2.13, 'tracing session' was replaced with 'recording session'
+        # (see lttng-tools e971184)
+        no_tracing_sessions = any(
+            f'Currently no available {name} session' in output for name in ('tracing', 'recording')
+        )
+        if not no_tracing_sessions:
+            # Destroy tracing sessions if there are any, this way we can continue running tests and
+            # avoid possible interference between them
+            self.run_lttng_destroy_all()
+        self.assertTrue(no_tracing_sessions, 'tracing session(s) exist:\n' + output)
+
+    def assertTraceExist(self, trace_dir: str) -> None:
+        self.assertTrue(os.path.isdir(trace_dir), f'trace directory does not exist: {trace_dir}')
+
+    def assertTraceNotExist(self, trace_dir: str) -> None:
+        self.assertFalse(os.path.isdir(trace_dir), f'trace directory exists: {trace_dir}')
+
+    def assertTraceContains(
+        self,
+        trace_dir: str,
+        expected_trace_data: List[Tuple[str, str]],
+    ) -> None:
+        self.assertTraceExist(trace_dir)
+        from tracetools_read.trace import get_trace_events
+        events = get_trace_events(trace_dir)
+        for trace_data in expected_trace_data:
+            self.assertTrue(
+                any(trace_data in event.items() for event in events),
+                f'{trace_data} not found in events: {events}',
+            )
+
+    def create_test_tmpdir(self, test_name: str) -> str:
+        prefix = self.__class__.__name__ + '__' + test_name
+        return tempfile.mkdtemp(prefix=prefix)
+
+    def get_subdirectories(self, directory: str) -> List[str]:
+        return [f.name for f in os.scandir(directory) if f.is_dir()]
+
+    def run_lttng_list(self) -> str:
+        process = subprocess.run(
+            ['lttng', 'list'],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            encoding='utf-8',
+        )
+        return process.stdout + process.stderr
+
+    def run_lttng_destroy_all(self):
+        process = subprocess.run(
+            ['lttng', 'destroy', '--all'],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            encoding='utf-8',
+        )
+        output = process.stdout + process.stderr
+        self.assertEqual(0, process.returncode, f"'lttng destroy' command failed: {output}")
+
+    def run_trace_command_start(
+        self,
+        args: List[str],
+        *,
+        env: Optional[Dict[str, str]] = None,
+        wait_for_start: bool = False,
+    ) -> subprocess.Popen:
+        args = ['ros2', 'trace', *args]
+        print('=>running:', args)
+        process_env = os.environ.copy()
+        process_env['PYTHONUNBUFFERED'] = '1'
+        if env:
+            process_env.update(env)
+        process = subprocess.Popen(
+            args,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            encoding='utf-8',
+            env=process_env,
+        )
+        # Write <enter> to stdin to start tracing
+        assert process.stdin
+        process.stdin.write('\n')
+        process.stdin.flush()
+        # If needed, wait until tracing has started by waiting until 'ros2 trace' is ready to stop
+        if wait_for_start:
+            assert process.stdout
+            stdout = ''
+            while 'press enter to stop...' not in stdout:
+                stdout += process.stdout.read(1)
+        return process
+
+    def run_trace_command_stop(
+        self,
+        process: subprocess.Popen,
+    ) -> int:
+        # Write <enter> to stdin to stop tracing
+        assert process.stdin
+        process.stdin.write('\n')
+        process.stdin.flush()
+        stdout, stderr = process.communicate()
+        stdout = stdout.strip(' \r\n\t')
+        stderr = stderr.strip(' \r\n\t')
+        print('=>stdout:\n' + stdout)
+        print('=>stderr:\n' + stderr)
+        return process.wait()
+
+    def run_trace_command(
+        self,
+        args: List[str],
+        *,
+        env: Optional[Dict[str, str]] = None,
+    ) -> int:
+        process = self.run_trace_command_start(args, env=env)
+        return self.run_trace_command_stop(process)
+
+    def test_default(self) -> None:
+        tmpdir = self.create_test_tmpdir('test_default')
+
+        # Test with the default session name
+        ret = self.run_trace_command(['--path', tmpdir])
+        self.assertEqual(0, ret)
+        # Check that the trace directory was created
+        subdirs = self.get_subdirectories(tmpdir)
+        self.assertEqual(1, len(subdirs))
+        self.assertTrue(subdirs[0].startswith('session-'))
+
+        # Test with a provided session name
+        ret = self.run_trace_command(['--path', tmpdir, '--session-name', 'test_default'])
+        self.assertEqual(0, ret)
+        self.assertTraceExist(os.path.join(tmpdir, 'test_default'))
+
+        shutil.rmtree(tmpdir)
+
+    @unittest.skipIf(not are_tracepoints_included(), 'tracepoints are required')
+    def test_default_tracing(self) -> None:
+        tmpdir = self.create_test_tmpdir('test_default_tracing')
+
+        def run_nodes():
+            nodes = [
+                Node(
+                    package='test_tracetools',
+                    executable='test_ping',
+                    output='screen',
+                ),
+                Node(
+                    package='test_tracetools',
+                    executable='test_pong',
+                    output='screen',
+                ),
+            ]
+            ld = LaunchDescription(nodes)
+            ls = LaunchService()
+            ls.include_launch_description(ld)
+            exit_code = ls.run()
+            self.assertEqual(0, exit_code)
+
+        # Test with the default session name
+        process = self.run_trace_command_start(
+            ['--path', tmpdir, '--ust', tracepoints.rcl_subscription_init],
+            wait_for_start=True,
+        )
+        run_nodes()
+        ret = self.run_trace_command_stop(process)
+        self.assertEqual(0, ret)
+        # Check that the trace directory was created
+        subdirs = self.get_subdirectories(tmpdir)
+        self.assertEqual(1, len(subdirs))
+        trace_dir_name = subdirs[0]
+        self.assertTrue(trace_dir_name.startswith('session-'))
+        trace_dir = os.path.join(tmpdir, trace_dir_name)
+        # Check that the trace contains at least the publishers/subscriptions we expect
+        self.assertTraceContains(
+            trace_dir,
+            [
+                ('topic_name', '/ping'),
+                ('topic_name', '/pong'),
+            ],
+        )
+
+        # Test with a provided session name
+        process = self.run_trace_command_start(
+            [
+                '--path', tmpdir,
+                '--ust', tracepoints.rcl_subscription_init,
+                '--session-name', 'test_default_tracing',
+            ],
+            wait_for_start=True,
+        )
+        run_nodes()
+        ret = self.run_trace_command_stop(process)
+        self.assertEqual(0, ret)
+        self.assertTraceContains(
+            os.path.join(tmpdir, 'test_default_tracing'),
+            [
+                ('topic_name', '/ping'),
+                ('topic_name', '/pong'),
+            ],
+        )
+
+        shutil.rmtree(tmpdir)
+
+    def test_env_var_ros_trace_dir(self) -> None:
+        tmpdir = self.create_test_tmpdir('test_env_var_ros_trace_dir')
+
+        # Env var only
+        ret = self.run_trace_command(
+            ['--session-name', 'test_env_var_ros_trace_dir'],
+            env={'ROS_TRACE_DIR': tmpdir},
+        )
+        self.assertEqual(0, ret)
+        self.assertTraceExist(os.path.join(tmpdir, 'test_env_var_ros_trace_dir'))
+
+        # Env var and argument should use argument
+        tmpdir_path = self.create_test_tmpdir('test_env_var_ros_trace_dir__arg')
+        ret = self.run_trace_command(
+            ['--path', tmpdir_path, '--session-name', 'test_env_var_ros_trace_dir2'],
+            env={'ROS_TRACE_DIR': tmpdir},
+        )
+        self.assertEqual(0, ret)
+        self.assertTraceExist(os.path.join(tmpdir_path, 'test_env_var_ros_trace_dir2'))
+        self.assertTraceNotExist(os.path.join(tmpdir, 'test_env_var_ros_trace_dir2'))
+
+        shutil.rmtree(tmpdir_path)
+        shutil.rmtree(tmpdir)
+
+    def test_env_var_ros_home(self) -> None:
+        tmpdir = self.create_test_tmpdir('test_env_var_ros_home')
+
+        ret = self.run_trace_command(
+            ['--session-name', 'test_env_var_ros_home'],
+            env={'ROS_HOME': tmpdir},
+        )
+        self.assertEqual(0, ret)
+        # Under the 'tracing' directory
+        self.assertTraceExist(os.path.join(tmpdir, 'tracing', 'test_env_var_ros_home'))
+
+        # Env var and argument should use argument
+        tmpdir_path = self.create_test_tmpdir('test_env_var_ros_home__arg')
+        ret = self.run_trace_command(
+            ['--path', tmpdir_path, '--session-name', 'test_env_var_ros_home2'],
+            env={'ROS_HOME': tmpdir},
+        )
+        self.assertEqual(0, ret)
+        self.assertTraceExist(os.path.join(tmpdir_path, 'test_env_var_ros_home2'))
+        self.assertTraceNotExist(os.path.join(tmpdir, 'test_env_var_ros_home2'))
+
+        shutil.rmtree(tmpdir_path)
+        shutil.rmtree(tmpdir)
+
+    def test_empty_session_name(self) -> None:
+        tmpdir = self.create_test_tmpdir('test_env_var_ros_home')
+
+        # Empty session name should result in an error
+        ret = self.run_trace_command(['--session-name', ''])
+        self.assertEqual(1, ret)
+
+        shutil.rmtree(tmpdir)
+
+    def test_base_path_not_exist(self) -> None:
+        tmpdir = self.create_test_tmpdir('test_base_path_not_exist')
+
+        # Base directory should be created if it does not exist
+        fake_base_path = os.path.join(tmpdir, 'doesnt_exist')
+        ret = self.run_trace_command(
+            ['--path', fake_base_path, '--session-name', 'test_base_path_not_exist'],
+        )
+        self.assertEqual(0, ret)
+        self.assertTraceExist(os.path.join(fake_base_path, 'test_base_path_not_exist'))
+
+        shutil.rmtree(tmpdir)
+
+    def test_unknown_context_field(self) -> None:
+        tmpdir = self.create_test_tmpdir('test_unknown_context_field')
+
+        # Unknown context field should result in an error
+        ret = self.run_trace_command(
+            ['--path', tmpdir, '--context', 'some_nonexistent_context_field'],
+        )
+        self.assertEqual(1, ret)
+
+        shutil.rmtree(tmpdir)

--- a/tracetools_trace/test/tracetools_trace/test_lttng_tracing.py
+++ b/tracetools_trace/test/tracetools_trace/test_lttng_tracing.py
@@ -78,14 +78,16 @@ class TestLttngTracing(unittest.TestCase):
 
     def test_no_kernel_tracer(self):
         from tracetools_trace.tools.lttng_impl import setup
-        with mock.patch(
-            'tracetools_trace.tools.lttng_impl.is_kernel_tracer_available',
-            return_value=(False, 'some error message'),
+        with (
+            mock.patch(
+                'tracetools_trace.tools.lttng_impl.is_kernel_tracer_available',
+                return_value=(False, 'some error message'),
+            ),
+            mock.patch('lttng.session_daemon_alive', return_value=1),
         ):
-            with mock.patch('lttng.session_daemon_alive', return_value=1):
-                self.assertIsNone(
-                    setup(
-                        session_name='test-session',
-                        base_path='/tmp',
-                        kernel_events=['sched_switch'],
-                    ))
+            with self.assertRaises(RuntimeError):
+                setup(
+                    session_name='test-session',
+                    base_path='/tmp',
+                    kernel_events=['sched_switch'],
+                )

--- a/tracetools_trace/tracetools_trace/tools/lttng.py
+++ b/tracetools_trace/tracetools_trace/tools/lttng.py
@@ -58,6 +58,8 @@ def lttng_init(**kwargs) -> Optional[str]:
 
     For the full list of kwargs, see `lttng_impl.setup()`.
 
+    Raises RuntimeError on failure, in which case the tracing session might still exist.
+
     :return: the full path to the trace directory, or `None` if initialization failed
     """
     if not is_lttng_installed():
@@ -73,6 +75,8 @@ def lttng_init(**kwargs) -> Optional[str]:
 def lttng_fini(**kwargs) -> None:
     """
     Stop and destroy LTTng session.
+
+    Raises RuntimeError on failure.
 
     :param session_name: the name of the session
     """

--- a/tracetools_trace/tracetools_trace/tools/lttng_impl.py
+++ b/tracetools_trace/tracetools_trace/tools/lttng_impl.py
@@ -84,13 +84,17 @@ def setup(
     Initialization will fail if the list of kernel events to be
     enabled is not empty and if the kernel tracer is not installed.
 
+    Raises RuntimeError on failure, in which case the tracing session might still exist.
+
     :param session_name: the name of the session
-    :param base_path: the path to the directory in which to create the tracing session directory
+    :param base_path: the path to the directory in which to create the tracing session directory,
+        which will be created if needed
     :param ros_events: list of ROS events to enable
     :param kernel_events: list of kernel events to enable
     :param context_fields: the names of context fields to enable
         if it's a list or a set, the context fields are enabled for both kernel and userspace;
         if it's a dictionary: { domain type string -> context fields list }
+            with the domain type string being either 'kernel' or 'userspace'
     :param channel_name_ust: the UST channel name
     :param channel_name_kernel: the kernel channel name
     :param subbuffer_size_ust: the size of the subbuffers for userspace events (defaults to 8 times
@@ -99,6 +103,10 @@ def setup(
         times the usual page size, since there can be way more kernel events than UST events)
     :return: the full path to the trace directory, or `None` if initialization failed
     """
+    # Validate parameters
+    if not session_name:
+        raise RuntimeError('empty session name')
+
     # Check if there is a session daemon running
     if lttng.session_daemon_alive() == 0:
         # Otherwise spawn one and check if it worked
@@ -106,23 +114,21 @@ def setup(
             ['lttng-sessiond', '--daemonize'],
         )
         if lttng.session_daemon_alive() == 0:
-            print('error: failed to start lttng session daemon')
-            return None
+            raise RuntimeError('failed to start lttng session daemon')
 
     # Make sure the kernel tracer is available if there are kernel events
     # Do this after spawning a session daemon, otherwise we can't detect the kernel tracer
     if 0 < len(kernel_events):
         kernel_tracer_available, message = is_kernel_tracer_available()
         if not kernel_tracer_available:
-            print(
-                f'error: kernel tracer is not available: {message}\n'
+            raise RuntimeError(
+                f'kernel tracer is not available: {message}\n'
                 '  cannot use kernel events:\n'
                 "    'ros2 trace' command: cannot use '-k' option\n"
                 "    'Trace' action: cannot set 'events_kernel'/'events-kernel' list\n"
                 '  install the kernel tracer, e.g., on Ubuntu, install lttng-modules-dkms\n'
                 '  see: https://github.com/ros2/ros2_tracing#building'
             )
-            return None
 
     # Convert lists to sets
     if not isinstance(ros_events, set):
@@ -131,9 +137,6 @@ def setup(
         kernel_events = set(kernel_events)
     if isinstance(context_fields, list):
         context_fields = set(context_fields)
-
-    # Resolve full tracing directory path
-    full_path = os.path.join(base_path, session_name)
 
     ust_enabled = ros_events is not None and len(ros_events) > 0
     kernel_enabled = kernel_events is not None and len(kernel_events) > 0
@@ -176,7 +179,9 @@ def setup(
         channel_kernel.attr.output = lttng.EVENT_MMAP
         events_list_kernel = _create_events(kernel_events)
 
-    # Session
+    # Resolve full tracing directory path and create session
+    # LTTng will create the parent directories if needed
+    full_path = os.path.join(base_path, session_name)
     _create_session(session_name, full_path)
 
     # Handles, channels, events
@@ -207,6 +212,8 @@ def start(
     """
     Start LTTng session, and check for errors.
 
+    Raises RuntimeError on failure to start.
+
     :param session_name: the name of the session
     """
     result = lttng.start(session_name)
@@ -217,30 +224,38 @@ def start(
 def stop(
     *,
     session_name: str,
+    ignore_error: bool = False,
     **kwargs,
 ) -> None:
     """
     Stop LTTng session, and check for errors.
 
+    Raises RuntimeError on failure to stop, unless ignored.
+
     :param session_name: the name of the session
+    :param ignore_error: whether to ignore any error when stopping
     """
     result = lttng.stop(session_name)
-    if result < 0:
+    if result < 0 and not ignore_error:
         raise RuntimeError(f'failed to stop tracing: {lttng.strerror(result)}')
 
 
 def destroy(
     *,
     session_name: str,
+    ignore_error: bool = False,
     **kwargs,
 ) -> None:
     """
     Destroy LTTng session, and check for errors.
 
+    Raises RuntimeError on failure to stop, unless ignored.
+
     :param session_name: the name of the session
+    :param ignore_error: whether to ignore any error when destroying
     """
     result = lttng.destroy(session_name)
-    if result < 0:
+    if result < 0 and not ignore_error:
         raise RuntimeError(f'failed to destroy tracing session: {lttng.strerror(result)}')
 
 


### PR DESCRIPTION
Closes #26

Closes #36

This improves error handling and error report in `tracetools_trace`. The common functions used by `ros2trace` (for the `ros2 trace` command) and `tracetools_launch` (for the `Trace` launch action) now do not print anything; they raise exceptions where appropriate. Then, `ros2 trace`/`Trace` can catch any error and report it using the appropriate method: print to `stderr` for `ros2 trace` and log error for `Trace`.

This also makes sure to destroy the tracing session if it exists when tracing configuration fails.

Finally, this adds end-to-end tests for the `ros2 trace` command to cover the main cases. It also improves parameter validation for the session name.

Signed-off-by: Christophe Bedard <christophe.bedard@apex.ai>