### PR TITLE
Remove extra single quote in LdPreload debug log

### DIFF
--- a/tracetools_launch/tracetools_launch/actions/ld_preload.py
+++ b/tracetools_launch/tracetools_launch/actions/ld_preload.py
@@ -104,9 +104,9 @@ class LdPreload(Action):
             return None
         # Assuming that there are no spaces in paths (which should be valid for Linux libs)
         paths = output_split[1].split(' ')
-        cls.__logger.debug(f"lib paths for '{lib_name}'': {paths}")
+        cls.__logger.debug(f"lib paths for '{lib_name}': {paths}")
         # Try to find a shared library
-        # Paths could contain a shared lib (.so) or a static lib (.a) in any order
+        # Paths could contain: shared lib (.so), static lib (.a), or libtools text file (.la)
         shared_lib_paths = [path for path in paths if path.endswith('.so')]
         if not shared_lib_paths:
             return None


### PR DESCRIPTION
This can be seen in the test output for `test_tracetools_launch`:

```
test/test_tracetools_launch/test_trace_action.py::TestTraceAction::test_action_ld_preload [DEBUG] [launch.launch_context]: emitting event synchronously: 'launch.events.IncludeLaunchDescription'
[INFO] [launch]: All log files can be found below /home/christophe.bedard/.ros/log/2023-08-30-14-54-14-398230-ul-pa-1255-1-1810625
[INFO] [launch]: Default logging verbosity is set to DEBUG
[DEBUG] [launch]: processing event: '<launch.events.include_launch_description.IncludeLaunchDescription object at 0x7f6fd7b98ee0>'
[DEBUG] [launch]: processing event: '<launch.events.include_launch_description.IncludeLaunchDescription object at 0x7f6fd7b98ee0>' ✓ '<launch.event_handlers.on_include_launch_description.OnIncludeLaunchDescription object at 0x7f6fd7b98be0>'
[DEBUG] [tracetools_launch.actions.ld_preload]: whereis command for 'liblttng-ust-libc-wrapper.so' exited with 0: liblttng-ust-libc-wrapper.so: /usr/lib/x86_64-linux-gnu/liblttng-ust-libc-wrapper.so
[DEBUG] [tracetools_launch.actions.ld_preload]: lib paths for 'liblttng-ust-libc-wrapper.so'': ['/usr/lib/x86_64-linux-gnu/liblttng-ust-libc-wrapper.so']
[DEBUG] [tracetools_launch.actions.ld_preload]: Shared library for 'liblttng-ust-libc-wrapper.so' found at: /usr/lib/x86_64-linux-gnu/liblttng-ust-libc-wrapper.so
[DEBUG] [tracetools_launch.actions.ld_preload]: whereis command for 'liblttng-ust-pthread-wrapper.so' exited with 0: liblttng-ust-pthread-wrapper.so: /usr/lib/x86_64-linux-gnu/liblttng-ust-pthread-wrapper.so
[DEBUG] [tracetools_launch.actions.ld_preload]: lib paths for 'liblttng-ust-pthread-wrapper.so'': ['/usr/lib/x86_64-linux-gnu/liblttng-ust-pthread-wrapper.so']
[DEBUG] [tracetools_launch.actions.ld_preload]: Shared library for 'liblttng-ust-pthread-wrapper.so' found at: /usr/lib/x86_64-linux-gnu/liblttng-ust-pthread-wrapper.so
[DEBUG] [tracetools_launch.actions.ld_preload]: whereis command for 'liblttng-ust-dl.so' exited with 0: liblttng-ust-dl.so: /usr/lib/x86_64-linux-gnu/liblttng-ust-dl.so
[DEBUG] [tracetools_launch.actions.ld_preload]: lib paths for 'liblttng-ust-dl.so'': ['/usr/lib/x86_64-linux-gnu/liblttng-ust-dl.so']
[DEBUG] [tracetools_launch.actions.ld_preload]: Shared library for 'liblttng-ust-dl.so' found at: /usr/lib/x86_64-linux-gnu/liblttng-ust-dl.so
[DEBUG] [tracetools_launch.actions.ld_preload]: whereis command for 'liblttng-ust-cyg-profile-fast.so' exited with 0: liblttng-ust-cyg-profile-fast.so: /usr/lib/x86_64-linux-gnu/liblttng-ust-cyg-profile-fast.so
[DEBUG] [tracetools_launch.actions.ld_preload]: lib paths for 'liblttng-ust-cyg-profile-fast.so'': ['/usr/lib/x86_64-linux-gnu/liblttng-ust-cyg-profile-fast.so']
[DEBUG] [tracetools_launch.actions.ld_preload]: Shared library for 'liblttng-ust-cyg-profile-fast.so' found at: /usr/lib/x86_64-linux-gnu/liblttng-ust-cyg-profile-fast.so
```

See: `lib paths for 'liblttng-ust-dl.so''`.

Also, update a nearby comment about possible files returned by `whereis -b` to mention `.la` files.