### PR TITLE
Fix Python not being found for lttngpy in Windows debug mode

### DIFF
--- a/lttngpy/CMakeLists.txt
+++ b/lttngpy/CMakeLists.txt
@@ -15,6 +15,15 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
 
+# Figure out Python3 debug/release before anything else can find_package it
+if(WIN32 AND CMAKE_BUILD_TYPE STREQUAL "Debug")
+  find_package(python_cmake_module REQUIRED)
+  find_package(PythonExtra REQUIRED)
+
+  # Force FindPython3 to use the debug interpreter where ROS 2 expects it
+  set(Python3_EXECUTABLE "${PYTHON_EXECUTABLE_DEBUG}")
+endif()
+
 find_package(ament_cmake REQUIRED)
 
 if(WIN32 OR APPLE OR ANDROID)


### PR DESCRIPTION
Closes #86

I found this fix in a few other packages that use Python in CMake.