### PR TITLE
Allow tracing tests to be run in parallel with other tests

### DIFF
--- a/test_ros2trace/package.xml
+++ b/test_ros2trace/package.xml
@@ -25,6 +25,7 @@
   <test_depend>test_tracetools</test_depend>
   <test_depend>tracetools</test_depend>
   <test_depend>tracetools_read</test_depend>
+  <test_depend>tracetools_test</test_depend>
   <test_depend>tracetools_trace</test_depend>
 
   <!-- TODO(clalancette): This is actually a false dependency,

--- a/test_ros2trace/test/test_ros2trace/test_trace.py
+++ b/test_ros2trace/test/test_ros2trace/test_trace.py
@@ -60,38 +60,29 @@ class TestROS2TraceCLI(unittest.TestCase):
         )
 
     def setUp(self) -> None:
-        # Make sure there are no existing tracing sessions before running a test
-        self.assertNoTracingSession()
-
         self.trace_test_id = get_trace_test_id(self._testMethodName)
 
     def tearDown(self) -> None:
-        # Make sure there are no leftover tracing sessions after running a test
-        # Even if running 'ros2 trace' fails, we do not want any lingering tracing session
-        self.assertNoTracingSession()
-
         del self.trace_test_id
 
-    def assertTracingSession(self) -> None:
+    def assertTracingSessionExist(self, session_name: str) -> None:
         self.assertTrue(
             lttngpy.is_lttng_session_daemon_alive(),
-            'no tracing sessions exist because there is no daemon',
+            f"tracing session '{session_name}' does not exist because there is no daemon",
         )
         session_names = lttngpy.get_session_names()
-        has_tracing_sessions = session_names is not None and 0 < len(session_names)
-        self.assertTrue(has_tracing_sessions, 'no tracing sessions exist')
+        self.assertIn(
+            session_name,
+            session_names,
+            f"tracing session '{session_name}' does not exist",
+        )
 
-    def assertNoTracingSession(self) -> None:
+    def assertTracingSessionNotExist(self, session_name: str) -> None:
         # If there is no session daemon, then there are no tracing sessions
         if not lttngpy.is_lttng_session_daemon_alive():
             return
         session_names = lttngpy.get_session_names()
-        no_tracing_sessions = 0 == len(session_names)
-        if not no_tracing_sessions:
-            # Destroy tracing sessions if there are any, this way we can continue running tests and
-            # avoid possible interference between them
-            self.assertEqual(0, lttngpy.destroy_all_sessions())
-        self.assertTrue(no_tracing_sessions, f'tracing session(s) exist: {session_names}')
+        self.assertNotIn(session_name, session_names, f"tracing session '{session_name}' exists")
 
     def assertTraceExist(self, trace_dir: str) -> None:
         self.assertTrue(os.path.isdir(trace_dir), f'trace directory does not exist: {trace_dir}')
@@ -242,12 +233,16 @@ class TestROS2TraceCLI(unittest.TestCase):
         # Check that the trace directory was created
         subdirs = self.get_subdirectories(tmpdir)
         self.assertEqual(1, len(subdirs))
-        self.assertTrue(subdirs[0].startswith('session-'))
+        trace_dir_name = subdirs[0]
+        self.assertTrue(trace_dir_name.startswith('session-'))
+        self.assertTracingSessionNotExist(trace_dir_name)
 
         # Test with a provided session name
-        ret = self.run_trace_command(['--path', tmpdir, '--session-name', 'test_default'])
+        session_name = 'test_default'
+        ret = self.run_trace_command(['--path', tmpdir, '--session-name', session_name])
         self.assertEqual(0, ret)
-        self.assertTraceExist(os.path.join(tmpdir, 'test_default'))
+        self.assertTraceExist(os.path.join(tmpdir, session_name))
+        self.assertTracingSessionNotExist(session_name)
 
         shutil.rmtree(tmpdir)
 
@@ -280,157 +275,186 @@ class TestROS2TraceCLI(unittest.TestCase):
                 ('topic_name', '/pong'),
             ],
         )
+        self.assertTracingSessionNotExist(trace_dir_name)
 
         # Test with a provided session name
+        session_name = 'test_default_tracing'
         process = self.run_trace_command_start(
             [
                 '--path', tmpdir,
                 '--ust', tracepoints.rcl_subscription_init, TRACE_TEST_ID_TP_NAME,
-                '--session-name', 'test_default_tracing',
+                '--session-name', session_name,
             ],
             wait_for_start=True,
         )
+        self.assertTracingSessionExist(session_name)
         self.run_nodes()
         ret = self.run_trace_command_stop(process)
         self.assertEqual(0, ret)
         self.assertTraceContains(
-            os.path.join(tmpdir, 'test_default_tracing'),
+            os.path.join(tmpdir, session_name),
             [
                 ('topic_name', '/ping'),
                 ('topic_name', '/pong'),
             ],
         )
