### PR TITLE
Use Ubuntu 24.04 Noble for GitHub CI

### DIFF
--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -8,7 +8,9 @@ on:
     - cron: "0 5 * * *"
 jobs:
   binary:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
+    container:
+      image: ubuntu:24.04
     continue-on-error: true
     strategy:
       fail-fast: false
@@ -51,7 +53,9 @@ jobs:
         source install/setup.bash
         (! ros2 run tracetools status)
   source:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
+    container:
+      image: ubuntu:24.04
     continue-on-error: true
     strategy:
       fail-fast: false

--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -6,6 +6,9 @@ on:
       - rolling
   schedule:
     - cron: "0 5 * * *"
+defaults:
+  run:
+    shell: bash
 jobs:
   binary:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,9 @@ on:
       - rolling
   schedule:
     - cron: "0 5 * * *"
+defaults:
+  run:
+    shell: bash
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,32 +8,34 @@ on:
     - cron: "0 5 * * *"
 jobs:
   test:
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
+    container:
+      image: ${{ matrix.os }}
     continue-on-error: ${{ matrix.build-type == 'binary' }}
     strategy:
       fail-fast: false
       matrix:
         include:
           # Normal build (binary)
-          - os: ubuntu-22.04
+          - os: ubuntu:24.04
             distro: rolling
             build-type: binary
             instrumentation: instr-enabled
             tracepoints: tp-included
           # Normal build (source)
-          - os: ubuntu-22.04
+          - os: ubuntu:24.04
             distro: rolling
             build-type: source
             instrumentation: instr-enabled
             tracepoints: tp-included
           # Build with instrumentation disabled
-          - os: ubuntu-22.04
+          - os: ubuntu:24.04
             distro: rolling
             build-type: source
             instrumentation: instr-disabled
             tracepoints: tp-included
           # Normal build with tracepoints excluded
-          - os: ubuntu-22.04
+          - os: ubuntu:24.04
             distro: rolling
             build-type: source
             instrumentation: instr-enabled


### PR DESCRIPTION
* The `ubuntu-24.04` GitHub actions runner might not be available until August 2024 (https://github.com/actions/runner-images/issues/9691), so just use Docker
* We seem to now need to explicitly set the default shell to bash to get `source` to work (possibly due to running in Docker and not the runner itself)