### PR TITLE
Fix warnings when using mypy 1.8.0.

### DIFF
--- a/tracetools_launch/launch/example.launch.py
+++ b/tracetools_launch/launch/example.launch.py
@@ -14,13 +14,13 @@
 
 """Example launch file for the Trace action."""
 
-from launch import LaunchDescription
+import launch
 from launch_ros.actions import Node
 from tracetools_launch.action import Trace
 
 
 def generate_launch_description():
-    return LaunchDescription([
+    return launch.LaunchDescription([
         Trace(
             session_name='my-tracing-session',
         ),

--- a/tracetools_launch/test/tracetools_launch/test_ld_preload_action.py
+++ b/tracetools_launch/test/tracetools_launch/test_ld_preload_action.py
@@ -18,8 +18,7 @@ import platform
 import unittest
 from unittest import mock
 
-from launch import LaunchDescription
-from launch import LaunchService
+import launch
 
 from tracetools_launch.actions.ld_preload import LdPreload
 
@@ -28,8 +27,8 @@ from tracetools_launch.actions.ld_preload import LdPreload
 class TestLdPreloadAction(unittest.TestCase):
 
     def _assert_launch_no_errors(self, actions):
-        ld = LaunchDescription(actions)
-        ls = LaunchService(debug=True)
+        ld = launch.LaunchDescription(actions)
+        ls = launch.LaunchService(debug=True)
         ls.include_launch_description(ld)
         assert 0 == ls.run()
 


### PR DESCRIPTION
For reasons I admit I don't understand, when using mypy 1.8.0 with this code it fails to determine that it can import submodules from launch properly.  Since we can easily workaround this by just doing 'import launch', do that here.