### PR TITLE
Error out if trace already exists unless 'append' option is used

### DIFF
--- a/ros2trace/test/ros2trace/test_trace.py
+++ b/ros2trace/test/ros2trace/test_trace.py
@@ -349,3 +349,34 @@ class TestROS2TraceCLI(unittest.TestCase):
         self.assertEqual(1, ret)
 
         shutil.rmtree(tmpdir)
+
+    def test_append_trace(self) -> None:
+        tmpdir = self.create_test_tmpdir('test_append_trace')
+
+        # Generate a normal trace
+        ret = self.run_trace_command(
+            ['--path', tmpdir, '--session-name', 'test_append_trace'],
+        )
+        self.assertEqual(0, ret)
+        trace_dir = os.path.join(tmpdir, 'test_append_trace')
+        self.assertTraceExist(trace_dir)
+
+        # Generating another trace with the same path should error out
+        ret = self.run_trace_command(
+            ['--path', tmpdir, '--session-name', 'test_append_trace'],
+        )
+        self.assertEqual(1, ret)
+        self.assertTraceExist(trace_dir)
+
+        # But it should work if we use the '--append-trace' option
+        ret = self.run_trace_command(
+            [
+                '--path', tmpdir,
+                '--session-name', 'test_append_trace',
+                '--append-trace',
+            ],
+        )
+        self.assertEqual(0, ret)
+        self.assertTraceExist(trace_dir)
+
+        shutil.rmtree(tmpdir)

--- a/test_tracetools_launch/test/test_tracetools_launch/test_trace_action.py
+++ b/test_tracetools_launch/test/test_tracetools_launch/test_trace_action.py
@@ -20,6 +20,7 @@ import shutil
 import tempfile
 import textwrap
 from typing import List
+from typing import Optional
 import unittest
 
 from launch import LaunchDescription
@@ -43,18 +44,31 @@ class TestTraceAction(unittest.TestCase):
             *args,
         )
 
-    def _assert_launch_no_errors(self, actions) -> None:
+    def setUp(self) -> None:
+        self.assertIsNone(os.environ.get('LD_PRELOAD'))
+
+    def tearDown(self) -> None:
+        if 'LD_PRELOAD' in os.environ:
+            del os.environ['LD_PRELOAD']
+
+    def _assert_launch(self, actions) -> int:
         ld = LaunchDescription(actions)
         ls = LaunchService(debug=True)
         ls.include_launch_description(ld)
-        assert 0 == ls.run()
+        return ls.run()
+
+    def _assert_launch_no_errors(self, actions) -> None:
+        self.assertEqual(0, self._assert_launch(actions), 'expected no errors')
+
+    def _assert_launch_errors(self, actions) -> None:
+        self.assertEqual(1, self._assert_launch(actions), 'expected errors')
 
     def _assert_launch_frontend_no_errors(self, file) -> Trace:
         root_entity, parser = Parser.load(file)
         ld = parser.parse_description(root_entity)
         ls = LaunchService()
         ls.include_launch_description(ld)
-        assert 0 == ls.run()
+        self.assertEqual(0, ls.run(), 'expected no errors')
         trace_action = ld.describe_sub_entities()[0]
         return trace_action
 
@@ -62,14 +76,18 @@ class TestTraceAction(unittest.TestCase):
         self,
         action,
         tmpdir,
-        session_name: str = 'my-session-name',
+        *,
+        session_name: Optional[str] = 'my-session-name',
+        append_trace: bool = False,
         events_ust: List[str] = ['ros2:*', '*'],
         subbuffer_size_ust: int = 524288,
         subbuffer_size_kernel: int = 1048576,
     ) -> None:
-        self.assertEqual(session_name, action.session_name)
+        if session_name is not None:
+            self.assertEqual(session_name, action.session_name)
         self.assertEqual(tmpdir, action.base_path)
         self.assertTrue(action.trace_directory.startswith(tmpdir))
+        self.assertEqual(append_trace, action.append_trace)
         self.assertEqual([], action.events_kernel)
         self.assertEqual(events_ust, action.events_ust)
         self.assertTrue(pathlib.Path(tmpdir).exists())
@@ -77,7 +95,6 @@ class TestTraceAction(unittest.TestCase):
         self.assertEqual(subbuffer_size_kernel, action.subbuffer_size_kernel)
 
     def test_action(self) -> None:
-        self.assertIsNone(os.environ.get('LD_PRELOAD'))
         tmpdir = tempfile.mkdtemp(prefix='TestTraceAction__test_action')
 
         # Disable kernel events just to not require kernel tracing for the test
