### PR TITLE
Use a memcmp for the expected symbol name.

### DIFF
--- a/test_tracetools/test/test_utils.cpp
+++ b/test_tracetools/test/test_utils.cpp
@@ -84,10 +84,9 @@ TEST(TestUtils, valid_symbol_lambda_capture) {
 
   auto m = [&](int other_num) {return num + other_num;};
   symbol = tracetools::get_symbol(m);
-  EXPECT_STREQ(
-    symbol,
-    "TestUtils_valid_symbol_lambda_capture_Test::TestBody()::{lambda(int)#2}") <<
-    "invalid symbol";
+  const std::string expected_symbol_name =
+    "TestUtils_valid_symbol_lambda_capture_Test::TestBody()::{lambda(int)#";
+  EXPECT_EQ(memcmp(symbol, expected_symbol_name.c_str(), expected_symbol_name.length()), 0);
   std::free(symbol);
 }
 

--- a/test_tracetools/test/test_utils.cpp
+++ b/test_tracetools/test/test_utils.cpp
@@ -84,6 +84,12 @@ TEST(TestUtils, valid_symbol_lambda_capture) {
 
   auto m = [&](int other_num) {return num + other_num;};
   symbol = tracetools::get_symbol(m);
+
+  // g++ does not guarantee symbol names.  Thus in g++ 11.4.0, the symbol for the
+  // lambda above is "TestUtils_valid_symbol_lambda_capture_Test::TestBody()::{lambda(int)#2}"
+  // while in g++ 13.2.0 the symbol for the lambda is
+  // "TestUtils_valid_symbol_lambda_capture_Test::TestBody()::{lambda(int)#1}"
+  // We only check the first part of the string so we can handle either.
   const std::string expected_symbol_name =
     "TestUtils_valid_symbol_lambda_capture_Test::TestBody()::{lambda(int)#";
   EXPECT_EQ(memcmp(symbol, expected_symbol_name.c_str(), expected_symbol_name.length()), 0);


### PR DESCRIPTION
I believe that g++ does not guarantee what a particular symbol name will be.  Thus, in g++ 11.4.0 (what is in Ubuntu 22.04), the symbol name here ended with "#2", while in g++ 13.2.0 (what is in Ubuntu 24.04), the symbol name ends with "#1".  Given that we can't guarantee this, just search for the first part of the name up to the number, which should be good enough for this test.