+        self.assertTracingSessionNotExist(session_name)
 
         shutil.rmtree(tmpdir)
 
     def test_env_var_ros_trace_dir(self) -> None:
         tmpdir = self.create_test_tmpdir('test_env_var_ros_trace_dir')
+        session_name = 'test_env_var_ros_trace_dir'
 
         # Env var only
         ret = self.run_trace_command(
-            ['--session-name', 'test_env_var_ros_trace_dir'],
+            ['--session-name', session_name],
             env={'ROS_TRACE_DIR': tmpdir},
         )
         self.assertEqual(0, ret)
-        self.assertTraceExist(os.path.join(tmpdir, 'test_env_var_ros_trace_dir'))
+        self.assertTraceExist(os.path.join(tmpdir, session_name))
+        self.assertTracingSessionNotExist(session_name)
 
         # Env var and argument should use argument
         tmpdir_path = self.create_test_tmpdir('test_env_var_ros_trace_dir__arg')
+        session_name = 'test_env_var_ros_trace_dir2'
         ret = self.run_trace_command(
-            ['--path', tmpdir_path, '--session-name', 'test_env_var_ros_trace_dir2'],
+            ['--path', tmpdir_path, '--session-name', session_name],
             env={'ROS_TRACE_DIR': tmpdir},
         )
         self.assertEqual(0, ret)
-        self.assertTraceExist(os.path.join(tmpdir_path, 'test_env_var_ros_trace_dir2'))
-        self.assertTraceNotExist(os.path.join(tmpdir, 'test_env_var_ros_trace_dir2'))
+        self.assertTraceExist(os.path.join(tmpdir_path, session_name))
+        self.assertTraceNotExist(os.path.join(tmpdir, session_name))
+        self.assertTracingSessionNotExist(session_name)
 
         shutil.rmtree(tmpdir_path)
         shutil.rmtree(tmpdir)
 
     def test_env_var_ros_home(self) -> None:
         tmpdir = self.create_test_tmpdir('test_env_var_ros_home')
+        session_name = 'test_env_var_ros_home'
 
         ret = self.run_trace_command(
-            ['--session-name', 'test_env_var_ros_home'],
+            ['--session-name', session_name],
             env={'ROS_HOME': tmpdir},
         )
         self.assertEqual(0, ret)
         # Under the 'tracing' directory
-        self.assertTraceExist(os.path.join(tmpdir, 'tracing', 'test_env_var_ros_home'))
+        self.assertTraceExist(os.path.join(tmpdir, 'tracing', session_name))
+        self.assertTracingSessionNotExist(session_name)
 
         # Env var and argument should use argument
         tmpdir_path = self.create_test_tmpdir('test_env_var_ros_home__arg')
+        session_name = 'test_env_var_ros_home2'
         ret = self.run_trace_command(
-            ['--path', tmpdir_path, '--session-name', 'test_env_var_ros_home2'],
+            ['--path', tmpdir_path, '--session-name', session_name],
             env={'ROS_HOME': tmpdir},
         )
         self.assertEqual(0, ret)
-        self.assertTraceExist(os.path.join(tmpdir_path, 'test_env_var_ros_home2'))
-        self.assertTraceNotExist(os.path.join(tmpdir, 'test_env_var_ros_home2'))
+        self.assertTraceExist(os.path.join(tmpdir_path, session_name))
+        self.assertTraceNotExist(os.path.join(tmpdir, session_name))
+        self.assertTracingSessionNotExist(session_name)
 
         shutil.rmtree(tmpdir_path)
         shutil.rmtree(tmpdir)
 
     def test_empty_session_name(self) -> None:
-        tmpdir = self.create_test_tmpdir('test_env_var_ros_home')
+        tmpdir = self.create_test_tmpdir('test_empty_session_name')
 
         # Empty session name should result in an error
-        ret = self.run_trace_command(['--session-name', ''])
+        ret = self.run_trace_command(
+            ['--path', tmpdir, '--session-name', ''],
+        )
         self.assertEqual(1, ret)
+        self.assertTracingSessionNotExist('')
 
         shutil.rmtree(tmpdir)
 
     def test_base_path_not_exist(self) -> None:
         tmpdir = self.create_test_tmpdir('test_base_path_not_exist')
+        session_name = 'test_base_path_not_exist'
 
         # Base directory should be created if it does not exist
         fake_base_path = os.path.join(tmpdir, 'doesnt_exist')
         ret = self.run_trace_command(
-            ['--path', fake_base_path, '--session-name', 'test_base_path_not_exist'],
+            ['--path', fake_base_path, '--session-name', session_name],
         )
         self.assertEqual(0, ret)
