### PR TITLE
Update tests and docs after new rmw_publish timestamp field

### DIFF
--- a/doc/design_ros_2.md
+++ b/doc/design_ros_2.md
@@ -516,9 +516,7 @@ For normal inter-process publishing, this then passes that on to `rcl`, which it
 
 **Important information**:
 * Link to publisher handle(s)
-* Message being published, with timestamp
-* TODO
-    * Source timestamp of message being published
+* Message being published, with its timestamp
 
 ```mermaid
 sequenceDiagram
@@ -536,7 +534,7 @@ sequenceDiagram
     Publisher->>rcl: rcl_publish(rcl_publisher_t *, msg *)
     rcl-->>tracetools: TP(rcl_publish, rcl_publisher_t *, msg *)
     rcl->>rmw: rmw_publish(rmw_publisher_t *, msg *)
-    rmw-->>tracetools: TP(rmw_publish, msg *)
+    rmw-->>tracetools: TP(rmw_publish, rmw_publisher_t *, msg *, timestamp)
     Note over rmw: calls middleware
     Note over node: keeps, returns, or destroys msg
 ```

--- a/test_tracetools/test/test_pub_sub.py
+++ b/test_tracetools/test/test_pub_sub.py
@@ -100,12 +100,12 @@ class TestPubSub(TraceTestCase):
         # Get corresponding rmw/rcl/rclcpp publish events for ping & pong
         rmw_publish_events = self.get_events_with_name(tp.rmw_publish)
         ping_rmw_pub_events = self.get_events_with_field_value(
-            'publisher_handle',
+            'rmw_publisher_handle',
             ping_rmw_pub_handle,
             rmw_publish_events,
         )
         pong_rmw_pub_events = self.get_events_with_field_value(
-            'publisher_handle',
+            'rmw_publisher_handle',
             pong_rmw_pub_handle,
             rmw_publish_events,
         )

--- a/test_tracetools/test/test_pub_sub.py
+++ b/test_tracetools/test/test_pub_sub.py
@@ -36,6 +36,7 @@ class TestPubSub(TraceTestCase):
                 tp.rcl_subscription_init,
                 tp.rclcpp_subscription_init,
                 tp.rclcpp_subscription_callback_added,
+                tp.rmw_take,
                 tp.callback_start,
                 tp.callback_end,
             ],
@@ -97,27 +98,26 @@ class TestPubSub(TraceTestCase):
         ])
 
         # Get corresponding rmw/rcl/rclcpp publish events for ping & pong
