### PR TITLE
Switch <depend> to <exec_depend> in pure Python packages

### DIFF
--- a/ros2trace/package.xml
+++ b/ros2trace/package.xml
@@ -12,8 +12,8 @@
   <url type="bugtracker">https://github.com/ros2/ros2_tracing/issues</url>
   <author email="fixed-term.christophe.bourquebedard@de.bosch.com">Christophe Bedard</author>
 
-  <depend>ros2cli</depend>
-  <depend>tracetools_trace</depend>
+  <exec_depend>ros2cli</exec_depend>
+  <exec_depend>tracetools_trace</exec_depend>
 
   <test_depend>ament_copyright</test_depend>
   <test_depend>ament_flake8</test_depend>

--- a/tracetools_test/package.xml
+++ b/tracetools_test/package.xml
@@ -12,11 +12,11 @@
   <url type="bugtracker">https://github.com/ros2/ros2_tracing/issues</url>
   <author email="fixed-term.christophe.bourquebedard@de.bosch.com">Christophe Bedard</author>
 
-  <depend>launch</depend>
-  <depend>launch_ros</depend>
-  <depend>tracetools_launch</depend>
-  <depend>tracetools_read</depend>
-  <depend>tracetools_trace</depend>
+  <exec_depend>launch</exec_depend>
+  <exec_depend>launch_ros</exec_depend>
+  <exec_depend>tracetools_launch</exec_depend>
+  <exec_depend>tracetools_read</exec_depend>
+  <exec_depend>tracetools_trace</exec_depend>
 
   <test_depend>ament_copyright</test_depend>
   <test_depend>ament_flake8</test_depend>


### PR DESCRIPTION
Signed-off-by: Christophe Bedard <christophe.bedard@apex.ai>