-        self.assertTraceExist(os.path.join(fake_base_path, 'test_base_path_not_exist'))
+        self.assertTraceExist(os.path.join(fake_base_path, session_name))
+        self.assertTracingSessionNotExist(session_name)
 
         shutil.rmtree(tmpdir)
 
     def test_no_events(self) -> None:
         tmpdir = self.create_test_tmpdir('test_no_events')
+        session_name = 'test_no_events'
 
         # Enabling no events should result in an error
         ret = self.run_trace_command(
-            ['--path', tmpdir, '--ust', '--kernel'],
+            ['--path', tmpdir, '--ust', '--kernel', '--session-name', session_name],
         )
         self.assertEqual(1, ret)
+        self.assertTraceNotExist(os.path.join(tmpdir, session_name))
+        self.assertTracingSessionNotExist(session_name)
 
         shutil.rmtree(tmpdir)
 
     def test_unknown_context_field(self) -> None:
         tmpdir = self.create_test_tmpdir('test_unknown_context_field')
+        session_name = 'some_nonexistent_context_field'
 
         # Unknown context field should result in an error
         ret = self.run_trace_command(
-            ['--path', tmpdir, '--context', 'some_nonexistent_context_field'],
+            ['--path', tmpdir, '--context', session_name],
         )
         self.assertEqual(1, ret)
+        self.assertTraceNotExist(os.path.join(tmpdir, session_name))
+        self.assertTracingSessionNotExist(session_name)
 
         shutil.rmtree(tmpdir)
 
     def test_append_trace(self) -> None:
         tmpdir = self.create_test_tmpdir('test_append_trace')
+        session_name = 'test_append_trace'
 
         # Generate a normal trace
         ret = self.run_trace_command(
-            ['--path', tmpdir, '--session-name', 'test_append_trace'],
+            ['--path', tmpdir, '--session-name', session_name],
         )
         self.assertEqual(0, ret)
-        trace_dir = os.path.join(tmpdir, 'test_append_trace')
+        trace_dir = os.path.join(tmpdir, session_name)
         self.assertTraceExist(trace_dir)
+        self.assertTracingSessionNotExist(session_name)
 
         # Generating another trace with the same path should error out
         ret = self.run_trace_command(
-            ['--path', tmpdir, '--session-name', 'test_append_trace'],
+            ['--path', tmpdir, '--session-name', session_name],
         )
         self.assertEqual(1, ret)
         self.assertTraceExist(trace_dir)
+        self.assertTracingSessionNotExist(session_name)
 
         # But it should work if we use the '--append-trace' option
         ret = self.run_trace_command(
             [
                 '--path', tmpdir,
-                '--session-name', 'test_append_trace',
+                '--session-name', session_name,
                 '--append-trace',
             ],
         )
         self.assertEqual(0, ret)
         self.assertTraceExist(trace_dir)
+        self.assertTracingSessionNotExist(session_name)
 
         shutil.rmtree(tmpdir)
 
     def test_pause_resume_stop_bad_session_name(self) -> None:
         for subcommand in ('pause', 'resume', 'stop'):
             # Session name doesn't exist
-            ret = self.run_trace_subcommand([subcommand, 'some_nonexistent_session_name'])
+            session_name = 'some_nonexistent_session_name'
+            ret = self.run_trace_subcommand([subcommand, session_name])
             self.assertEqual(1, ret, f'subcommand: {subcommand}')
+            self.assertTracingSessionNotExist(session_name)
             # Session name not provided
             ret = self.run_trace_subcommand([subcommand])
             self.assertEqual(2, ret, f'subcommand: {subcommand}')
@@ -438,25 +462,26 @@ class TestROS2TraceCLI(unittest.TestCase):
     @unittest.skipIf(not are_tracepoints_included(), 'tracepoints are required')
     def test_start_pause_resume_stop(self) -> None:
         tmpdir = self.create_test_tmpdir('test_start_pause_resume_stop')
+        session_name = 'test_start_pause_resume_stop'
 
         # Start tracing and run nodes
         ret = self.run_trace_subcommand(
             [
-                'start', 'test_start_pause_resume_stop',
+                'start', session_name,
                 '--ust', 'ros2:*', TRACE_TEST_ID_TP_NAME,
                 '--path', tmpdir,
             ],
         )
         self.assertEqual(0, ret)
-        trace_dir = os.path.join(tmpdir, 'test_start_pause_resume_stop')
+        trace_dir = os.path.join(tmpdir, session_name)
         self.assertTraceExist(trace_dir)
-        self.assertTracingSession()
+        self.assertTracingSessionExist(session_name)
         self.run_nodes()
 
         # Pause tracing and check trace
