### PR TITLE
Allow requiring minimum lttng package version for is_lttng_installed

### DIFF
--- a/test_tracetools/test/test_executor.py
+++ b/test_tracetools/test/test_executor.py
@@ -16,8 +16,10 @@ import unittest
 
 from tracetools_test.case import TraceTestCase
 from tracetools_trace.tools import tracepoints as tp
+from tracetools_trace.tools.lttng import is_lttng_installed
 
 
+@unittest.skipIf(not is_lttng_installed(minimum_version='2.9.0'), 'LTTng is required')
 class TestExecutor(TraceTestCase):
 
     def __init__(self, *args) -> None:

--- a/test_tracetools/test/test_intra.py
+++ b/test_tracetools/test/test_intra.py
@@ -16,8 +16,10 @@ import unittest
 
 from tracetools_test.case import TraceTestCase
 from tracetools_trace.tools import tracepoints as tp
+from tracetools_trace.tools.lttng import is_lttng_installed
 
 
+@unittest.skipIf(not is_lttng_installed(minimum_version='2.9.0'), 'LTTng is required')
 class TestIntra(TraceTestCase):
 
     def __init__(self, *args) -> None:

--- a/test_tracetools/test/test_lifecycle_node.py
+++ b/test_tracetools/test/test_lifecycle_node.py
@@ -16,8 +16,10 @@ import unittest
 
 from tracetools_test.case import TraceTestCase
 from tracetools_trace.tools import tracepoints as tp
+from tracetools_trace.tools.lttng import is_lttng_installed
 
 
+@unittest.skipIf(not is_lttng_installed(minimum_version='2.9.0'), 'LTTng is required')
 class TestLifecycleNode(TraceTestCase):
 
     def __init__(self, *args) -> None:

--- a/test_tracetools/test/test_node.py
+++ b/test_tracetools/test/test_node.py
@@ -16,11 +16,13 @@ import unittest
 
 from tracetools_test.case import TraceTestCase
 from tracetools_trace.tools import tracepoints as tp
+from tracetools_trace.tools.lttng import is_lttng_installed
 
 
 VERSION_REGEX = r'^[0-9]+\.[0-9]+\.[0-9]+$'
 
 
+@unittest.skipIf(not is_lttng_installed(minimum_version='2.9.0'), 'LTTng is required')
 class TestNode(TraceTestCase):
 
     def __init__(self, *args) -> None:

--- a/test_tracetools/test/test_pub_sub.py
+++ b/test_tracetools/test/test_pub_sub.py
@@ -16,8 +16,10 @@ import unittest
 
 from tracetools_test.case import TraceTestCase
 from tracetools_trace.tools import tracepoints as tp
+from tracetools_trace.tools.lttng import is_lttng_installed
 
 
+@unittest.skipIf(not is_lttng_installed(minimum_version='2.9.0'), 'LTTng is required')
 class TestPubSub(TraceTestCase):
 
     def __init__(self, *args) -> None:

--- a/test_tracetools/test/test_publisher.py
+++ b/test_tracetools/test/test_publisher.py
@@ -17,8 +17,10 @@ import unittest
 
 from tracetools_test.case import TraceTestCase
 from tracetools_trace.tools import tracepoints as tp
+from tracetools_trace.tools.lttng import is_lttng_installed
 
 
+@unittest.skipIf(not is_lttng_installed(minimum_version='2.9.0'), 'LTTng is required')
 class TestPublisher(TraceTestCase):
 
     def __init__(self, *args) -> None:

--- a/test_tracetools/test/test_service.py
+++ b/test_tracetools/test/test_service.py
@@ -16,8 +16,10 @@ import unittest
 
 from tracetools_test.case import TraceTestCase
 from tracetools_trace.tools import tracepoints as tp
+from tracetools_trace.tools.lttng import is_lttng_installed
 
 
+@unittest.skipIf(not is_lttng_installed(minimum_version='2.9.0'), 'LTTng is required')
 class TestService(TraceTestCase):
 
     def __init__(self, *args) -> None:

--- a/test_tracetools/test/test_subscription.py
+++ b/test_tracetools/test/test_subscription.py
@@ -18,8 +18,10 @@ import unittest
 
 from tracetools_test.case import TraceTestCase
 from tracetools_trace.tools import tracepoints as tp
+from tracetools_trace.tools.lttng import is_lttng_installed
 
 
+@unittest.skipIf(not is_lttng_installed(minimum_version='2.9.0'), 'LTTng is required')
 class TestSubscription(TraceTestCase):
 
     def __init__(self, *args) -> None:

--- a/test_tracetools/test/test_timer.py
+++ b/test_tracetools/test/test_timer.py
@@ -17,8 +17,10 @@ import unittest
 
 from tracetools_test.case import TraceTestCase
 from tracetools_trace.tools import tracepoints as tp
+from tracetools_trace.tools.lttng import is_lttng_installed
 
 
+@unittest.skipIf(not is_lttng_installed(minimum_version='2.9.0'), 'LTTng is required')
 class TestTimer(TraceTestCase):
 
     def __init__(self, *args) -> None:

