### PR TITLE
Improve tracetools rosdoc2/doxygen output

### DIFF
--- a/tracetools/Doxyfile
+++ b/tracetools/Doxyfile
@@ -5,6 +5,7 @@ PROJECT_NUMBER         = rolling
 PROJECT_BRIEF          = "Tracing tools and instrumentation for ROS 2"
 
 INPUT                  = ./include
+EXCLUDE                = ./include/tracetools/tp_call.h
 
 RECURSIVE              = YES
 OUTPUT_DIRECTORY       = doc_output
@@ -18,13 +19,23 @@ ENABLE_PREPROCESSING   = YES
 MACRO_EXPANSION        = YES
 EXPAND_ONLY_PREDEF     = NO
 PREDEFINED             = \
-    "TRACETOOLS_PUBLIC="
+    "TRACETOOLS_LOCAL=" \
+    "TRACETOOLS_PUBLIC=" \
+    "TRACETOOLS_PUBLIC_TYPE="
 
 EXCLUDE_SYMBOLS        = \
+    "_GET_MACRO" \
+    "_TRACEPOINT_NOARGS" \
+    "_TRACEPOINT_ARGS" \
+    "_DO_TRACEPOINT_NOARGS" \
+    "_DO_TRACEPOINT_ARGS" \
+    "_DECLARE_TRACEPOINT_NOARGS" \
+    "_DECLARE_TRACEPOINT_ARGS" \
+    "_GET_MACRO_TRACEPOINT" \
+    "_GET_MACRO_DO_TRACEPOINT" \
+    "_GET_MACRO_DECLARE_TRACEPOINT" \
     "DECLARE_TRACEPOINT" \
-    "tracetools::detail*" \
-    "_demangle_symbol" \
-    "_get_symbol_funcptr"
+    "tracetools::detail*"
 
 # Tag files that do not exist will produce a warning and cross-project linking will not work.
 TAGFILES += "../../../../../doxygen_tag_files/cppreference-doxygen-web.tag.xml=http://en.cppreference.com/w/"

--- a/tracetools/include/tracetools/tracetools.h
+++ b/tracetools/include/tracetools/tracetools.h
@@ -85,14 +85,33 @@
 /**
  * The first argument is mandatory and should be the tracepoint event name.
  * The other arguments should be the tracepoint arguments.
- * This is the preferred method over calling the actual function directly.
+ * This is the preferred method over calling the underlying function directly.
  *
  * This macro currently supports up to 9 tracepoint arguments after the event name.
  */
 #  define TRACEPOINT(...) \
   _GET_MACRO_TRACEPOINT(__VA_ARGS__)(__VA_ARGS__)
+/// Check if a tracepoint is enabled at runtime.
+/**
+ * This can be useful to only compute tracepoint arguments if the tracepoint is actually enabled at
+ * runtime. Combine this with `DO_TRACEPOINT()` instead of `TRACEPOINT()` to trigger a tracepoint
+ * after checking if it is enabled and computing its arguments.
+ *
+ * This is the preferred method over calling the underlying function directly.
+ */
 #  define TRACEPOINT_ENABLED(event_name) \
   ros_trace_enabled_ ## event_name()
+/// Call a tracepoint, without checking if it is enabled.
+/**
+ * Combine this with `TRACEPOINT_ENABLED()` to check if a tracepoint is enabled before triggering
+ * it.
+ *
+ * The first argument is mandatory and should be the tracepoint event name.
+ * The other arguments should be the tracepoint arguments.
+ * This is the preferred method over calling the underlying function directly.
+ *
+ * This macro currently supports up to 9 tracepoint arguments after the event name.
+ */
 #  define DO_TRACEPOINT(...) \
   _GET_MACRO_DO_TRACEPOINT(__VA_ARGS__)(__VA_ARGS__)
 #  define DECLARE_TRACEPOINT(...) \


### PR DESCRIPTION
This documents the new `TRACEPOINT_ENABLED()`/`DO_TRACEPOINT()` macros.

This also modifies `tracetools`' `Doxyfile` to improve the `rosdoc2` output. I excluded a bunch of internal macros. Unfortunately, due to the macro wizardry with the tracepoint declarations in `tracetools.h` (see `DECLARE_TRACEPOINT()`), I can't quite get Doxygen to detect the generated functions for the tracepoints properly, so the generated documentation unfortunately does not list the tracepoints. It's at least better than the current output, which is pretty useless: https://docs.ros.org/en/humble/p/tracetools/generated/index.html

Signed-off-by: Christophe Bedard <bedard.christophe@gmail.com>