-        ret = self.run_trace_subcommand(['pause', 'test_start_pause_resume_stop'])
+        ret = self.run_trace_subcommand(['pause', session_name])
         self.assertEqual(0, ret)
-        self.assertTracingSession()
+        self.assertTracingSessionExist(session_name)
         expected_trace_data = [
             ('topic_name', '/ping'),
             ('topic_name', '/pong'),
@@ -464,9 +489,9 @@ class TestROS2TraceCLI(unittest.TestCase):
         num_events = self.assertTraceContains(trace_dir, expected_trace_data)
 
         # Pausing again should give an error but not affect anything
-        ret = self.run_trace_subcommand(['pause', 'test_start_pause_resume_stop'])
+        ret = self.run_trace_subcommand(['pause', session_name])
         self.assertEqual(1, ret)
-        self.assertTracingSession()
+        self.assertTracingSessionExist(session_name)
         new_num_events = self.assertTraceContains(trace_dir, expected_trace_data)
         self.assertEqual(num_events, new_num_events, 'unexpected new events in trace')
 
@@ -476,25 +501,26 @@ class TestROS2TraceCLI(unittest.TestCase):
         self.assertEqual(num_events, new_num_events, 'unexpected new events in trace')
 
         # Resume tracing and run nodes again
-        ret = self.run_trace_subcommand(['resume', 'test_start_pause_resume_stop'])
+        ret = self.run_trace_subcommand(['resume', session_name])
         self.assertEqual(0, ret)
-        self.assertTracingSession()
+        self.assertTracingSessionExist(session_name)
         self.run_nodes()
 
         # Resuming tracing again should give an error but not affect anything
-        ret = self.run_trace_subcommand(['resume', 'test_start_pause_resume_stop'])
+        ret = self.run_trace_subcommand(['resume', session_name])
         self.assertEqual(1, ret)
-        self.assertTracingSession()
+        self.assertTracingSessionExist(session_name)
 
         # Stop tracing and check that trace changed
-        ret = self.run_trace_subcommand(['stop', 'test_start_pause_resume_stop'])
+        ret = self.run_trace_subcommand(['stop', session_name])
         self.assertEqual(0, ret)
-        self.assertNoTracingSession()
+        self.assertTracingSessionNotExist(session_name)
         new_num_events = self.assertTraceContains(trace_dir, expected_trace_data)
         self.assertGreater(new_num_events, num_events, 'no new events in trace')
 
         # Stopping tracing again should give an error but not affect anything
-        ret = self.run_trace_subcommand(['stop', 'test_start_pause_resume_stop'])
+        ret = self.run_trace_subcommand(['stop', session_name])
         self.assertEqual(1, ret)
+        self.assertTracingSessionNotExist(session_name)
 
         shutil.rmtree(tmpdir)

--- a/test_tracetools/CMakeLists.txt
+++ b/test_tracetools/CMakeLists.txt
@@ -36,13 +36,36 @@ if(BUILD_TESTING)
   find_package(lifecycle_msgs REQUIRED)
   find_package(rclcpp REQUIRED)
   find_package(rclcpp_lifecycle REQUIRED)
+  find_package(rcpputils REQUIRED)
   find_package(std_msgs REQUIRED)
   find_package(std_srvs REQUIRED)
+
+  # The utility lib is needed even if TRACETOOLS_DISABLED; it's just empty
+  add_library(${PROJECT_NAME}_mark_process src/mark_process.cpp)
+  if(NOT TRACETOOLS_DISABLED)
+    find_package(PkgConfig REQUIRED)
+    pkg_check_modules(LTTNG REQUIRED lttng-ust)
+    target_link_libraries(${PROJECT_NAME}_mark_process PRIVATE
+      ${LTTNG_LIBRARIES}
+      rcpputils::rcpputils
+    )
+  endif()
+  target_include_directories(${PROJECT_NAME}_mark_process PUBLIC
+    "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+  )
+  if(TRACETOOLS_DISABLED)
+    target_compile_definitions(${PROJECT_NAME}_mark_process PRIVATE TRACETOOLS_DISABLED)
+  endif()
+  install(
+    DIRECTORY include/
+    DESTINATION include/${PROJECT_NAME}
+  )
 
   add_executable(test_publisher
     src/test_publisher.cpp
   )
   target_link_libraries(test_publisher PRIVATE
+    ${PROJECT_NAME}_mark_process
     rclcpp::rclcpp
     ${std_msgs_TARGETS}
   )
@@ -51,6 +74,7 @@ if(BUILD_TESTING)
     src/test_intra.cpp
   )
   target_link_libraries(test_intra PRIVATE
+    ${PROJECT_NAME}_mark_process
     rclcpp::rclcpp
     ${std_msgs_TARGETS}
   )
@@ -59,6 +83,7 @@ if(BUILD_TESTING)
     src/test_lifecycle_node.cpp
   )
   target_link_libraries(test_lifecycle_node PRIVATE
+    ${PROJECT_NAME}_mark_process
     rclcpp::rclcpp
     rclcpp_lifecycle::rclcpp_lifecycle
   )