--- a/test_tracetools_launch/test/test_tracetools_launch/test_trace_action.py
+++ b/test_tracetools_launch/test/test_tracetools_launch/test_trace_action.py
@@ -35,6 +35,7 @@ from tracetools_launch.action import Trace
 from tracetools_trace.tools.lttng import is_lttng_installed
 
 
+@unittest.skipIf(not is_lttng_installed(minimum_version='2.9.0'), 'LTTng is required')
 class TestTraceAction(unittest.TestCase):
 
     def __init__(self, *args) -> None:
@@ -71,7 +72,6 @@ class TestTraceAction(unittest.TestCase):
         self.assertEqual(events_ust, action.events_ust)
         self.assertTrue(pathlib.Path(tmpdir).exists())
 
-    @unittest.skipIf(not is_lttng_installed(), 'LTTng is required')
     def test_action(self) -> None:
         self.assertIsNone(os.environ.get('LD_PRELOAD'))
         tmpdir = tempfile.mkdtemp(prefix='TestTraceAction__test_action')
@@ -92,7 +92,6 @@ class TestTraceAction(unittest.TestCase):
         shutil.rmtree(tmpdir)
         del os.environ['LD_PRELOAD']
 
-    @unittest.skipIf(not is_lttng_installed(), 'LTTng is required')
     def test_action_frontend_xml(self) -> None:
         self.assertIsNone(os.environ.get('LD_PRELOAD'))
         tmpdir = tempfile.mkdtemp(prefix='TestTraceAction__test_frontend_xml')
@@ -119,7 +118,6 @@ class TestTraceAction(unittest.TestCase):
         shutil.rmtree(tmpdir)
         del os.environ['LD_PRELOAD']
 
-    @unittest.skipIf(not is_lttng_installed(), 'LTTng is required')
     def test_action_frontend_yaml(self) -> None:
         self.assertIsNone(os.environ.get('LD_PRELOAD'))
         tmpdir = tempfile.mkdtemp(prefix='TestTraceAction__test_frontend_yaml')
@@ -144,7 +142,6 @@ class TestTraceAction(unittest.TestCase):
         shutil.rmtree(tmpdir)
         del os.environ['LD_PRELOAD']
 
-    @unittest.skipIf(not is_lttng_installed(), 'LTTng is required')
     def test_action_context_per_domain(self) -> None:
         self.assertIsNone(os.environ.get('LD_PRELOAD'))
         tmpdir = tempfile.mkdtemp(prefix='TestTraceAction__test_action_context_per_domain')
@@ -176,7 +173,6 @@ class TestTraceAction(unittest.TestCase):
         shutil.rmtree(tmpdir)
         del os.environ['LD_PRELOAD']
 
-    @unittest.skipIf(not is_lttng_installed(), 'LTTng is required')
     def test_action_substitutions(self) -> None:
         self.assertIsNone(os.environ.get('LD_PRELOAD'))
         tmpdir = tempfile.mkdtemp(prefix='TestTraceAction__test_action_substitutions')
@@ -223,7 +219,6 @@ class TestTraceAction(unittest.TestCase):
         del os.environ['TestTraceAction__context_field']
         del os.environ['LD_PRELOAD']
 
-    @unittest.skipIf(not is_lttng_installed(), 'LTTng is required')
     def test_action_ld_preload(self) -> None:
         self.assertIsNone(os.environ.get('LD_PRELOAD'))
         tmpdir = tempfile.mkdtemp(prefix='TestTraceAction__test_action_ld_preload')

--- a/tracetools_trace/test/tracetools_trace/test_lttng_tracing.py
+++ b/tracetools_trace/test/tracetools_trace/test_lttng_tracing.py
@@ -12,9 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import subprocess
 import unittest
 from unittest import mock
 
+from packaging.version import Version
 from tracetools_trace.tools.lttng import is_lttng_installed
 
 
@@ -25,6 +27,49 @@ class TestLttngTracing(unittest.TestCase):
         super().__init__(
             *args,
         )
+
+    def test_is_lttng_installed(self):
+        # Different OS
+        with mock.patch('platform.system', return_value='Windows'):
+            self.assertFalse(is_lttng_installed())
+
+        # LTTng command not found
+        class PopenFileNotFound:
+
+            def __init__(self, *args, **kwargs):
+                raise FileNotFoundError('file not found')
+
+        with mock.patch.object(subprocess, 'Popen', PopenFileNotFound):
+            self.assertFalse(is_lttng_installed())
+
+        # Other error when running LTTng command
+        class PopenReturnCodeError:
+
+            def __init__(self, *args, **kwargs):
+                pass
+
+            def communicate(self):
+                return 'stdout'.encode(), 'stderr'.encode()
+
+            @property
+            def returncode(self):
+                return 1
+
+        with mock.patch.object(subprocess, 'Popen', PopenReturnCodeError):
+            self.assertFalse(is_lttng_installed())
+
+        # lttng Python package or version not found
+        with mock.patch('tracetools_trace.tools.lttng.get_lttng_version', return_value=None):
+            self.assertFalse(is_lttng_installed())
+
+        # Minimum version requirement
+        with mock.patch(
+            'tracetools_trace.tools.lttng.get_lttng_version',
+            return_value=Version('1.2.3'),
+        ):
+            self.assertFalse(is_lttng_installed(minimum_version='1.2.4'))
+            self.assertTrue(is_lttng_installed(minimum_version='1.2.3'))
+            self.assertTrue(is_lttng_installed())
 
     def test_lttng_not_installed(self):
         from tracetools_trace.tools.lttng import lttng_init

