### PR TITLE
Fix the build on RHEL-9.

### DIFF
--- a/test_tracetools/src/mark_process.cpp
+++ b/test_tracetools/src/mark_process.cpp
@@ -14,6 +14,7 @@
 
 #ifndef TRACETOOLS_DISABLED
 #include <lttng/tracef.h>
+#include <lttng/ust-version.h>
 
 #include "rcpputils/env.hpp"
 #endif  // TRACETOOLS_DISABLED
@@ -40,7 +41,11 @@ void mark_trace_test_process()
   const std::string env_var{trace_test_id_env_var};
   const auto test_id = rcpputils::get_env_var(env_var.c_str());
   if (!test_id.empty()) {
+#if LTTNG_UST_MINOR_VERSION == 12
+    _lttng_ust_tracef("%s=%s", env_var.c_str(), test_id.c_str());
+#else
     lttng_ust__tracef("%s=%s", env_var.c_str(), test_id.c_str());
+#endif
   }
 #endif  // TRACETOOLS_DISABLED
 }

--- a/test_tracetools/src/mark_process.cpp
+++ b/test_tracetools/src/mark_process.cpp
@@ -41,7 +41,7 @@ void mark_trace_test_process()
   const std::string env_var{trace_test_id_env_var};
   const auto test_id = rcpputils::get_env_var(env_var.c_str());
   if (!test_id.empty()) {
-#if LTTNG_UST_MINOR_VERSION == 12
+#if LTTNG_UST_MINOR_VERSION <= 12
     _lttng_ust_tracef("%s=%s", env_var.c_str(), test_id.c_str());
 #else
     lttng_ust__tracef("%s=%s", env_var.c_str(), test_id.c_str());


### PR DESCRIPTION
It turns out that in the older version of lttng-ust on RHEL-9, the API to set a marker is spelled _lttng_ust_tracef.  Include the correct version header file, and use the correct API called depending on what version we are using.

This is a follow-up to the recently merged #96 , where I forgot to run RHEL CI before merging.