### PR TITLE
Make tracing test assert messages more descriptive

### DIFF
--- a/test_tracetools/test/test_buffer.py
+++ b/test_tracetools/test/test_buffer.py
@@ -61,11 +61,7 @@ class TestBuffer(TraceTestCase):
                 target_buffer,
                 buffer_to_ipb_events)
             # Only 1 for our given buffer
-            self.assertNumEventsEqual(
-                target_buffer_to_ipb_event,
-                1,
-                'none or more than 1 buffer_to_ipb event for the buffer',
-            )
+            self.assertNumEventsEqual(target_buffer_to_ipb_event, 1)
 
             target_ipb = self.get_field(target_buffer_to_ipb_event[0], 'ipb')
             target_ipb_to_subscription_event = self.get_events_with_field_value(
@@ -74,11 +70,7 @@ class TestBuffer(TraceTestCase):
                 ipb_to_subscription_events)
 
             # Only 1 for our given ipb
-            self.assertNumEventsEqual(
-                target_ipb_to_subscription_event,
-                1,
-                'none or more than 1 ipb_to_subscription event for the ipb',
-            )
+            self.assertNumEventsEqual(target_ipb_to_subscription_event, 1)
 
             # Check subscription init order
             #   * rclcpp_construct_ring_buffer

--- a/test_tracetools/test/test_buffer.py
+++ b/test_tracetools/test/test_buffer.py
@@ -59,7 +59,8 @@ class TestBuffer(TraceTestCase):
             target_buffer_to_ipb_event = self.get_events_with_field_value(
                 'buffer',
                 target_buffer,
-                buffer_to_ipb_events)
+                buffer_to_ipb_events,
+            )
             # Only 1 for our given buffer
             self.assertNumEventsEqual(target_buffer_to_ipb_event, 1)
 
@@ -67,7 +68,8 @@ class TestBuffer(TraceTestCase):
             target_ipb_to_subscription_event = self.get_events_with_field_value(
                 'ipb',
                 target_ipb,
-                ipb_to_subscription_events)
+                ipb_to_subscription_events,
+            )
 
             # Only 1 for our given ipb
             self.assertNumEventsEqual(target_ipb_to_subscription_event, 1)
@@ -79,7 +81,7 @@ class TestBuffer(TraceTestCase):
             self.assertEventOrder([
                 construct_event,
                 target_buffer_to_ipb_event[0],
-                target_ipb_to_subscription_event[0]
+                target_ipb_to_subscription_event[0],
             ])
 
 

--- a/test_tracetools/test/test_intra.py
+++ b/test_tracetools/test/test_intra.py
@@ -93,11 +93,13 @@ class TestIntra(TraceTestCase):
         start_events_topic = self.get_events_with_field_value(
             'callback',
             callback_pointers,
-            start_events)
+            start_events,
+        )
         end_events_topic = self.get_events_with_field_value(
             'callback',
             callback_pointers,
-            end_events)
+            end_events,
+        )
         self.assertNumEventsGreaterEqual(start_events_topic, 1)
         self.assertNumEventsGreaterEqual(end_events_topic, 1)
 

--- a/test_tracetools/test/test_intra.py
+++ b/test_tracetools/test/test_intra.py
@@ -51,11 +51,7 @@ class TestIntra(TraceTestCase):
             rcl_sub_init_events,
         )
         # Only 1 for our given topic
-        self.assertNumEventsEqual(
-            rcl_sub_init_topic_events,
-            1,
-            'none or more than 1 rcl_sub_init event for the topic',
-        )
+        self.assertNumEventsEqual(rcl_sub_init_topic_events, 1)
 
         # Get subscription handle
         rcl_sub_init_topic_event = rcl_sub_init_topic_events[0]
@@ -70,11 +66,7 @@ class TestIntra(TraceTestCase):
         )
         # Should have 2 events for the given subscription handle
         # (Subscription and SubscriptionIntraProcess)
-        self.assertNumEventsEqual(
-            rclcpp_sub_init_topic_events,
-            2,
-            'number of rclcpp_sub_init events for the topic not equal to 2',
-        )
+        self.assertNumEventsEqual(rclcpp_sub_init_topic_events, 2)
 
         # Get the 2 subscription pointers
         events = rclcpp_sub_init_topic_events
