### PR TITLE
Add a space in between not and parentheses.

### DIFF
--- a/tracetools_trace/tracetools_trace/tools/lttng_impl.py
+++ b/tracetools_trace/tracetools_trace/tools/lttng_impl.py
@@ -222,7 +222,7 @@ def setup(
 
     ust_enabled = ros_events is not None and len(ros_events) > 0
     kernel_enabled = kernel_events is not None and len(kernel_events) > 0
-    if not(ust_enabled or kernel_enabled):
+    if not (ust_enabled or kernel_enabled):
         raise RuntimeError('no events enabled')
 
     # Create session


### PR DESCRIPTION
This will fix a flake8 warning on newer versions.