@@ -96,10 +113,8 @@ class TestTraceAction(unittest.TestCase):
         self._check_trace_action(action, tmpdir)
 
         shutil.rmtree(tmpdir)
-        del os.environ['LD_PRELOAD']
 
     def test_action_frontend_xml(self) -> None:
-        self.assertIsNone(os.environ.get('LD_PRELOAD'))
         tmpdir = tempfile.mkdtemp(prefix='TestTraceAction__test_frontend_xml')
 
         xml_file = textwrap.dedent(
@@ -107,7 +122,9 @@ class TestTraceAction(unittest.TestCase):
             <launch>
                 <trace
                     session-name="my-session-name"
+                    append-timestamp="false"
                     base-path="{}"
+                    append-trace="true"
                     events-kernel=""
                     events-ust="ros2:* *"
                     subbuffer-size-ust="524288"
@@ -121,13 +138,11 @@ class TestTraceAction(unittest.TestCase):
         with io.StringIO(xml_file) as f:
             trace_action = self._assert_launch_frontend_no_errors(f)
 
-        self._check_trace_action(trace_action, tmpdir)
+        self._check_trace_action(trace_action, tmpdir, append_trace=True)
 
         shutil.rmtree(tmpdir)
-        del os.environ['LD_PRELOAD']
 
     def test_action_frontend_yaml(self) -> None:
-        self.assertIsNone(os.environ.get('LD_PRELOAD'))
         tmpdir = tempfile.mkdtemp(prefix='TestTraceAction__test_frontend_yaml')
 
         yaml_file = textwrap.dedent(
@@ -135,7 +150,9 @@ class TestTraceAction(unittest.TestCase):
             launch:
             - trace:
                 session-name: my-session-name
+                append-timestamp: false
                 base-path: {}
+                append-trace: true
                 events-kernel: ""
                 events-ust: ros2:* *
                 subbuffer-size-ust: 524288
@@ -147,13 +164,11 @@ class TestTraceAction(unittest.TestCase):
         with io.StringIO(yaml_file) as f:
             trace_action = self._assert_launch_frontend_no_errors(f)
 
-        self._check_trace_action(trace_action, tmpdir)
+        self._check_trace_action(trace_action, tmpdir, append_trace=True)
 
         shutil.rmtree(tmpdir)
-        del os.environ['LD_PRELOAD']
 
     def test_action_context_per_domain(self) -> None:
-        self.assertIsNone(os.environ.get('LD_PRELOAD'))
         tmpdir = tempfile.mkdtemp(prefix='TestTraceAction__test_action_context_per_domain')
 
         action = Trace(
@@ -183,10 +198,8 @@ class TestTraceAction(unittest.TestCase):
         )
 
         shutil.rmtree(tmpdir)
-        del os.environ['LD_PRELOAD']
 
     def test_action_substitutions(self) -> None:
-        self.assertIsNone(os.environ.get('LD_PRELOAD'))
         tmpdir = tempfile.mkdtemp(prefix='TestTraceAction__test_action_substitutions')
 
         self.assertIsNone(os.environ.get('TestTraceAction__event_ust', None))
@@ -231,10 +244,8 @@ class TestTraceAction(unittest.TestCase):
         shutil.rmtree(tmpdir)
         del os.environ['TestTraceAction__event_ust']
         del os.environ['TestTraceAction__context_field']
-        del os.environ['LD_PRELOAD']
 
     def test_action_ld_preload(self) -> None:
-        self.assertIsNone(os.environ.get('LD_PRELOAD'))
         tmpdir = tempfile.mkdtemp(prefix='TestTraceAction__test_action_ld_preload')
 
         action = Trace(
@@ -285,7 +296,70 @@ class TestTraceAction(unittest.TestCase):
         self.assertTrue(any(p.endswith('liblttng-ust-dl.so') for p in paths))
 
         shutil.rmtree(tmpdir)
-        del os.environ['LD_PRELOAD']
+
+    def test_append_timestamp(self) -> None:
+        tmpdir = tempfile.mkdtemp(prefix='TestTraceAction__test_append_timestamp')
+
+        action = Trace(
+            session_name='my-session-name',
+            append_timestamp=True,
+            base_path=tmpdir,
+            events_kernel=[],
+            events_ust=[
+                'ros2:*',
+                '*',
+            ],
+            subbuffer_size_ust=524288,
+            subbuffer_size_kernel=1048576,
+        )
+        self._assert_launch_no_errors([action])
+        self._check_trace_action(action, tmpdir, session_name=None)
+        # Session name should start with the given prefix and end with the timestamp, but don't
+        # bother validating the timestamp here
+        self.assertTrue(action.session_name.startswith('my-session-name-'))
+        self.assertNotEqual('my-session-name-', action.session_name)
+
+        shutil.rmtree(tmpdir)
+
+    def test_append_trace(self) -> None:
+        tmpdir = tempfile.mkdtemp(prefix='TestTraceAction__test_append_trace')
+
+        # Generate a normal trace
+        action = Trace(
+            session_name='my-session-name',
+            base_path=tmpdir,
+            append_trace=False,
+            events_kernel=[],
+            events_ust=[
+                'ros2:*',
+                '*',
+            ],
+            subbuffer_size_ust=524288,
+            subbuffer_size_kernel=1048576,
+        )
+        self._assert_launch_no_errors([action])
+        self._check_trace_action(action, tmpdir, append_trace=False)
+
+        # Generating another trace with the same path should error out
+        self._assert_launch_errors([action])
+
+        # But it should work if we use the append_trace option
+        action = Trace(
+            session_name='my-session-name',
+            base_path=tmpdir,
+            append_trace=True,
+            events_kernel=[],
+            events_ust=[
+                'ros2:*',
+                '*',
+            ],
+            subbuffer_size_ust=524288,
+            subbuffer_size_kernel=1048576,
+        )
+        self._assert_launch_no_errors([action])
+        self._check_trace_action(action, tmpdir, append_trace=True)
+
+        shutil.rmtree(tmpdir)
 
 
 if __name__ == '__main__':

--- a/tracetools_trace/tracetools_trace/tools/args.py
+++ b/tracetools_trace/tracetools_trace/tools/args.py
@@ -76,3 +76,6 @@ def add_arguments(parser: argparse.ArgumentParser) -> None:
     parser.add_argument(
         '-l', '--list', dest='list', action='store_true',
         help='display lists of enabled events and context names (default: %(default)s)')
+    parser.add_argument(
+        '-a', '--append-trace', dest='append_trace', action='store_true',
+        help='append to trace if it already exists, otherwise error out (default: %(default)s)')

--- a/tracetools_trace/tracetools_trace/trace.py
+++ b/tracetools_trace/tracetools_trace/trace.py
@@ -33,6 +33,7 @@ def init(
     *,
     session_name: str,
     base_path: Optional[str],
+    append_trace: bool,
     ros_events: List[str],
     kernel_events: List[str],
     context_fields: List[str],
@@ -46,6 +47,8 @@ def init(
     :param session_name: the name of the session
     :param base_path: the path to the directory in which to create the tracing session directory,
         or `None` for default
+    :param append_trace: whether to append to the trace directory if it already exists, otherwise
+        an error is reported
     :param ros_events: list of ROS events to enable
     :param kernel_events: list of kernel events to enable
     :param context_fields: list of context fields to enable
@@ -84,6 +87,7 @@ def init(
     trace_directory = lttng.lttng_init(
         session_name=session_name,
         base_path=base_path,
+        append_trace=append_trace,
         ros_events=ros_events,
         kernel_events=kernel_events,
         context_fields=context_fields,
@@ -137,6 +141,7 @@ def trace(args: argparse.Namespace) -> int:
         if not init(
             session_name=args.session_name,
             base_path=args.path,
+            append_trace=args.append_trace,
             ros_events=args.events_ust,
             kernel_events=args.events_kernel,
             context_fields=args.context_fields,


### PR DESCRIPTION
Closes #12

This makes the `ros2 trace` command and the `Trace` launch action fail if the trace already exists, unless the `--append-trace` or `append_trace`/`append-trace` option is used, respectively. Example:

```sh
$ ros2 trace -s 'my-trace'  # Generate trace
UST tracing enabled (28 events)
kernel tracing disabled
context (3 fields)
writing tracing session to: /home/chris/.ros/tracing/my-trace
press enter to start...
press enter to stop...
stopping & destroying tracing session
$ ros2 trace -s 'my-trace'  # Mistakenly append to existing trace, error out
UST tracing enabled (28 events)
kernel tracing disabled
context (3 fields)
writing tracing session to: /home/chris/.ros/tracing/my-trace
press enter to start...
error: trace directory already exists, use the append option to append to it: /home/chris/.ros/tracing/my-trace
$ ros2 trace -s 'my-trace' --append-trace   # Use '--append-trace' option, all good
UST tracing enabled (28 events)
kernel tracing disabled
context (3 fields)
writing tracing session to: /home/chris/.ros/tracing/my-trace
press enter to start...
press enter to stop...
stopping & destroying tracing session
```

I've also added tests to cover it in both `ros2trace` and `test_tracetools_launch`. I added a simple test for the existing `append_timestamp` `Trace` launch action option to `test_tracetools_launch` as well.

Signed-off-by: Christophe Bedard <christophe.bedard@apex.ai>