@@ -67,6 +92,7 @@ if(BUILD_TESTING)
     src/test_lifecycle_client.cpp
   )
   target_link_libraries(test_lifecycle_client PRIVATE
+    ${PROJECT_NAME}_mark_process
     ${lifecycle_msgs_TARGETS}
     rclcpp::rclcpp
   )
@@ -75,6 +101,7 @@ if(BUILD_TESTING)
     src/test_ping.cpp
   )
   target_link_libraries(test_ping PRIVATE
+    ${PROJECT_NAME}_mark_process
     rclcpp::rclcpp
     ${std_msgs_TARGETS}
   )
@@ -83,6 +110,7 @@ if(BUILD_TESTING)
     src/test_pong.cpp
   )
   target_link_libraries(test_pong PRIVATE
+    ${PROJECT_NAME}_mark_process
     rclcpp::rclcpp
     ${std_msgs_TARGETS}
   )
@@ -91,6 +119,7 @@ if(BUILD_TESTING)
     src/test_timer.cpp
   )
   target_link_libraries(test_timer PRIVATE
+    ${PROJECT_NAME}_mark_process
     rclcpp::rclcpp
   )
 
@@ -98,6 +127,7 @@ if(BUILD_TESTING)
     src/test_service_ping.cpp
   )
   target_link_libraries(test_service_ping PRIVATE
+    ${PROJECT_NAME}_mark_process
     rclcpp::rclcpp
     ${std_srvs_TARGETS}
   )
@@ -106,6 +136,7 @@ if(BUILD_TESTING)
     src/test_service_pong.cpp
   )
   target_link_libraries(test_service_pong PRIVATE
+    ${PROJECT_NAME}_mark_process
     rclcpp::rclcpp
     ${std_srvs_TARGETS}
   )

--- a/test_tracetools/include/test_tracetools/mark_process.hpp
+++ b/test_tracetools/include/test_tracetools/mark_process.hpp
@@ -1,0 +1,41 @@
+// Copyright 2024 Apex.AI, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef TEST_TRACETOOLS__MARK_PROCESS_HPP_
+#define TEST_TRACETOOLS__MARK_PROCESS_HPP_
+
+#include <string>
+
+namespace test_tracetools
+{
+
+/// Mark process to link it to a trace test.
+/**
+ * This should be called once by each test application (process) to mark the process so that it can
+ * be linked to the trace test that spawned it.
+ *
+ * The process responsible for spawning the current process is responsible for setting the
+ * `TRACETOOLS_TEST_TRACE_TEST_ID` environment variable to a unique value.
+ *
+ * If the `TRACETOOLS_TEST_TRACE_TEST_ID` environment variable is set and not empty, this marks the
+ * current process by triggering an `lttng_ust_tracef:event` trace event with a `msg` field value
+ * equal to: `"TRACETOOLS_TEST_TRACE_TEST_ID=<value of TRACETOOLS_TEST_TRACE_TEST_ID>"`.
+ *
+ * \see tracetools_test
+ */
+void mark_trace_test_process();
+
+}  // namespace test_tracetools
+
+#endif  // TEST_TRACETOOLS__MARK_PROCESS_HPP_

--- a/test_tracetools/package.xml
+++ b/test_tracetools/package.xml
@@ -20,9 +20,11 @@
        the dependencies that those packages use so that colcon properly sets up the
        environment when running those tests.
   -->
+  <build_export_depend>liblttng-ust-dev</build_export_depend>
   <build_export_depend>lifecycle_msgs</build_export_depend>
   <build_export_depend>rclcpp</build_export_depend>
   <build_export_depend>rclcpp_lifecycle</build_export_depend>
+  <build_export_depend>rcpputils</build_export_depend>
   <build_export_depend>std_msgs</build_export_depend>
   <build_export_depend>std_srvs</build_export_depend>
 
@@ -31,11 +33,13 @@
   <test_depend>ament_cmake_pytest</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
+  <test_depend>liblttng-ust-dev</test_depend>
   <test_depend>lifecycle_msgs</test_depend>
   <test_depend>python3-pytest</test_depend>
   <test_depend>python3-pytest-cov</test_depend>
   <test_depend>rclcpp</test_depend>
   <test_depend>rclcpp_lifecycle</test_depend>
+  <test_depend>rcpputils</test_depend>
   <test_depend>std_msgs</test_depend>
   <test_depend>std_srvs</test_depend>
   <test_depend>tracetools</test_depend>