@@ -96,14 +88,8 @@ class TestIntra(TraceTestCase):
         start_events = self.get_events_with_name(tp.callback_start)
         end_events = self.get_events_with_name(tp.callback_end)
         # Should have at least one start:end pair
-        self.assertNumEventsGreaterEqual(
-            start_events,
-            1,
-            'does not have at least 1 callback start event')
-        self.assertNumEventsGreaterEqual(
-            end_events,
-            1,
-            'does not have at least 1 callback end event')
+        self.assertNumEventsGreaterEqual(start_events, 1)
+        self.assertNumEventsGreaterEqual(end_events, 1)
         start_events_topic = self.get_events_with_field_value(
             'callback',
             callback_pointers,
@@ -112,14 +98,8 @@ class TestIntra(TraceTestCase):
             'callback',
             callback_pointers,
             end_events)
-        self.assertNumEventsGreaterEqual(
-            start_events_topic,
-            1,
-            'no callback_start event found for topic')
-        self.assertNumEventsGreaterEqual(
-            end_events_topic,
-            1,
-            'no callback_end found event for topic')
+        self.assertNumEventsGreaterEqual(start_events_topic, 1)
+        self.assertNumEventsGreaterEqual(end_events_topic, 1)
 
         # Check for is_intra_process field value of 1/true
         start_events_intra = self.get_events_with_field_value(
@@ -128,11 +108,7 @@ class TestIntra(TraceTestCase):
             start_events_topic,
         )
         # Should have one event
-        self.assertNumEventsEqual(
-            start_events_intra,
-            1,
-            'none or more than 1 callback_start event for intra-process topic',
-        )
+        self.assertNumEventsEqual(start_events_intra, 1)
         # As a sanity check, make sure its callback pointer has a corresponding callback_end event
         callback_pointer_intra = self.get_field(start_events_intra[0], 'callback')
         end_events_intra = self.get_events_with_field_value(
@@ -140,11 +116,7 @@ class TestIntra(TraceTestCase):
             callback_pointer_intra,
             end_events_topic,
         )
-        self.assertNumEventsEqual(
-            end_events_intra,
-            1,
-            'none or more than 1 callback_end event for intra-process topic',
-        )
+        self.assertNumEventsEqual(end_events_intra, 1)
 
 
 if __name__ == '__main__':

--- a/test_tracetools/test/test_intra_pub_sub.py
+++ b/test_tracetools/test/test_intra_pub_sub.py
@@ -67,22 +67,22 @@ class TestIntraPubSub(TraceTestCase):
             ipb_ = self.get_events_with_field_value(
                 'buffer',
                 buffer,
-                buffer_to_ipb_events
+                buffer_to_ipb_events,
             )
             self.assertNumEventsEqual(ipb_, 1)
 
             subscription_ = self.get_events_with_field_value(
                 'ipb',
                 self.get_field(ipb_[0], 'ipb'),
-                ipb_to_subscription_events
+                ipb_to_subscription_events,
             )
             self.assertNumEventsEqual(subscription_, 1)
 
             callback_ = self.get_events_with_field_value(
                 'subscription',
                 self.get_field(subscription_[0], 'subscription'),
-                rclcpp_subscription_callback_added_events
-                )
+                rclcpp_subscription_callback_added_events,
+            )
             self.assertNumEventsEqual(callback_, 1)
             buffer_to_callback[buffer] = self.get_field(callback_[0], 'callback')
 