--- a/tracetools_trace/tracetools_trace/tools/lttng.py
+++ b/tracetools_trace/tracetools_trace/tools/lttng.py
@@ -20,25 +20,36 @@ import subprocess
 import sys
 from typing import Optional
 
+from packaging.version import Version
+
 try:
     from . import lttng_impl
-
     _lttng = lttng_impl  # type: ignore
-
-    # Check lttng module version
-    from packaging.version import Version
-    current_version = _lttng.get_version()
-    LTTNG_MIN_VERSION = '2.10.7'
-    if current_version is None or current_version < Version(LTTNG_MIN_VERSION):
-        print(
-            f'lttng module version >={LTTNG_MIN_VERSION} required, found {str(current_version)}',
-            file=sys.stderr,
-        )
 except ImportError:
     # Fall back on stub functions so that this still passes linter checks
     from . import lttng_stub
-
     _lttng = lttng_stub  # type: ignore
+
+
+def get_lttng_version() -> Optional[Version]:
+    """
+    Get version of lttng Python package.
+
+    :return: the version of the lttng Python package, or `None` if it is not available
+    """
+    if not hasattr(_lttng, 'get_version') or not callable(_lttng.get_version):
+        return None
+    return _lttng.get_version()
+
+
+# Check lttng module version
+current_version = get_lttng_version()
+LTTNG_MIN_VERSION = '2.10.7'
+if current_version is None or current_version < Version(LTTNG_MIN_VERSION):
+    print(
+        f'lttng module version >={LTTNG_MIN_VERSION} required, found {str(current_version)}',
+        file=sys.stderr,
+    )
 
 
 def lttng_init(**kwargs) -> Optional[str]:
@@ -69,15 +80,24 @@ def lttng_fini(**kwargs) -> None:
     _lttng.destroy(**kwargs)
 
 
-def is_lttng_installed() -> bool:
+def is_lttng_installed(
+    *,
+    minimum_version: Optional[str] = None,
+) -> bool:
     """
     Check if LTTng is installed.
 
     It first checks if the OS can support LTTng.
-    If so, it then simply checks if LTTng is installed using the 'lttng' command.
+    If so, it then simply checks if LTTng is installed using the 'lttng' command, and checks if the
+    lttng Python package is installed (python3-lttng).
 
-    :return: True if it is installed, False otherwise
+    Optionally, a minimum version can also be specified for the lttng Python package.
+
+    :param minimum_version: the minimum required lttng Python package version
+    :return: True if LTTng and the lttng Python package are installed, and optionally if the
+        version of lttng Python package is sufficient, False otherwise
     """
+    # Check system
     message_doc = (
         'Cannot trace. See documentation at: '
         'https://github.com/ros2/ros2_tracing'
@@ -86,6 +106,7 @@ def is_lttng_installed() -> bool:
     if 'Linux' != system:
         print(f"System '{system}' does not support LTTng.\n{message_doc}", file=sys.stderr)
         return False
+    # Check if LTTng (CLI) is installed
     try:
         process = subprocess.Popen(
             ['lttng', '--version'],
@@ -95,7 +116,25 @@ def is_lttng_installed() -> bool:
         _, stderr = process.communicate()
         if 0 != process.returncode:
             raise RuntimeError(stderr.decode())
-        return True
     except (RuntimeError, FileNotFoundError) as e:
         print(f'LTTng not found: {e}\n{message_doc}', file=sys.stderr)
         return False
+    # Check if lttng Python package is installed
+    lttng_version = get_lttng_version()
+    if not lttng_version:
+        print(
+            f'lttng Python package (python3-lttng) not installed\n{message_doc}',
+            file=sys.stderr,
+        )
+        return False
+    # Check if lttng Python package version is sufficient
+    if minimum_version and lttng_version < Version(minimum_version):
+        print(
+            (
+                f'lttng Python package (python3-lttng) version >={minimum_version} required, '
+                f'found {str(lttng_version)}'
+            ),
+            file=sys.stderr,
+        )
+        return False
+    return True


### PR DESCRIPTION
Closes #16

This changes `is_lttng_installed()` to also check for the `lttng` Python package.

This also adds an optional `minimum_version` parameter to `is_lttng_installed()` to check if the `lttng` Python package version is sufficient. This is then used to ignore some tests which require `lttng.BUFFER_*`, which isn't available until version 2.9. RHEL 8 has LTTng 2.8, so those tests fail. With this change, tests run successfully on RHEL 8, or, rather, the tests that can't run are skipped.

Signed-off-by: Christophe Bedard <christophe.bedard@apex.ai>