--- a/test_tracetools/src/mark_process.cpp
+++ b/test_tracetools/src/mark_process.cpp
@@ -1,0 +1,48 @@
+// Copyright 2024 Apex.AI, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef TRACETOOLS_DISABLED
+#include <lttng/tracef.h>
+
+#include "rcpputils/env.hpp"
+#endif  // TRACETOOLS_DISABLED
+
+#include "test_tracetools/mark_process.hpp"
+
+namespace test_tracetools
+{
+
+namespace
+{
+
+/**
+ * \see tracetools_test
+ */
+constexpr std::string_view trace_test_id_env_var = "TRACETOOLS_TEST_TRACE_TEST_ID";
+
+}  // namespace
+
+void mark_trace_test_process()
+{
+#ifndef TRACETOOLS_DISABLED
+  // See tracetools_test.mark_process for more details
+  const std::string env_var{trace_test_id_env_var};
+  const auto test_id = rcpputils::get_env_var(env_var.c_str());
+  if (!test_id.empty()) {
+    lttng_ust__tracef("%s=%s", env_var.c_str(), test_id.c_str());
+  }
+#endif  // TRACETOOLS_DISABLED
+}
+
+}  // namespace test_tracetools

--- a/test_tracetools/src/test_intra.cpp
+++ b/test_tracetools/src/test_intra.cpp
@@ -16,6 +16,7 @@
 
 #include "rclcpp/rclcpp.hpp"
 #include "std_msgs/msg/string.hpp"
+#include "test_tracetools/mark_process.hpp"
 
 using namespace std::chrono_literals;
 