@@ -92,43 +92,48 @@ class TestIntraPubSub(TraceTestCase):
             enqueue_event_cand = self.get_events_with_field_value(
                 'vtid',
                 self.get_field(intra_publish_event, 'vtid'),
-                ring_buffer_enqueue_events
+                ring_buffer_enqueue_events,
             )
             target_enqueue_event = self.get_corresponding_event(
                 self.get_field(intra_publish_event, '_timestamp'),
-                enqueue_event_cand)
+                enqueue_event_cand,
+            )
 
             # Find corresponding enqueue/dequeue event
             target_index = self.get_field(target_enqueue_event, 'index')
             target_buffer = self.get_field(target_enqueue_event, 'buffer')
             filtered_dequeue_events = self.get_filtered_event(
                 {'buffer': target_buffer, 'index': target_index},
-                ring_buffer_dequeue_events)
+                ring_buffer_dequeue_events,
+            )
             target_dequeue_event = self.get_corresponding_event(
                 self.get_field(target_enqueue_event, '_timestamp'),
-                filtered_dequeue_events)
+                filtered_dequeue_events,
+            )
 
             callback_ = buffer_to_callback[target_buffer]
 
             filterd_callback_start = self.get_events_with_field_value(
                 'callback',
                 callback_,
-                callback_start_events
+                callback_start_events,
             )
 
             # Find corresponding callback_start/callback_end event
             target_callback_start = self.get_corresponding_event(
                 self.get_field(target_dequeue_event, '_timestamp'),
-                filterd_callback_start)
+                filterd_callback_start,
+            )
 
             callback_end_cand = self.get_events_with_field_value(
                 'callback',
                 callback_,
-                callback_end_events
+                callback_end_events,
             )
             target_callback_end = self.get_corresponding_event(
                 self.get_field(target_callback_start, '_timestamp'),
-                callback_end_cand)
+                callback_end_cand,
+            )
 
             event_sequence = [
                 intra_publish_event,
@@ -142,7 +147,8 @@ class TestIntraPubSub(TraceTestCase):
             for e in event_sequence:
                 self.assertTrue(
                     e is not None,
-                    'cannot find corresponding event for intra_publish')
+                    'cannot find corresponding event for intra_publish',
+                )
 
             # Check the order of events.
             self.assertEventOrder(event_sequence)

--- a/test_tracetools/test/test_lifecycle_node.py
+++ b/test_tracetools/test/test_lifecycle_node.py
@@ -46,22 +46,14 @@ class TestLifecycleNode(TraceTestCase):
             'test_lifecycle_node',
             rcl_node_init_events,
         )
-        self.assertEqual(
-            len(lifecycle_node_matches),
-            1,
-            'no node init event for lifecycle node',
-        )
+        self.assertNumEventsEqual(lifecycle_node_matches, 1)
         lifecycle_node_handle = self.get_field(lifecycle_node_matches[0], 'node_handle')
 
         # Check the state machine init event
         rcl_lifecycle_state_machine_init_events = self.get_events_with_name(
             tp.rcl_lifecycle_state_machine_init,
         )
-        self.assertEqual(
-            len(rcl_lifecycle_state_machine_init_events),
-            1,
-            'more than one state machine init event',
-        )
+        self.assertNumEventsEqual(rcl_lifecycle_state_machine_init_events, 1)
         # Make sure the node handle matches the one from the node init event
         rcl_lifecycle_state_machine_init_event = rcl_lifecycle_state_machine_init_events[0]
         node_handle = self.get_field(rcl_lifecycle_state_machine_init_event, 'node_handle')
@@ -116,7 +108,10 @@ class TestLifecycleNode(TraceTestCase):
                 self.get_field(event, 'state_machine') == state_machine_handle
                 for event in rcl_lifecycle_transition_events
             ),
-            'state machine handle does not match',
+            (
+                f"state machine handles do not all match '{state_machine_handle}': "
+                f'{rcl_lifecycle_transition_events}'
+            ),
         )
 
 

--- a/test_tracetools/test/test_pub_sub.py
+++ b/test_tracetools/test/test_pub_sub.py
@@ -166,11 +166,11 @@ class TestPubSub(TraceTestCase):
         ping_rcl_subscription_init_event = ping_rcl_subscription_init_events[0]
         pong_rcl_subscription_init_event = pong_rcl_subscription_init_events[0]
         ping_sub_handle = self.get_field(ping_rcl_subscription_init_event, 'subscription_handle')
-        ping_rmw_sub_handle = self.get_field(
-            ping_rcl_subscription_init_event, 'rmw_subscription_handle')
+        ping_rmw_sub_handle = \
+            self.get_field(ping_rcl_subscription_init_event, 'rmw_subscription_handle')
         pong_sub_handle = self.get_field(pong_rcl_subscription_init_event, 'subscription_handle')
