### PR TITLE
Add timestamp to rmw_publish tracepoint

### DIFF
--- a/tracetools/include/tracetools/tp_call.h
+++ b/tracetools/include/tracetools/tp_call.h
@@ -137,10 +137,14 @@ TRACEPOINT_EVENT(
   TRACEPOINT_PROVIDER,
   rmw_publish,
   TP_ARGS(
-    const void *, message_arg
+    const void *, publisher_handle_arg,
+    const void *, message_arg,
+    int64_t, timestamp_arg
   ),
   TP_FIELDS(
+    ctf_integer_hex(const void *, publisher_handle, publisher_handle_arg)
     ctf_integer_hex(const void *, message, message_arg)
+    ctf_integer(int64_t, timestamp, timestamp_arg)
   )
 )
 

--- a/tracetools/include/tracetools/tracetools.h
+++ b/tracetools/include/tracetools/tracetools.h
@@ -274,7 +274,9 @@ _DECLARE_TRACEPOINT(
  */
 _DECLARE_TRACEPOINT(
   rmw_publish,
-  const void * message)
+  const void * publisher_handle,
+  const void * message,
+  int64_t timestamp)
 
 /// `rmw_subscription_init`
 /**

--- a/tracetools/src/tracetools.c
+++ b/tracetools/src/tracetools.c
@@ -156,9 +156,13 @@ DEFINE_TRACEPOINT(
 DEFINE_TRACEPOINT(
   rmw_publish,
   TRACEPOINT_PARAMS(
-    const void * message),
+    const void * publisher_handle,
+    const void * message,
+    int64_t timestamp),
   TRACEPOINT_ARGS(
-    message))
+    publisher_handle,
+    message,
+    timestamp))
 
 DEFINE_TRACEPOINT(
   rmw_subscription_init,


### PR DESCRIPTION
See https://github.com/ros2/ros2_tracing/issues/73

Corresponding `rmw` implementation PRs:

* https://github.com/ros2/rmw_cyclonedds/pull/454
* https://github.com/ros2/rmw_fastrtps/pull/694
* https://github.com/ros2/rmw_connextdds/pull/120

action-ros-ci-repos-override: https://gist.githubusercontent.com/christophebedard/124d8311bed71f7820a2185ce0a25cc3/raw/49c81e6cacce1a5e621ed3880b205dac9096a3ac/ros2.repos