-        rcl_publish_events = self.get_events_with_name(tp.rcl_publish)
-        ping_rcl_pub_events = self.get_events_with_field_value(
+        rmw_publish_events = self.get_events_with_name(tp.rmw_publish)
+        ping_rmw_pub_events = self.get_events_with_field_value(
             'publisher_handle',
-            ping_pub_handle,
-            rcl_publish_events,
+            ping_rmw_pub_handle,
+            rmw_publish_events,
         )
-        pong_rcl_pub_events = self.get_events_with_field_value(
+        pong_rmw_pub_events = self.get_events_with_field_value(
             'publisher_handle',
-            pong_pub_handle,
-            rcl_publish_events,
+            pong_rmw_pub_handle,
+            rmw_publish_events,
         )
-        self.assertNumEventsEqual(ping_rcl_pub_events, 1)
-        self.assertNumEventsEqual(pong_rcl_pub_events, 1)
-        ping_rcl_pub_event = ping_rcl_pub_events[0]
-        pong_rcl_pub_event = pong_rcl_pub_events[0]
+        self.assertNumEventsEqual(ping_rmw_pub_events, 1)
+        self.assertNumEventsEqual(pong_rmw_pub_events, 1)
+        ping_rmw_pub_event = ping_rmw_pub_events[0]
+        pong_rmw_pub_event = pong_rmw_pub_events[0]
+        ping_pub_message = self.get_field(ping_rmw_pub_event, 'message')
+        pong_pub_message = self.get_field(pong_rmw_pub_event, 'message')
 
         rclcpp_publish_events = self.get_events_with_name(tp.rclcpp_publish)
-        rmw_publish_events = self.get_events_with_name(tp.rmw_publish)
-        ping_pub_message = self.get_field(ping_rcl_pub_event, 'message')
-        pong_pub_message = self.get_field(pong_rcl_pub_event, 'message')
-
+        rcl_publish_events = self.get_events_with_name(tp.rcl_publish)
         ping_rclcpp_pub_events = self.get_events_with_field_value(
             'message',
             ping_pub_message,
@@ -128,24 +128,26 @@ class TestPubSub(TraceTestCase):
             pong_pub_message,
             rclcpp_publish_events,
         )
-        ping_rmw_pub_events = self.get_events_with_field_value(
+        ping_rcl_pub_events = self.get_events_with_field_value(
             'message',
             ping_pub_message,
-            rmw_publish_events,
+            rcl_publish_events,
         )
-        pong_rmw_pub_events = self.get_events_with_field_value(
+        pong_rcl_pub_events = self.get_events_with_field_value(
             'message',
             pong_pub_message,
-            rmw_publish_events,
+            rcl_publish_events,
         )
         self.assertNumEventsEqual(ping_rclcpp_pub_events, 1)
         self.assertNumEventsEqual(pong_rclcpp_pub_events, 1)
-        self.assertNumEventsEqual(ping_rmw_pub_events, 1)
-        self.assertNumEventsEqual(pong_rmw_pub_events, 1)
+        self.assertNumEventsEqual(ping_rcl_pub_events, 1)
+        self.assertNumEventsEqual(pong_rcl_pub_events, 1)
         ping_rclcpp_pub_event = ping_rclcpp_pub_events[0]
         pong_rclcpp_pub_event = pong_rclcpp_pub_events[0]
-        ping_rmw_pub_event = ping_rmw_pub_events[0]
-        pong_rmw_pub_event = pong_rmw_pub_events[0]
+        ping_rcl_pub_event = ping_rcl_pub_events[0]
+        pong_rcl_pub_event = pong_rcl_pub_events[0]
+        self.assertFieldEquals(ping_rcl_pub_event, 'publisher_handle', ping_pub_handle)
+        self.assertFieldEquals(pong_rcl_pub_event, 'publisher_handle', pong_pub_handle)
 
         # Get subscription init events & subscription handles of test topics
         rcl_subscription_init_events = self.get_events_with_name(tp.rcl_subscription_init)
@@ -228,6 +230,29 @@ class TestPubSub(TraceTestCase):
         ping_callback_object = self.get_field(ping_rclcpp_subscription_callback_event, 'callback')
         pong_callback_object = self.get_field(pong_rclcpp_subscription_callback_event, 'callback')
 
+        # Get rmw_take events
+        rmw_take_events = self.get_events_with_name(tp.rmw_take)
+        pong_rmw_take_events = self.get_events_with_field_value(
+            'rmw_subscription_handle',
+            pong_rmw_sub_handle,
+            rmw_take_events,
+        )
+        ping_rmw_take_events = self.get_events_with_field_value(
+            'rmw_subscription_handle',
+            ping_rmw_sub_handle,
+            rmw_take_events,
+        )
+        self.assertNumEventsEqual(pong_rmw_take_events, 1)
+        self.assertNumEventsEqual(ping_rmw_take_events, 1)
+        pong_rmw_take_event = pong_rmw_take_events[0]
+        ping_rmw_take_event = ping_rmw_take_events[0]
+
+        # Check that pub->sub timestamps match
+        ping_timestamp = self.get_field(ping_rmw_pub_event, 'timestamp')
+        self.assertFieldEquals(ping_rmw_take_event, 'source_timestamp', ping_timestamp)
+        pong_timestamp = self.get_field(pong_rmw_pub_event, 'timestamp')
+        self.assertFieldEquals(pong_rmw_take_event, 'source_timestamp', pong_timestamp)
+
         # Check subscription init order
         self.assertEventOrder([
             ping_rmw_sub_init_event,
@@ -278,6 +303,7 @@ class TestPubSub(TraceTestCase):
         #   * /ping pub rclcpp_publish
         #   * /ping pub rcl_publish
         #   * /ping pub rmw_publish
+        #   * /ping sub rmw_take
         #   * /ping sub callback_start
         #   * /pong pub rclcpp_publish
         #   * /pong pub rcl_publish
@@ -286,12 +312,14 @@ class TestPubSub(TraceTestCase):
         #   * /ping sub callback_end
         #   ... we shouldn't necessarily expect the /pong callback to start
         #       before the /ping callback has ended
+        #   * /pong sub rmw_take
         #   * /pong sub callback_start
         #   * /pong sub callback_end
         self.assertEventOrder([
             ping_rclcpp_pub_event,
             ping_rcl_pub_event,
             ping_rmw_pub_event,
+            ping_rmw_take_event,
             ping_callback_start_event,
             pong_rclcpp_pub_event,
             pong_rcl_pub_event,
@@ -302,6 +330,7 @@ class TestPubSub(TraceTestCase):
             pong_rclcpp_pub_event,
             pong_rcl_pub_event,
             pong_rmw_pub_event,
+            pong_rmw_take_event,
             pong_callback_start_event,
             pong_callback_end_event,
         ])

--- a/test_tracetools/test/test_publisher.py
+++ b/test_tracetools/test/test_publisher.py
@@ -61,7 +61,7 @@ class TestPublisher(TraceTestCase):
             # Message is a pointer (aka a handle)
             self.assertValidHandle(
                 event,
-                ['publisher_handle', 'message'],
+                ['rmw_publisher_handle', 'message'],
             )
             self.assertFieldType(event, 'timestamp', int)
         rcl_publish_events = self.get_events_with_name(tp.rcl_publish)
@@ -141,7 +141,7 @@ class TestPublisher(TraceTestCase):
         # Find pointer of published message using rmw_publisher_handle of corresponding rmw_publish
         # event, since it's the "main" publication event
         rmw_publish_topic_events = self.get_events_with_field_value(
-            'publisher_handle',
+            'rmw_publisher_handle',
             rmw_publisher_handle,
             rmw_publish_events,
         )

--- a/tracetools/include/tracetools/tp_call.h
+++ b/tracetools/include/tracetools/tp_call.h
@@ -137,12 +137,12 @@ TRACEPOINT_EVENT(
   TRACEPOINT_PROVIDER,
   rmw_publish,
   TP_ARGS(
-    const void *, publisher_handle_arg,
+    const void *, rmw_publisher_handle_arg,
     const void *, message_arg,
     int64_t, timestamp_arg
   ),
   TP_FIELDS(
-    ctf_integer_hex(const void *, publisher_handle, publisher_handle_arg)
+    ctf_integer_hex(const void *, rmw_publisher_handle, rmw_publisher_handle_arg)
     ctf_integer_hex(const void *, message, message_arg)
     ctf_integer(int64_t, timestamp, timestamp_arg)
   )

--- a/tracetools/include/tracetools/tracetools.h
+++ b/tracetools/include/tracetools/tracetools.h
@@ -270,11 +270,13 @@ _DECLARE_TRACEPOINT(
  * Message publication.
  * Notes the pointer to the message being published at the `rmw` level.
  *
+ * \param[in] rmw_publisher_handle pointer to the publisher's `rmw_publisher_t` handle
  * \param[in] message pointer to the message being published
+ * \param[in] timestamp the source timestamp of the message
  */
 _DECLARE_TRACEPOINT(
   rmw_publish,
-  const void * publisher_handle,
+  const void * rmw_publisher_handle,
   const void * message,
   int64_t timestamp)
 

--- a/tracetools/src/tracetools.c
+++ b/tracetools/src/tracetools.c
@@ -156,11 +156,11 @@ DEFINE_TRACEPOINT(
 DEFINE_TRACEPOINT(
   rmw_publish,
   TRACEPOINT_PARAMS(
-    const void * publisher_handle,
+    const void * rmw_publisher_handle,
     const void * message,
     int64_t timestamp),
   TRACEPOINT_ARGS(
-    publisher_handle,
+    rmw_publisher_handle,
     message,
     timestamp))
 


### PR DESCRIPTION
Follow-up to #74

Relates to #73

1. Update tests to cover the `rmw_publish` tracepoint's new handle and timestamp fields
   * Check that the timestamps match between the publication and taking of the same message
2. Update design doc
3. Rename `rmw_publish` tracepoint's `publisher_handle` field to `rmw_publisher_handle`, since it's an `rmw` handle and we use this name for `rmw` handles everywhere else 
   * And update arguments doc in `tracetools.h`