-        pong_rmw_sub_handle = self.get_field(
-            pong_rcl_subscription_init_event, 'rmw_subscription_handle')
+        pong_rmw_sub_handle = \
+            self.get_field(pong_rcl_subscription_init_event, 'rmw_subscription_handle')
 
         # Find corresponding rmw_sub_init events
         ping_rmw_sub_init_events = self.get_events_with_field_value(

--- a/test_tracetools/test/test_publisher.py
+++ b/test_tracetools/test/test_publisher.py
@@ -150,8 +150,11 @@ class TestPublisher(TraceTestCase):
         publisher_handle = self.get_field(test_pub_init_topic_event, 'publisher_handle')
         self.assertFieldEquals(rcl_publish_topic_event, 'publisher_handle', publisher_handle)
         # Check publication events order
-        self.assertEventOrder(
-            [rclcpp_publish_topic_event, rcl_publish_topic_event, rmw_publish_topic_event])
+        self.assertEventOrder([
+            rclcpp_publish_topic_event,
+            rcl_publish_topic_event,
+            rmw_publish_topic_event,
+        ])
 
 
 if __name__ == '__main__':

--- a/test_tracetools/test/test_publisher.py
+++ b/test_tracetools/test/test_publisher.py
@@ -86,20 +86,11 @@ class TestPublisher(TraceTestCase):
             '/the_topic',
             test_pub_init_events,
         )
-        self.assertNumEventsEqual(
-            test_pub_init_topic_events,
-            1,
-            'none or more than 1 rcl_pub_init even for test topic',
-        )
+        self.assertNumEventsEqual(test_pub_init_topic_events, 1)
 
         # Check queue_depth value
         test_pub_init_topic_event = test_pub_init_topic_events[0]
-        self.assertFieldEquals(
-            test_pub_init_topic_event,
-            'queue_depth',
-            10,
-            'pub_init event does not have expected queue depth value',
-        )
+        self.assertFieldEquals(test_pub_init_topic_event, 'queue_depth', 10)
 
         # Check that the node handle matches with the node_init event
         node_init_events = self.get_events_with_name(tp.rcl_node_init)
@@ -107,11 +98,7 @@ class TestPublisher(TraceTestCase):
             'test_publisher',
             node_init_events,
         )
-        self.assertNumEventsEqual(
-            test_pub_node_init_events,
-            1,
-            'none or more than 1 node_init event',
-        )
+        self.assertNumEventsEqual(test_pub_node_init_events, 1)
         test_pub_node_init_event = test_pub_node_init_events[0]
         self.assertMatchingField(
             test_pub_node_init_event,
@@ -127,11 +114,7 @@ class TestPublisher(TraceTestCase):
             rmw_publisher_handle,
             rmw_pub_init_events,
         )
-        self.assertNumEventsEqual(
-            rmw_pub_init_events,
-            1,
-            'none or more than 1 rmw_pub_init event for test topic',
-        )
+        self.assertNumEventsEqual(rmw_pub_init_events, 1)
         rmw_pub_init_event = rmw_pub_init_events[0]
 
         # Check publisher creation events order (rmw then rcl)
@@ -145,11 +128,7 @@ class TestPublisher(TraceTestCase):
             rmw_publisher_handle,
             rmw_publish_events,
         )
-        self.assertNumEventsEqual(
-            rmw_publish_topic_events,
-            1,
-            'none or more than 1 rmw_publish event for test topic',
-        )
+        self.assertNumEventsEqual(rmw_publish_topic_events, 1)
         rmw_publish_topic_event = rmw_publish_topic_events[0]
         pub_message = self.get_field(rmw_publish_topic_event, 'message')
         # Find corresponding rclcpp/rcl_publish event
@@ -163,16 +142,8 @@ class TestPublisher(TraceTestCase):
             pub_message,
             rcl_publish_events,
         )
-        self.assertNumEventsEqual(
-            rclcpp_publish_topic_events,
-            1,
-            'none or more than 1 rclcpp_publish event for test topic',
-        )
-        self.assertNumEventsEqual(
-            rcl_publish_topic_events,
-            1,
-            'none or more than 1 rcl_publish event for test topic',
-        )
+        self.assertNumEventsEqual(rclcpp_publish_topic_events, 1)
+        self.assertNumEventsEqual(rcl_publish_topic_events, 1)
         rclcpp_publish_topic_event = rclcpp_publish_topic_events[0]
         rcl_publish_topic_event = rcl_publish_topic_events[0]
         # Get publisher handle from rcl_publisher_init event