@@ -73,6 +74,8 @@ private:
 
 int main(int argc, char * argv[])
 {
+  test_tracetools::mark_trace_test_process();
+
   rclcpp::init(argc, argv);
 
   rclcpp::executors::SingleThreadedExecutor exec;

--- a/test_tracetools/src/test_lifecycle_client.cpp
+++ b/test_tracetools/src/test_lifecycle_client.cpp
@@ -25,6 +25,7 @@
 #include "lifecycle_msgs/srv/get_state.hpp"
 #include "rclcpp/rclcpp.hpp"
 #include "rcutils/logging_macros.h"
+#include "test_tracetools/mark_process.hpp"
 
 using namespace std::chrono_literals;
 
@@ -256,6 +257,8 @@ void cycle_through_states(std::shared_ptr<LifecycleNodeClient> client_node)
 
 int main(int argc, char ** argv)
 {
+  test_tracetools::mark_trace_test_process();
+
   rclcpp::init(argc, argv);
 
   rclcpp::executors::SingleThreadedExecutor exec;

--- a/test_tracetools/src/test_lifecycle_node.cpp
+++ b/test_tracetools/src/test_lifecycle_node.cpp
@@ -16,6 +16,7 @@
 
 #include "rclcpp/rclcpp.hpp"
 #include "rclcpp_lifecycle/lifecycle_node.hpp"
+#include "test_tracetools/mark_process.hpp"
 
 class LifecycleNode : public rclcpp_lifecycle::LifecycleNode
 {
@@ -66,6 +67,8 @@ public:
 
 int main(int argc, char ** argv)
 {
+  test_tracetools::mark_trace_test_process();
+
   rclcpp::init(argc, argv);
 
   rclcpp::executors::SingleThreadedExecutor exec;

--- a/test_tracetools/src/test_ping.cpp
+++ b/test_tracetools/src/test_ping.cpp
@@ -17,6 +17,7 @@
 
 #include "rclcpp/rclcpp.hpp"
 #include "std_msgs/msg/string.hpp"
+#include "test_tracetools/mark_process.hpp"
 
 using namespace std::chrono_literals;
 
@@ -70,6 +71,8 @@ private:
 
 int main(int argc, char * argv[])
 {
+  test_tracetools::mark_trace_test_process();
+
   bool do_only_one = true;
   for (int i = 0; i < argc; ++i) {
     if (strncmp(argv[i], "do_more", 7) == 0) {

--- a/test_tracetools/src/test_pong.cpp
+++ b/test_tracetools/src/test_pong.cpp
@@ -16,6 +16,7 @@
 
 #include "rclcpp/rclcpp.hpp"
 #include "std_msgs/msg/string.hpp"
+#include "test_tracetools/mark_process.hpp"
 
 #define NODE_NAME "test_pong"
 #define SUB_TOPIC_NAME "ping"
@@ -58,6 +59,8 @@ private:
 
 int main(int argc, char * argv[])
 {
+  test_tracetools::mark_trace_test_process();
+
   bool do_only_one = true;
   for (int i = 0; i < argc; ++i) {
     if (strncmp(argv[i], "do_more", 7) == 0) {

--- a/test_tracetools/src/test_publisher.cpp
+++ b/test_tracetools/src/test_publisher.cpp
@@ -17,6 +17,7 @@
 
 #include "rclcpp/rclcpp.hpp"
 #include "std_msgs/msg/string.hpp"
+#include "test_tracetools/mark_process.hpp"
 
 #define NODE_NAME "test_publisher"
 #define TOPIC_NAME "the_topic"
@@ -43,6 +44,8 @@ private:
 
 int main(int argc, char * argv[])
 {
+  test_tracetools::mark_trace_test_process();
+
   rclcpp::init(argc, argv);
 
   rclcpp::executors::SingleThreadedExecutor exec;

--- a/test_tracetools/src/test_service.cpp
+++ b/test_tracetools/src/test_service.cpp
@@ -16,6 +16,7 @@
 
 #include "rclcpp/rclcpp.hpp"
 #include "std_srvs/srv/empty.hpp"
+#include "test_tracetools/mark_process.hpp"
 
 #define NODE_NAME "test_service"
 #define SERVICE_NAME "the_service"
@@ -53,6 +54,8 @@ private:
 
 int main(int argc, char * argv[])
 {
+  test_tracetools::mark_trace_test_process();
+
   rclcpp::init(argc, argv);
 
   rclcpp::executors::SingleThreadedExecutor exec;

--- a/test_tracetools/src/test_service_ping.cpp
+++ b/test_tracetools/src/test_service_ping.cpp
@@ -17,6 +17,7 @@
 
 #include "rclcpp/rclcpp.hpp"
 #include "std_srvs/srv/empty.hpp"
+#include "test_tracetools/mark_process.hpp"
 
 using namespace std::chrono_literals;
 
@@ -71,6 +72,8 @@ private:
 
 int main(int argc, char * argv[])
 {
+  test_tracetools::mark_trace_test_process();
+
   rclcpp::init(argc, argv);
 
   rclcpp::executors::SingleThreadedExecutor exec;

--- a/test_tracetools/src/test_service_pong.cpp
+++ b/test_tracetools/src/test_service_pong.cpp
@@ -16,6 +16,7 @@
 
 #include "rclcpp/rclcpp.hpp"
 #include "std_srvs/srv/empty.hpp"
+#include "test_tracetools/mark_process.hpp"
 
 #define NODE_NAME "test_service_pong"
 #define SERVICE_NAME "ping"
@@ -59,6 +60,8 @@ private:
 
 int main(int argc, char * argv[])
 {
+  test_tracetools::mark_trace_test_process();
+
   rclcpp::init(argc, argv);
 
   rclcpp::executors::SingleThreadedExecutor exec;

--- a/test_tracetools/src/test_timer.cpp
+++ b/test_tracetools/src/test_timer.cpp
@@ -16,6 +16,7 @@
 #include <chrono>
 
 #include "rclcpp/rclcpp.hpp"
+#include "test_tracetools/mark_process.hpp"
 
 using namespace std::chrono_literals;
 
@@ -50,6 +51,8 @@ private:
 
 int main(int argc, char * argv[])
 {
+  test_tracetools::mark_trace_test_process();
+
   rclcpp::init(argc, argv);
 
   rclcpp::executors::SingleThreadedExecutor exec;

--- a/tracetools_read/tracetools_read/__init__.py
+++ b/tracetools_read/tracetools_read/__init__.py
@@ -16,6 +16,7 @@
 
 from typing import Any
 from typing import Dict
+from typing import List
 
 
 DictEvent = Dict[str, Any]
@@ -54,5 +55,41 @@ def get_event_timestamp(event: DictEvent) -> int:
     return event['_timestamp']
 
 
+def get_event_pid(event: DictEvent) -> int:
+    return event['vpid']
+
+
 def get_procname(event: DictEvent) -> str:
     return event['procname']
+
+
+def get_events_with_name(
+    event_name: str,
+    events: List[DictEvent],
+) -> List[DictEvent]:
+    """
+    Get all events with the given name.
+
+    :param event_name: the event name
+    :param events: the events to check
+    :return: the list of events with the given name
+    """
+    return [e for e in events if get_event_name(e) == event_name]
+
+
+def get_events_with_field_value(
+    field_name: str,
+    field_values: Any,
+    events: List[DictEvent],
+) -> List[DictEvent]:
+    """
+    Get all events with the given field:value.
+
+    :param field_name: the name of the field to check
+    :param field_values: the value(s) of the field to check
+    :param events: the events to check
+    :return: the events with the given field:value pair
+    """
+    if not isinstance(field_values, (list, set)):
+        field_values = [field_values]
+    return [e for e in events if get_field(e, field_name, None) in field_values]

--- a/tracetools_test/tracetools_test/mark_process.py
+++ b/tracetools_test/tracetools_test/mark_process.py
@@ -1,0 +1,77 @@
+# Copyright 2024 Apex.AI, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+from typing import List
+
+from tracetools_read import DictEvent
+from tracetools_read import get_event_pid
+from tracetools_read import get_events_with_field_value
+from tracetools_read import get_events_with_name
+from tracetools_read import get_field
+
+
+# Name of environment variable used by a trace test to communicate its trace test ID
+TRACE_TEST_ID_ENV_VAR = 'TRACETOOLS_TEST_TRACE_TEST_ID'
+# Name of trace event used to register a trace test ID for a given process
+TRACE_TEST_ID_TP_NAME = 'lttng_ust_tracef:event'
+# Field name of trace event used to register a trace test ID for a given process
+TRACE_TEST_ID_TP_FIELD_NAME = 'msg'
+
+
+def get_trace_test_id(id_prefix: str) -> str:
+    """
+    Get a trace test ID value for this test.
+
+    The environment for the processes spawned by the current test (e.g., test application process)
+    should include the environment variable with name `$TRACE_TEST_ID_ENV_VAR` and with this value.
+
+    The string ID prefix should uniquely-enough represent the test.
+
+    :param id_prefix: a string ID prefix
+    :return: trace test ID for this test
+    """
+    # Append the current PID to make the ID unique
+    return f'{id_prefix}#{os.getpid()}'
+
+
+def _get_trace_test_id_event_value(trace_test_id: str) -> str:
+    """
+    Get value for trace test ID event field (`$TRACE_TEST_ID_TP_NAME`).
+
+    :param trace_test_id: the trace test ID
+    :return: the trace test ID marker event field value
+    """
+    return f'{TRACE_TEST_ID_ENV_VAR}={trace_test_id}'
+
+
+def get_corresponding_trace_test_events(
+    events: List[DictEvent],
+    trace_test_id: str,
+) -> List[DictEvent]:
+    """
+    Get trace events corresponding to the current trace test.
+
+    :param events: all of the trace events
+    :param trace_test_id: the trace test ID
+    :return: the relevant trace events corresponding to the given test
+    """
+    expected_event_msg = _get_trace_test_id_event_value(trace_test_id)
+    events_id = get_events_with_name(TRACE_TEST_ID_TP_NAME, events)
+    pids = {
+        get_event_pid(event_id)
+        for event_id in events_id
+        if get_field(event_id, TRACE_TEST_ID_TP_FIELD_NAME) == expected_event_msg
+    }
+    return get_events_with_field_value('vpid', pids, events)

--- a/tracetools_test/tracetools_test/utils.py
+++ b/tracetools_test/tracetools_test/utils.py
@@ -74,6 +74,8 @@ def run_and_trace(
             executable=node_name,
             namespace=namespace,
             output='screen',
+            # Explicitly request to use the current environment
+            env=None,
         )
         launch_actions.append(n)
     launch_actions.extend(additional_actions)


### PR DESCRIPTION
Resolves #94

This allows tracing tests to be run in parallel with (a) other tracing tests (e.g., from another package) and (b) normal tests (e.g., any ROS 2 tests). It achieves that by doing two things in two separate commits:

1. Only consider test trace data corresponding to the current test
    1. If we configure tracing in a tracing test and other tests (and therefore "ROS 2 applications") run in parallel, we will collect trace data from all running applications and end up with irrelevant data. #94 provides an overview of the possible solutions along with pros and cons. The chosen (and most robust) solution is:
        1. The tracing test passes a trace test ID to the test application processes it spawns through an environment variable
            1. The trace test ID contains the tracing test's PID and the test name (for easy identification)
        2. The test application processes spawned by the test (all in `test_tracetools`) retrieve that trace test ID from the environment and mark their process by triggering an `lttng_ust_tracef:event` event with that trace test ID in its payload, which will link the trace test ID to that process ID, since the trace event includes the PID
            1. `lttng_ust_tracef:event` was chosen because it is simple and doesn't require defining a new tracepoint; it simply collects a string `msg` value, see the [lttng_ust_tracef API](https://lttng.org/docs/v2.13/#doc-tracef)
        3. The tracing test reads those `lttng_ust_tracef:event` events, collects the PIDs of the events matching its test ID, and filters out trace data from all other processes, leaving only relevant trace data
    1. This only concerns `test_tracetools` and `test_ros2trace`
2. Allow having existing tracing sessions during tracing tests
    1. Now that having multiple tests (in this case multiple tracing tests) run in parallel is possible, we don't have to expect to have only one tracing session at any given time
        1. Since we don't check that _no_ tracing session exists before and after each test, I modified the tests to check that they do not leave their tracing sessions behind
    2. This only concerns `test_ros2trace`