### PR TITLE
Unpin mypy in GitHub CI

### DIFF
--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -23,9 +23,6 @@ jobs:
       with:
         required-ros-distributions: ${{ matrix.distro }}
         use-ros2-testing: true
-    - name: Pin mypy==0.942
-      run: |
-        python3 -m pip install 'mypy==0.942'
     - name: Install other dependencies
       run: |
         sudo apt-get update
@@ -66,9 +63,6 @@ jobs:
       with:
         path: ws/src/ros2/ros2_tracing
     - uses: ros-tooling/setup-ros@master
-    - name: Pin mypy==0.942
-      run: |
-        python3 -m pip install 'mypy==0.942'
     - name: Build
       run: |
         cd $GITHUB_WORKSPACE/ws

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,9 +46,6 @@ jobs:
       with:
         required-ros-distributions: ${{ matrix.build-type == 'binary' && matrix.distro || '' }}
         use-ros2-testing: true
-    - name: Pin mypy==0.942
-      run: |
-        python3 -m pip install 'mypy==0.942'
     - uses: ros-tooling/action-ros-ci@master
       with:
         package-name: >


### PR DESCRIPTION
Closes #27

This is no longer necessary after https://github.com/ros-tooling/setup-ros/pull/593. This PR wraps up #27.