--- a/test_tracetools/test/test_service.py
+++ b/test_tracetools/test/test_service.py
@@ -60,12 +60,7 @@ class TestService(TraceTestCase):
         for event in start_events:
             self.assertValidHandle(event, 'callback')
             # Should not be 1 for services (yet)
-            self.assertFieldEquals(
-                event,
-                'is_intra_process',
-                0,
-                'invalid value for is_intra_process',
-            )
+            self.assertFieldEquals(event, 'is_intra_process', 0)
         for event in end_events:
             self.assertValidHandle(event, 'callback')
 
@@ -79,11 +74,7 @@ class TestService(TraceTestCase):
             '/pong',
             ping_node_srv_init_events,
         )
-        self.assertEqual(
-            len(ping_node_test_srv_init_events),
-            1,
-            'none or more than 1 /pong service under the test_service_pong node',
-        )
+        self.assertNumEventsEqual(ping_node_test_srv_init_events, 1)
 
         pong_node_srv_init_events = self.get_events_with_procname(
             'test_service_pong',
@@ -94,11 +85,7 @@ class TestService(TraceTestCase):
             '/ping',
             pong_node_srv_init_events,
         )
-        self.assertGreaterEqual(
-            len(pong_node_test_srv_init_events),
-            1,
-            'cannot find test service name',
-        )
+        self.assertNumEventsGreaterEqual(pong_node_test_srv_init_events, 1)
 
         # Check that the service init events have a matching node handle (with node_init events)
         node_init_events = self.get_events_with_name(tp.rcl_node_init)
@@ -140,11 +127,7 @@ class TestService(TraceTestCase):
             ping_node_test_service_handle,
             ping_node_srv_callback_added_events,
         )
-        self.assertEqual(
-            len(ping_node_test_srv_callback_added_events),
-            1,
-            'none or more than 1 matching callback_added events for the test_service_ping node',
-        )
+        self.assertNumEventsEqual(ping_node_test_srv_callback_added_events, 1)
 
         pong_node_srv_callback_added_events = self.get_events_with_procname(
             'test_service_pong',
@@ -155,11 +138,7 @@ class TestService(TraceTestCase):
             pong_node_test_service_handle,
             pong_node_srv_callback_added_events,
         )
-        self.assertEqual(
-            len(pong_node_test_srv_callback_added_events),
-            1,
-            'none or more than 1 matching callback_added events for the test_service_pong node',
-        )
+        self.assertNumEventsEqual(pong_node_test_srv_callback_added_events, 1)
 
         # Check that there are matching rclcpp_callback_register events
         ping_node_test_callback_ref = self.get_field(
@@ -180,11 +159,7 @@ class TestService(TraceTestCase):
             ping_node_test_callback_ref,
             ping_node_callback_register_events,
         )
-        self.assertEqual(
-            len(ping_node_test_callback_register_events),
-            1,
-            'none or more than 1 matching callback_register events for the test_service_ping node',
-        )
+        self.assertNumEventsEqual(ping_node_test_callback_register_events, 1)
 
         pong_node_callback_register_events = self.get_events_with_procname(
             'test_service_pong',
@@ -195,11 +170,7 @@ class TestService(TraceTestCase):
             pong_node_test_callback_ref,
             pong_node_callback_register_events,
         )
-        self.assertEqual(
-            len(pong_node_test_callback_register_events),
-            1,
-            'none or more than 1 matching callback_register events for the test_service_pong node',
-        )
+        self.assertNumEventsEqual(pong_node_test_callback_register_events, 1)
 
         # Check that there are corresponding callback_start/stop pairs
         ping_node_test_callback_start_events = self.get_events_with_field_value(
@@ -207,44 +178,28 @@ class TestService(TraceTestCase):
             ping_node_test_callback_ref,
             start_events,
         )
-        self.assertEqual(
-            len(ping_node_test_callback_start_events),
-            1,
-            'none or more than 1 matching callback_start events for the test_service_ping node',
-        )
+        self.assertNumEventsEqual(ping_node_test_callback_start_events, 1)
 
         pong_node_test_callback_start_events = self.get_events_with_field_value(
             'callback',
             pong_node_test_callback_ref,
             start_events,
         )
