### PR TITLE
Remove python_cmake_module use.

### DIFF
--- a/lttngpy/CMakeLists.txt
+++ b/lttngpy/CMakeLists.txt
@@ -15,15 +15,6 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
 
-# Figure out Python3 debug/release before anything else can find_package it
-if(WIN32 AND CMAKE_BUILD_TYPE STREQUAL "Debug")
-  find_package(python_cmake_module REQUIRED)
-  find_package(PythonExtra REQUIRED)
-
-  # Force FindPython3 to use the debug interpreter where ROS 2 expects it
-  set(Python3_EXECUTABLE "${PYTHON_EXECUTABLE_DEBUG}")
-endif()
-
 find_package(ament_cmake REQUIRED)
 
 if(WIN32 OR APPLE OR ANDROID)

--- a/lttngpy/CMakeLists.txt
+++ b/lttngpy/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.20)
 
 project(lttngpy)
 
@@ -26,6 +26,21 @@ option(
   LTTNGPY_DISABLED
   "Explicitly disable support, don't link against liblttng-ctl"
   ${DISABLED_DEFAULT})
+
+# By default, without the settings below, find_package(Python3) will attempt
+# to find the newest python version it can, and additionally will find the
+# most specific version.  For instance, on a system that has
+# /usr/bin/python3.10, /usr/bin/python3.11, and /usr/bin/python3, it will find
+# /usr/bin/python3.11, even if /usr/bin/python3 points to /usr/bin/python3.10.
+# The behavior we want is to prefer the "system" installed version unless the
+# user specifically tells us othewise through the Python3_EXECUTABLE hint.
+# Setting CMP0094 to NEW means that the search will stop after the first
+# python version is found.  Setting Python3_FIND_UNVERSIONED_NAMES means that
+# the search will prefer /usr/bin/python3 over /usr/bin/python3.11.  And that
+# latter functionality is only available in CMake 3.20 or later, so we need
+# at least that version.
+cmake_policy(SET CMP0094 NEW)
+set(Python3_FIND_UNVERSIONED_NAMES FIRST)
 
 # Find python before pybind11
 find_package(Python3 REQUIRED COMPONENTS Interpreter Development)

--- a/lttngpy/package.xml
+++ b/lttngpy/package.xml
@@ -12,7 +12,6 @@
   <author email="christophe.bedard@apex.ai">Christophe Bedard</author>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
-  <buildtool_depend>python_cmake_module</buildtool_depend>
 
   <depend>liblttng-ctl-dev</depend>
 


### PR DESCRIPTION
Also add in hints so that we find the unversioned python3 before finding versioned ones.

This must be merged before https://github.com/ros2/ros2/pull/1524 ; see that pull request for more information about this change.