### PR TITLE
Use lttng_ust_tracef instead of lttng_ust__tracef

### DIFF
--- a/test_tracetools/src/mark_process.cpp
+++ b/test_tracetools/src/mark_process.cpp
@@ -42,9 +42,9 @@ void mark_trace_test_process()
   const auto test_id = rcpputils::get_env_var(env_var.c_str());
   if (!test_id.empty()) {
 #if LTTNG_UST_MINOR_VERSION <= 12
-    _lttng_ust_tracef("%s=%s", env_var.c_str(), test_id.c_str());
+    tracef("%s=%s", env_var.c_str(), test_id.c_str());
 #else
-    lttng_ust__tracef("%s=%s", env_var.c_str(), test_id.c_str());
+    lttng_ust_tracef("%s=%s", env_var.c_str(), test_id.c_str());
 #endif
   }
 #endif  // TRACETOOLS_DISABLED


### PR DESCRIPTION
Follow-up to #95
Follow-up to #98

The "official" symbol that the LTTng documentation mentions is:

1. \>=2.13: `lttng_ust_tracef()`, not `lttng_ust__tracef()`
    1. Docs: https://lttng.org/docs/v2.13/#doc-tracef
    2. Code: https://github.com/lttng/lttng-ust/blob/2e8e974039487cb8b2b22dc01ffdd6c9931ec02b/include/lttng/tracef.h#L23
2. <=2.12: `tracef()`, not `_lttng_ust_tracef()`
    1. Docs: https://lttng.org/docs/v2.12/#doc-tracef
    2. Code: https://github.com/lttng/lttng-ust/blob/6b0c6b76480d8162cb00919367cc2d13ccbe7037/include/lttng/tracef.h#L35

I thought that the difference between them is that the former checks if the tracepoint is enabled before triggering the tracepoint, while the latter just triggers it, but that is not the case. We can observe this by not enabling `lttng_ust_tracef:event` in `tracetools_test/case.py`: the tracepoint does not get triggered. The latter still ends up checking if the tracepoint is enabled before triggering it. The difference is that the latter formats the string using `vasprintf()` and _then_ tries to trigger the tracepoint, which may or may not trigger depending on whether it is enabled or not: https://github.com/lttng/lttng-ust/blob/9261aeadea4674c3d68e05c2e8fcbcefa54feb56/src/lib/lttng-ust/tracef.c#L46. Therefore, the former avoids formatting the string if the tracepoint is not enabled.

Anyway, all of this is to say that we should just use `lttng_ust_tracef()`/`tracef()` even though it's just a test.

This should be tested on RHEL because it uses LTTng <=2.12.