### PR TITLE
Remove unnecessary print in test

### DIFF
--- a/test_tracetools/test/test_intra.py
+++ b/test_tracetools/test/test_intra.py
@@ -41,8 +41,6 @@ class TestIntra(TraceTestCase):
         # Check events as set
         self.assertEventsSet(self._events_ros)
 
-        print('EVENTS: ', self._events)
-
         # Check rcl_subscription_init events
         rcl_sub_init_events = self.get_events_with_name(tp.rcl_subscription_init)
         rcl_sub_init_topic_events = self.get_events_with_field_value(


### PR DESCRIPTION
I think this was left over from when I first wrote the test.