-        self.assertEqual(
-            len(pong_node_test_callback_start_events),
-            1,
-            'none or more than 1 matching callback_start events for the test_service_pong node',
-        )
+        self.assertNumEventsEqual(pong_node_test_callback_start_events, 1)
 
         ping_node_test_callback_end_events = self.get_events_with_field_value(
             'callback',
             ping_node_test_callback_ref,
             end_events,
         )
-        self.assertEqual(
-            len(ping_node_test_callback_end_events),
-            1,
-            'none or more than 1 matching callback_end events for the test_service_ping node',
-        )
+        self.assertNumEventsEqual(ping_node_test_callback_end_events, 1)
 
         pong_node_test_callback_end_events = self.get_events_with_field_value(
             'callback',
             pong_node_test_callback_ref,
             end_events,
         )
-        self.assertEqual(
-            len(pong_node_test_callback_end_events),
-            1,
-            'none or more than 1 matching callback_end events for the test_service_pong node',
-        )
+        self.assertNumEventsEqual(pong_node_test_callback_end_events, 1)
 
 
 if __name__ == '__main__':

--- a/test_tracetools/test/test_subscription.py
+++ b/test_tracetools/test/test_subscription.py
@@ -115,12 +115,7 @@ class TestSubscription(TraceTestCase):
         test_rcl_sub_init_event = test_rcl_sub_init_events[0]
 
         # Check queue_depth value
-        self.assertFieldEquals(
-            test_rcl_sub_init_event,
-            'queue_depth',
-            10,
-            'sub_init event does not have expected queue depth value',
-        )
+        self.assertFieldEquals(test_rcl_sub_init_event, 'queue_depth', 10)
 
         # Check that the node handle matches the node_init event
         node_init_events = self.get_events_with_name(tp.rcl_node_init)
@@ -128,11 +123,7 @@ class TestSubscription(TraceTestCase):
             'test_ping',
             node_init_events,
         )
-        self.assertNumEventsEqual(
-            test_sub_node_init_events,
-            1,
-            'none or more than 1 node_init event',
-        )
+        self.assertNumEventsEqual(test_sub_node_init_events, 1)
         test_sub_node_init_event = test_sub_node_init_events[0]
         self.assertMatchingField(
             test_sub_node_init_event,
@@ -149,11 +140,7 @@ class TestSubscription(TraceTestCase):
             rclcpp_sub_init_events,
         )
         # Should only have 1 rclcpp_sub_init event, since intra-process is not enabled
-        self.assertNumEventsEqual(
-            rclcpp_sub_init_matching_events,
-            1,
-            'none or more than 1 rclcpp_sub_init event for topic',
-        )
+        self.assertNumEventsEqual(rclcpp_sub_init_matching_events, 1)
         # Check that the rmw subscription handle matches between rmw_sub_init and rcl_sub_init
         rmw_subscription_handle = self.get_field(
             test_rcl_sub_init_event, 'rmw_subscription_handle')
@@ -162,11 +149,7 @@ class TestSubscription(TraceTestCase):
             rmw_subscription_handle,
             rmw_sub_init_events,
         )
-        self.assertNumEventsEqual(
-            rmw_sub_init_events,
-            1,
-            'none or more than 1 rmw_sub_init event for test topic',
-        )
+        self.assertNumEventsEqual(rmw_sub_init_events, 1)
         rmw_sub_init_event = rmw_sub_init_events[0]
 
         # Check that subscription pointer matches between rclcpp_sub_init and sub_callback_added
@@ -177,11 +160,7 @@ class TestSubscription(TraceTestCase):
             subscription_pointer,
             callback_added_events,
         )
-        self.assertNumEventsEqual(
-            callback_added_matching_events,
-            1,
-            'none or more than 1 rclcpp_sub_callback_added event for topic',
-        )
+        self.assertNumEventsEqual(callback_added_matching_events, 1)
         callback_added_matching_event = callback_added_matching_events[0]
 
         # Check that callback pointer matches between callback_added and callback_register
@@ -195,11 +174,7 @@ class TestSubscription(TraceTestCase):
             callback_handle,
             test_sub_node_callback_register_events,
         )
-        self.assertNumEventsEqual(
-            callback_register_matching_events,
-            1,
-            'none or more than 1 matching callback_register events for the test topic',
-        )
+        self.assertNumEventsEqual(callback_register_matching_events, 1)
         callback_register_matching_event = callback_register_matching_events[0]
 
         # Check susbcription creation events order
