### PR TITLE
Fix interference between test_tracetools and ros2lifecycle tests

### DIFF
--- a/tracetools_test/tracetools_test/case.py
+++ b/tracetools_test/tracetools_test/case.py
@@ -63,6 +63,7 @@ class TraceTestCase(unittest.TestCase):
         base_path: str = '/tmp',
         events_kernel: List[str] = [],
         additional_actions: Optional[List[Action]] = None,
+        namespace: Optional[str] = None,
     ) -> None:
         """Create a TraceTestCase."""
         super().__init__(methodName=args[0])
@@ -73,6 +74,7 @@ class TraceTestCase(unittest.TestCase):
         self._package = package
         self._nodes = nodes
         self._additional_actions = additional_actions or []
+        self._namespace = namespace
 
     def setUp(self):
         # Get timestamp before trace (ns)
@@ -85,6 +87,7 @@ class TraceTestCase(unittest.TestCase):
             self._events_kernel,
             self._package,
             self._nodes,
+            self._namespace,
             self._additional_actions,
         )
 

--- a/tracetools_test/tracetools_test/utils.py
+++ b/tracetools_test/tracetools_test/utils.py
@@ -17,6 +17,7 @@
 import os
 import shutil
 from typing import List
+from typing import Optional
 from typing import Tuple
 
 from launch import Action
@@ -36,6 +37,7 @@ def run_and_trace(
     kernel_events: List[str],
     package_name: str,
     node_names: List[str],
+    namespace: Optional[str],
     additional_actions: List[Action],
 ) -> Tuple[int, str]:
     """
@@ -47,6 +49,7 @@ def run_and_trace(
     :param kernel_events: the list of kernel events to enable
     :param package_name: the name of the package to use
     :param node_names: the names of the nodes to execute
+    :param namespace: the ROS namespace for the node(s)
     :param additional_actions: the list of additional actions to append
     :return: exit code, full generated path
     """
@@ -69,6 +72,7 @@ def run_and_trace(
         n = Node(
             package=package_name,
             executable=node_name,
+            namespace=namespace,
             output='screen',
         )
         launch_actions.append(n)


### PR DESCRIPTION
Part of #94

Relates to #95, but is still separate

`test_tracetools`'s `test_lifecycle_node` test and [`ros2lifecycle`'s `test_cli` test](https://github.com/ros2/ros2cli/blob/64d216cb8fafef83d046b79ee6294afb06b7c595/ros2lifecycle/test/test_cli.py) can interfere with each other if run in parallel, making one of them -- or both of them -- fail. For example, `test_tracetools` fails in this nightly job here: https://ci.ros2.org/view/nightly/job/nightly_linux_debug/2988/.

This is mainly because both tests use a lifecycle node with the same name and without any specific namespace:

1. `test_tracetools`'s `test_lifecycle_node` test uses [`test_lifecycle_node`](https://github.com/ros2/ros2_tracing/blob/9a807801f3608f937a3725dc6723a9ac417d670c/test_tracetools/src/test_lifecycle_node.cpp)
2. `ros2lifecycle`'s `test_cli` test [uses](https://github.com/ros2/ros2cli/blob/64d216cb8fafef83d046b79ee6294afb06b7c595/ros2lifecycle/test/test_cli.py#L138-L140) `ros2lifecycle_test_fixtures`'s [`simple_lifecycle_node`, which is named `test_lifecycle_node`](https://github.com/ros2/ros2cli/blob/64d216cb8fafef83d046b79ee6294afb06b7c595/ros2lifecycle_test_fixtures/src/simple_lifecycle_node.cpp#L87)

This can lead to two separate failures:

1. Since the lifecycle nodes have the same name, without any specific namespace, the tests can end up triggering transitions for the wrong lifecycle node
    * I think this sometimes results in `test_tracetools`'s `test_lifecycle_node` test timing out because the state machine ends up in a weird state (not sure why the timeouts in `test_lifecycle_node.cpp` don't make it exit before the 60-second timeout, though)
2. The trace that `test_tracetools`'s `test_lifecycle_node` test collects can include transitions from `ros2lifecycle`

The two separate solutions are:

1. Use a namespace (`/test_tracetools`) for the node in `test_tracetools`'s `test_lifecycle_node` test to avoid transition/topic-level interference
2. Make sure to only consider transition trace events for the right state machine instead of assuming that all transitions in the trace come from the expected state machine and _then_ checking if they correspond to the expected state machine
    * This would also be fixed by #95 even though they are different changes, but this change doesn't really hurt