### PR TITLE
Switch to target_link_libraries in test_tracetools.

### DIFF
--- a/test_tracetools/CMakeLists.txt
+++ b/test_tracetools/CMakeLists.txt
@@ -42,64 +42,72 @@ if(BUILD_TESTING)
   add_executable(test_publisher
     src/test_publisher.cpp
   )
-  ament_target_dependencies(test_publisher
-    rclcpp
-    std_msgs
+  target_link_libraries(test_publisher PRIVATE
+    rclcpp::rclcpp
+    ${std_msgs_TARGETS}
   )
+
   add_executable(test_intra
     src/test_intra.cpp
   )
-  ament_target_dependencies(test_intra
-    rclcpp
-    std_msgs
+  target_link_libraries(test_intra PRIVATE
+    rclcpp::rclcpp
+    ${std_msgs_TARGETS}
   )
+
   add_executable(test_lifecycle_node
     src/test_lifecycle_node.cpp
   )
-  ament_target_dependencies(test_lifecycle_node
-    rclcpp
-    rclcpp_lifecycle
+  target_link_libraries(test_lifecycle_node PRIVATE
+    rclcpp::rclcpp
+    rclcpp_lifecycle::rclcpp_lifecycle
   )
+
   add_executable(test_lifecycle_client
     src/test_lifecycle_client.cpp
   )
-  ament_target_dependencies(test_lifecycle_client
-    lifecycle_msgs
-    rclcpp
+  target_link_libraries(test_lifecycle_client PRIVATE
+    ${lifecycle_msgs_TARGETS}
+    rclcpp::rclcpp
   )
+
   add_executable(test_ping
     src/test_ping.cpp
   )
-  ament_target_dependencies(test_ping
-    rclcpp
-    std_msgs
+  target_link_libraries(test_ping PRIVATE
+    rclcpp::rclcpp
+    ${std_msgs_TARGETS}
   )
+
   add_executable(test_pong
     src/test_pong.cpp
   )
-  ament_target_dependencies(test_pong
-    rclcpp
-    std_msgs
+  target_link_libraries(test_pong PRIVATE
+    rclcpp::rclcpp
+    ${std_msgs_TARGETS}
   )
+
   add_executable(test_timer
     src/test_timer.cpp
   )
-  ament_target_dependencies(test_timer
-    rclcpp
+  target_link_libraries(test_timer PRIVATE
+    rclcpp::rclcpp
   )
+
   add_executable(test_service_ping
     src/test_service_ping.cpp
   )
-  ament_target_dependencies(test_service_ping
-    rclcpp
-    std_srvs
+  target_link_libraries(test_service_ping PRIVATE
+    rclcpp::rclcpp
+    ${std_srvs_TARGETS}
   )
+
   add_executable(test_service_pong
     src/test_service_pong.cpp
   )
-  ament_target_dependencies(test_service_pong
-    rclcpp
-    std_srvs
+  target_link_libraries(test_service_pong PRIVATE
+    rclcpp::rclcpp
+    ${std_srvs_TARGETS}
   )
 
   install(TARGETS
@@ -124,8 +132,8 @@ if(BUILD_TESTING)
     find_package(ament_cmake_gtest REQUIRED)
     ament_add_gtest(test_utils test/test_utils.cpp)
     if(TARGET test_utils)
-      ament_target_dependencies(test_utils
-        tracetools
+      target_link_libraries(test_utils
+        tracetools::tracetools
       )
     endif()
   endif()

--- a/test_tracetools/package.xml
+++ b/test_tracetools/package.xml
@@ -15,13 +15,16 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>pkg-config</buildtool_depend>
 
-  <!-- Two of the utilities from this package (test_ping and test_pong)
-       are used in test_ros2trace.  Because of that, we need to build_export_depend
+  <!-- This is a test package, but some of the utilities from this package are
+       used in downstream test packages.  Because of that, we build_export_depend
        the dependencies that those packages use so that colcon properly sets up the
-       environment when running thes test_ros2trace tests.
+       environment when running those tests.
   -->
+  <build_export_depend>lifecycle_msgs</build_export_depend>
   <build_export_depend>rclcpp</build_export_depend>
+  <build_export_depend>rclcpp_lifecycle</build_export_depend>
   <build_export_depend>std_msgs</build_export_depend>
+  <build_export_depend>std_srvs</build_export_depend>
 
   <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_cmake_mypy</test_depend>

--- a/test_tracetools/package.xml
+++ b/test_tracetools/package.xml
@@ -15,6 +15,14 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>pkg-config</buildtool_depend>
 
+  <!-- Two of the utilities from this package (test_ping and test_pong)
+       are used in test_ros2trace.  Because of that, we need to build_export_depend
+       the dependencies that those packages use so that colcon properly sets up the
+       environment when running thes test_ros2trace tests.
+  -->
+  <build_export_depend>rclcpp</build_export_depend>
+  <build_export_depend>std_msgs</build_export_depend>
+
   <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_cmake_mypy</test_depend>
   <test_depend>ament_cmake_pytest</test_depend>

--- a/test_tracetools/package.xml
+++ b/test_tracetools/package.xml
@@ -15,25 +15,18 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>pkg-config</buildtool_depend>
 
-  <build_depend>lifecycle_msgs</build_depend>
-  <build_depend>rclcpp</build_depend>
-  <build_depend>rclcpp_lifecycle</build_depend>
-  <build_depend>std_msgs</build_depend>
-  <build_depend>std_srvs</build_depend>
-
-  <exec_depend>lifecycle_msgs</exec_depend>
-  <exec_depend>rclcpp</exec_depend>
-  <exec_depend>rclcpp_lifecycle</exec_depend>
-  <exec_depend>std_msgs</exec_depend>
-  <exec_depend>std_srvs</exec_depend>
-
   <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_cmake_mypy</test_depend>
   <test_depend>ament_cmake_pytest</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
+  <test_depend>lifecycle_msgs</test_depend>
   <test_depend>python3-pytest</test_depend>
   <test_depend>python3-pytest-cov</test_depend>
+  <test_depend>rclcpp</test_depend>
+  <test_depend>rclcpp_lifecycle</test_depend>
+  <test_depend>std_msgs</test_depend>
+  <test_depend>std_srvs</test_depend>
   <test_depend>tracetools</test_depend>
   <test_depend>tracetools_test</test_depend>
 


### PR DESCRIPTION
While we are in here, mark all dependencies as test_depend (since this is a test-only package).