@@ -217,22 +192,14 @@ class TestSubscription(TraceTestCase):
             subscription_handle,
             execute_events,
         )
-        self.assertNumEventsEqual(
-            test_execute_events,
-            1,
-            'none or more than 1 executor_execute event for topic sub',
-        )
+        self.assertNumEventsEqual(test_execute_events, 1)
         test_execute_event = test_execute_events[0]
         test_rmw_take_events = self.get_events_with_field_value(
             'rmw_subscription_handle',
             rmw_subscription_handle,
             rmw_take_events,
         )
-        self.assertNumEventsEqual(
-            test_execute_events,
-            1,
-            'none or more than 1 executor_execute event for topic sub',
-        )
+        self.assertNumEventsEqual(test_execute_events, 1)
         test_rmw_take_event = test_rmw_take_events[0]
         test_taken_msg = self.get_field(test_rmw_take_event, 'message')
         self.assertFieldEquals(test_rmw_take_event, 'taken', 1, 'test message not taken')
@@ -241,22 +208,14 @@ class TestSubscription(TraceTestCase):
             test_taken_msg,
             rcl_take_events,
         )
-        self.assertNumEventsEqual(
-            test_rcl_take_events,
-            1,
-            'none or more than 1 rcl_take event for topic sub',
-        )
+        self.assertNumEventsEqual(test_rcl_take_events, 1)
         test_rcl_take_event = test_rcl_take_events[0]
         test_rclcpp_take_events = self.get_events_with_field_value(
             'message',
             test_taken_msg,
             rclcpp_take_events,
         )
-        self.assertNumEventsEqual(
-            test_rcl_take_events,
-            1,
-            'none or more than 1 rclcpp_take event for topic sub',
-        )
+        self.assertNumEventsEqual(test_rcl_take_events, 1)
         test_rclcpp_take_event = test_rclcpp_take_events[0]
 
         # Check that each start:end pair has a common callback handle
@@ -288,11 +247,7 @@ class TestSubscription(TraceTestCase):
             callback_pointer,
             ping_events_start,
         )
-        self.assertNumEventsEqual(
-            callback_start_matching_events,
-            1,
-            'none or more than 1 callback_start event for topic callback',
-        )
+        self.assertNumEventsEqual(callback_start_matching_events, 1)
         callback_start_matching_event = callback_start_matching_events[0]
         ping_events_end = self.get_events_with_name(tp.callback_end, ping_events)
         callback_end_matching_events = self.get_events_with_field_value(
@@ -300,11 +255,7 @@ class TestSubscription(TraceTestCase):
             callback_pointer,
             ping_events_end,
         )
-        self.assertNumEventsEqual(
-            callback_end_matching_events,
-            1,
-            'none or more than 1 callback_end event for topic callback',
-        )
+        self.assertNumEventsEqual(callback_end_matching_events, 1)
         callback_end_matching_event = callback_end_matching_events[0]
 
         # Check execute+take+callback order

--- a/test_tracetools/test/test_subscription.py
+++ b/test_tracetools/test/test_subscription.py
@@ -54,9 +54,7 @@ class TestSubscription(TraceTestCase):
         rmw_sub_init_events = self.get_events_with_name(tp.rmw_subscription_init)
         rcl_sub_init_events = self.get_events_with_name(tp.rcl_subscription_init)
         rclcpp_sub_init_events = self.get_events_with_name(tp.rclcpp_subscription_init)
-        callback_added_events = self.get_events_with_name(
-            tp.rclcpp_subscription_callback_added,
-        )
+        callback_added_events = self.get_events_with_name(tp.rclcpp_subscription_callback_added)
         callback_register_events = self.get_events_with_name(tp.rclcpp_callback_register)
         execute_events = self.get_events_with_name(tp.rclcpp_executor_execute)
         rmw_take_events = self.get_events_with_name(tp.rmw_take)
@@ -98,7 +96,7 @@ class TestSubscription(TraceTestCase):
             is_intra_process_value = self.get_field(event, 'is_intra_process')
             self.assertIsInstance(is_intra_process_value, int, 'is_intra_process not int')
             self.assertTrue(
-                is_intra_process_value in [0, 1],
+                is_intra_process_value in (0, 1),
                 f'invalid value for is_intra_process: {is_intra_process_value}',
             )
         for event in end_events:

--- a/test_tracetools/test/test_timer.py
+++ b/test_tracetools/test/test_timer.py
@@ -74,21 +74,16 @@ class TestTimer(TraceTestCase):
         for event in start_events:
             self.assertValidHandle(event, 'callback')
             # Should not be 1 for timer
-            self.assertFieldEquals(
-                event,
-                'is_intra_process',
-                0,
-                'invalid value for is_intra_process',
-            )
+            self.assertFieldEquals(event, 'is_intra_process', 0)
 
         end_events = self.get_events_with_name(tp.callback_end)
         for event in end_events:
             self.assertValidHandle(event, 'callback')
 
         # Find and check given timer period
-        self.assertNumEventsEqual(timer_init_events, 1, 'none or more test timer init events')
+        self.assertNumEventsEqual(timer_init_events, 1)
         test_timer_init_event = timer_init_events[0]
-        self.assertFieldEquals(test_timer_init_event, 'period', 1000000, 'invalid period')
+        self.assertFieldEquals(test_timer_init_event, 'period', 1000000)
         timer_handle = self.get_field(test_timer_init_event, 'timer_handle')
 
         # Check that the timer_init:callback_added pair exists and has a common timer handle
@@ -97,11 +92,7 @@ class TestTimer(TraceTestCase):
             timer_handle,
             callback_added_events,
         )
-        self.assertNumEventsEqual(
-            test_callback_added_events,
-            1,
-            'none or more than 1 matching callback_added events for the test timer',
-        )
+        self.assertNumEventsEqual(test_callback_added_events, 1)
         test_callback_added_event = test_callback_added_events[0]
 
         # Check that callback pointer matches between callback_added and callback_register
@@ -111,11 +102,7 @@ class TestTimer(TraceTestCase):
             callback_handle,
             callback_register_events,
         )
-        self.assertNumEventsEqual(
-            test_callback_register_events,
-            1,
-            'none or more than 1 matching callback_register events for the test topic',
-        )
+        self.assertNumEventsEqual(test_callback_register_events, 1)
         test_callback_register_event = test_callback_register_events[0]
 
         # Check that there is a link_node event for the timer
@@ -124,11 +111,7 @@ class TestTimer(TraceTestCase):
             timer_handle,
             link_node_events,
         )
-        self.assertNumEventsEqual(
-            test_link_node_events,
-            1,
-            'none or more than 1 matching timer_link_node events for the test timer',
-        )
+        self.assertNumEventsEqual(test_link_node_events, 1)
         test_link_node_event = test_link_node_events[0]
 
         # And that the node from that node handle exists
@@ -139,11 +122,7 @@ class TestTimer(TraceTestCase):
             node_handle,
             node_init_events,
         )
-        self.assertNumEventsEqual(
-            test_node_inits_events,
-            1,
-            'none or more than 1 matching node_init events for the test timer',
-        )
+        self.assertNumEventsEqual(test_node_inits_events, 1)
         test_node_inits_event = test_node_inits_events[0]
 
         # Check timer creation events order
@@ -161,11 +140,7 @@ class TestTimer(TraceTestCase):
             timer_handle,
             executor_execute_events,
         )
-        self.assertNumEventsEqual(
-            timer_execute_events,
-            2,
-            'not 2 executor_execute events for the test timer',
-        )
+        self.assertNumEventsEqual(timer_execute_events, 2)
 
         # Check that the callback events correspond to the registered timer callback
         self.assertMatchingField(


### PR DESCRIPTION
This is in the context of tracing tests failing on ROS 2 CI after parallelized testing was enabled. The goal is to improve the failed assertion messages to better understand how/why the tests failed just by looking at the test logs, which should hopefully help us fix the tests.

To do this, I:

1. Improved some of the default messages in `TraceTestCase`'s `assert*()` methods to include more information, like the full event(s) data, the field name(s), and the value(s) (if applicable).
2. Removed some of the assert messages in the tests to rely on the default ones. Most (if not all) messages didn't contain the actual event data or value, which is really the part that's useful. The messages only explained the context, which we can figure out by looking at the code anyway, so it wasn't really that useful.

I also did some formatting/code style fixes.