### PR TITLE
Improve tracetools_test and simplify test_tracetools code

### DIFF
--- a/test_tracetools/test/test_buffer.py
+++ b/test_tracetools/test/test_buffer.py
@@ -56,23 +56,22 @@ class TestBuffer(TraceTestCase):
         # Check corresponding events for construct_buffer_event
         for construct_event in construct_buffer_events:
             target_buffer = self.get_field(construct_event, 'buffer')
-            target_buffer_to_ipb_event = self.get_events_with_field_value(
+            # Only 1 for our given buffer
+            target_buffer_to_ipb_event = self.get_event_with_field_value_and_assert(
                 'buffer',
                 target_buffer,
                 buffer_to_ipb_events,
+                allow_multiple=False,
             )
-            # Only 1 for our given buffer
-            self.assertNumEventsEqual(target_buffer_to_ipb_event, 1)
 
-            target_ipb = self.get_field(target_buffer_to_ipb_event[0], 'ipb')
-            target_ipb_to_subscription_event = self.get_events_with_field_value(
+            target_ipb = self.get_field(target_buffer_to_ipb_event, 'ipb')
+            # Only 1 for our given ipb
+            target_ipb_to_subscription_event = self.get_event_with_field_value_and_assert(
                 'ipb',
                 target_ipb,
                 ipb_to_subscription_events,
+                allow_multiple=False,
             )
-
-            # Only 1 for our given ipb
-            self.assertNumEventsEqual(target_ipb_to_subscription_event, 1)
 
             # Check subscription init order
             #   * rclcpp_construct_ring_buffer
@@ -80,8 +79,8 @@ class TestBuffer(TraceTestCase):
             #   * rclcpp_ipb_to_subscription
             self.assertEventOrder([
                 construct_event,
-                target_buffer_to_ipb_event[0],
-                target_ipb_to_subscription_event[0],
+                target_buffer_to_ipb_event,
+                target_ipb_to_subscription_event,
             ])
 
 

--- a/test_tracetools/test/test_buffer.py
+++ b/test_tracetools/test/test_buffer.py
@@ -56,7 +56,6 @@ class TestBuffer(TraceTestCase):
         # Check corresponding events for construct_buffer_event
         for construct_event in construct_buffer_events:
             target_buffer = self.get_field(construct_event, 'buffer')
-            # Only 1 for our given buffer
             target_buffer_to_ipb_event = self.get_event_with_field_value_and_assert(
                 'buffer',
                 target_buffer,
@@ -65,7 +64,6 @@ class TestBuffer(TraceTestCase):
             )
 
             target_ipb = self.get_field(target_buffer_to_ipb_event, 'ipb')
-            # Only 1 for our given ipb
             target_ipb_to_subscription_event = self.get_event_with_field_value_and_assert(
                 'ipb',
                 target_ipb,

--- a/test_tracetools/test/test_generic_pub_sub.py
+++ b/test_tracetools/test/test_generic_pub_sub.py
@@ -53,40 +53,36 @@ class TestGenericPubSub(TraceTestCase):
         rmw_pub_init_events = self.get_events_with_name(tp.rmw_publisher_init)
         rmw_sub_init_events = self.get_events_with_name(tp.rmw_subscription_init)
         publisher_init_events = self.get_events_with_name(tp.rcl_publisher_init)
-        ping_publisher_init_events = self.get_events_with_field_value(
+        ping_publisher_init_event = self.get_event_with_field_value_and_assert(
             'topic_name',
             '/ping',
             publisher_init_events,
+            allow_multiple=False,
         )
-        pong_publisher_init_events = self.get_events_with_field_value(
+        pong_publisher_init_event = self.get_event_with_field_value_and_assert(
             'topic_name',
             '/pong',
             publisher_init_events,
+            allow_multiple=False,
         )
-        self.assertNumEventsEqual(ping_publisher_init_events, 1)
-        self.assertNumEventsEqual(pong_publisher_init_events, 1)
-        ping_publisher_init_event = ping_publisher_init_events[0]
-        pong_publisher_init_event = pong_publisher_init_events[0]
         ping_pub_handle = self.get_field(ping_publisher_init_event, 'publisher_handle')
         ping_rmw_pub_handle = self.get_field(ping_publisher_init_event, 'rmw_publisher_handle')
         pong_pub_handle = self.get_field(pong_publisher_init_event, 'publisher_handle')
         pong_rmw_pub_handle = self.get_field(pong_publisher_init_event, 'rmw_publisher_handle')
 
         # Find corresponding rmw_pub_init events
-        ping_rmw_pub_init_events = self.get_events_with_field_value(
+        ping_rmw_pub_init_event = self.get_event_with_field_value_and_assert(
             'rmw_publisher_handle',
             ping_rmw_pub_handle,
             rmw_pub_init_events,
+            allow_multiple=False,
         )
-        pong_rmw_pub_init_events = self.get_events_with_field_value(
+        pong_rmw_pub_init_event = self.get_event_with_field_value_and_assert(
             'rmw_publisher_handle',
             pong_rmw_pub_handle,
             rmw_pub_init_events,
+            allow_multiple=False,
         )
-        self.assertNumEventsEqual(ping_rmw_pub_init_events, 1)
-        self.assertNumEventsEqual(pong_rmw_pub_init_events, 1)
-        ping_rmw_pub_init_event = ping_rmw_pub_init_events[0]
-        pong_rmw_pub_init_event = pong_rmw_pub_init_events[0]
 
         # Check publisher init order (rmw then rcl)
         self.assertEventOrder([
@@ -100,72 +96,64 @@ class TestGenericPubSub(TraceTestCase):
 
         # Get corresponding rmw/rcl/rclcpp publish events for ping & pong
         rmw_publish_events = self.get_events_with_name(tp.rmw_publish)
-        ping_rmw_pub_events = self.get_events_with_field_value(
+        ping_rmw_pub_event = self.get_event_with_field_value_and_assert(
             'rmw_publisher_handle',
             ping_rmw_pub_handle,
             rmw_publish_events,
+            allow_multiple=False,
         )
-        pong_rmw_pub_events = self.get_events_with_field_value(
+        pong_rmw_pub_event = self.get_event_with_field_value_and_assert(
             'rmw_publisher_handle',
             pong_rmw_pub_handle,
             rmw_publish_events,
+            allow_multiple=False,
         )
-        self.assertNumEventsEqual(ping_rmw_pub_events, 1)
-        self.assertNumEventsEqual(pong_rmw_pub_events, 1)
-        ping_rmw_pub_event = ping_rmw_pub_events[0]
-        pong_rmw_pub_event = pong_rmw_pub_events[0]
         ping_pub_message = self.get_field(ping_rmw_pub_event, 'message')
         pong_pub_message = self.get_field(pong_rmw_pub_event, 'message')
 
         rclcpp_publish_events = self.get_events_with_name(tp.rclcpp_publish)
         rcl_publish_events = self.get_events_with_name(tp.rcl_publish)
-        ping_rclcpp_pub_events = self.get_events_with_field_value(
+        ping_rclcpp_pub_event = self.get_event_with_field_value_and_assert(
             'message',
             ping_pub_message,
             rclcpp_publish_events,
+            allow_multiple=False,
         )
-        pong_rclcpp_pub_events = self.get_events_with_field_value(
+        pong_rclcpp_pub_event = self.get_event_with_field_value_and_assert(
             'message',
             pong_pub_message,
             rclcpp_publish_events,
+            allow_multiple=False,
         )
-        ping_rcl_pub_events = self.get_events_with_field_value(
+        ping_rcl_pub_event = self.get_event_with_field_value_and_assert(
             'message',
             ping_pub_message,
             rcl_publish_events,
+            allow_multiple=False,
         )
-        pong_rcl_pub_events = self.get_events_with_field_value(
+        pong_rcl_pub_event = self.get_event_with_field_value_and_assert(
             'message',
             pong_pub_message,
             rcl_publish_events,
+            allow_multiple=False,
         )
-        self.assertNumEventsEqual(ping_rclcpp_pub_events, 1)
-        self.assertNumEventsEqual(pong_rclcpp_pub_events, 1)
-        self.assertNumEventsEqual(ping_rcl_pub_events, 1)
-        self.assertNumEventsEqual(pong_rcl_pub_events, 1)
-        ping_rclcpp_pub_event = ping_rclcpp_pub_events[0]
-        pong_rclcpp_pub_event = pong_rclcpp_pub_events[0]
-        ping_rcl_pub_event = ping_rcl_pub_events[0]
-        pong_rcl_pub_event = pong_rcl_pub_events[0]
         self.assertFieldEquals(ping_rcl_pub_event, 'publisher_handle', ping_pub_handle)
         self.assertFieldEquals(pong_rcl_pub_event, 'publisher_handle', pong_pub_handle)
 
         # Get subscription init events & subscription handles of test topics
         rcl_subscription_init_events = self.get_events_with_name(tp.rcl_subscription_init)
-        ping_rcl_subscription_init_events = self.get_events_with_field_value(
+        ping_rcl_subscription_init_event = self.get_event_with_field_value_and_assert(
             'topic_name',
             '/ping',
             rcl_subscription_init_events,
+            allow_multiple=False,
         )
-        pong_rcl_subscription_init_events = self.get_events_with_field_value(
+        pong_rcl_subscription_init_event = self.get_event_with_field_value_and_assert(
             'topic_name',
             '/pong',
             rcl_subscription_init_events,
+            allow_multiple=False,
         )
-        self.assertNumEventsEqual(ping_rcl_subscription_init_events, 1)
-        self.assertNumEventsEqual(pong_rcl_subscription_init_events, 1)
-        ping_rcl_subscription_init_event = ping_rcl_subscription_init_events[0]
-        pong_rcl_subscription_init_event = pong_rcl_subscription_init_events[0]
         ping_sub_handle = self.get_field(ping_rcl_subscription_init_event, 'subscription_handle')
         ping_rmw_sub_handle = \
             self.get_field(ping_rcl_subscription_init_event, 'rmw_subscription_handle')
@@ -174,39 +162,35 @@ class TestGenericPubSub(TraceTestCase):
             self.get_field(pong_rcl_subscription_init_event, 'rmw_subscription_handle')
 
         # Find corresponding rmw_sub_init events
-        ping_rmw_sub_init_events = self.get_events_with_field_value(
+        ping_rmw_sub_init_event = self.get_event_with_field_value_and_assert(
             'rmw_subscription_handle',
             ping_rmw_sub_handle,
             rmw_sub_init_events,
+            allow_multiple=False,
         )
-        pong_rmw_sub_init_events = self.get_events_with_field_value(
+        pong_rmw_sub_init_event = self.get_event_with_field_value_and_assert(
             'rmw_subscription_handle',
             pong_rmw_sub_handle,
             rmw_sub_init_events,
+            allow_multiple=False,
         )
-        self.assertNumEventsEqual(ping_rmw_sub_init_events, 1)
-        self.assertNumEventsEqual(pong_rmw_sub_init_events, 1)
-        ping_rmw_sub_init_event = ping_rmw_sub_init_events[0]
-        pong_rmw_sub_init_event = pong_rmw_sub_init_events[0]
 
         # Get corresponding subscription objects
         rclcpp_subscription_init_events = self.get_events_with_name(
             tp.rclcpp_subscription_init,
         )
-        ping_rclcpp_subscription_init_events = self.get_events_with_field_value(
+        ping_rclcpp_subscription_init_event = self.get_event_with_field_value_and_assert(
             'subscription_handle',
             ping_sub_handle,
             rclcpp_subscription_init_events,
+            allow_multiple=False,
         )
-        pong_rclcpp_subscription_init_events = self.get_events_with_field_value(
+        pong_rclcpp_subscription_init_event = self.get_event_with_field_value_and_assert(
             'subscription_handle',
             pong_sub_handle,
             rclcpp_subscription_init_events,
+            allow_multiple=False,
         )
-        self.assertNumEventsEqual(ping_rclcpp_subscription_init_events, 1)
-        self.assertNumEventsEqual(pong_rclcpp_subscription_init_events, 1)
-        ping_rclcpp_subscription_init_event = ping_rclcpp_subscription_init_events[0]
-        pong_rclcpp_subscription_init_event = pong_rclcpp_subscription_init_events[0]
         ping_sub_object = self.get_field(ping_rclcpp_subscription_init_event, 'subscription')
         pong_sub_object = self.get_field(pong_rclcpp_subscription_init_event, 'subscription')
 
@@ -214,39 +198,35 @@ class TestGenericPubSub(TraceTestCase):
         rclcpp_subscription_callback_events = self.get_events_with_name(
             tp.rclcpp_subscription_callback_added,
         )
-        ping_rclcpp_subscription_callback_events = self.get_events_with_field_value(
+        ping_rclcpp_subscription_callback_event = self.get_event_with_field_value_and_assert(
             'subscription',
             ping_sub_object,
             rclcpp_subscription_callback_events,
+            allow_multiple=False,
         )
-        pong_rclcpp_subscription_callback_events = self.get_events_with_field_value(
+        pong_rclcpp_subscription_callback_event = self.get_event_with_field_value_and_assert(
             'subscription',
             pong_sub_object,
             rclcpp_subscription_callback_events,
+            allow_multiple=False,
         )
-        self.assertNumEventsEqual(ping_rclcpp_subscription_callback_events, 1)
-        self.assertNumEventsEqual(pong_rclcpp_subscription_callback_events, 1)
-        ping_rclcpp_subscription_callback_event = ping_rclcpp_subscription_callback_events[0]
-        pong_rclcpp_subscription_callback_event = pong_rclcpp_subscription_callback_events[0]
         ping_callback_object = self.get_field(ping_rclcpp_subscription_callback_event, 'callback')
         pong_callback_object = self.get_field(pong_rclcpp_subscription_callback_event, 'callback')
 
         # Get rmw_take events
         rmw_take_events = self.get_events_with_name(tp.rmw_take)
-        pong_rmw_take_events = self.get_events_with_field_value(
+        pong_rmw_take_event = self.get_event_with_field_value_and_assert(
             'rmw_subscription_handle',
             pong_rmw_sub_handle,
             rmw_take_events,
+            allow_multiple=False,
         )
-        ping_rmw_take_events = self.get_events_with_field_value(
+        ping_rmw_take_event = self.get_event_with_field_value_and_assert(
             'rmw_subscription_handle',
             ping_rmw_sub_handle,
             rmw_take_events,
+            allow_multiple=False,
         )
-        self.assertNumEventsEqual(pong_rmw_take_events, 1)
-        self.assertNumEventsEqual(ping_rmw_take_events, 1)
-        pong_rmw_take_event = pong_rmw_take_events[0]
-        ping_rmw_take_event = ping_rmw_take_events[0]
 
         # Check that pub->sub timestamps match
         ping_timestamp = self.get_field(ping_rmw_pub_event, 'timestamp')
@@ -271,34 +251,30 @@ class TestGenericPubSub(TraceTestCase):
         # Get corresponding callback start/end events
         callback_start_events = self.get_events_with_name(tp.callback_start)
         callback_end_events = self.get_events_with_name(tp.callback_end)
-        ping_callback_start_events = self.get_events_with_field_value(
+        ping_callback_start_event = self.get_event_with_field_value_and_assert(
             'callback',
             ping_callback_object,
             callback_start_events,
+            allow_multiple=False,
         )
-        pong_callback_start_events = self.get_events_with_field_value(
+        pong_callback_start_event = self.get_event_with_field_value_and_assert(
             'callback',
             pong_callback_object,
             callback_start_events,
+            allow_multiple=False,
         )
-        ping_callback_end_events = self.get_events_with_field_value(
+        ping_callback_end_event = self.get_event_with_field_value_and_assert(
             'callback',
             ping_callback_object,
             callback_end_events,
+            allow_multiple=False,
         )
-        pong_callback_end_events = self.get_events_with_field_value(
+        pong_callback_end_event = self.get_event_with_field_value_and_assert(
             'callback',
             pong_callback_object,
             callback_end_events,
+            allow_multiple=False,
         )
-        self.assertNumEventsEqual(ping_callback_start_events, 1)
-        self.assertNumEventsEqual(pong_callback_start_events, 1)
-        self.assertNumEventsEqual(ping_callback_end_events, 1)
-        self.assertNumEventsEqual(pong_callback_end_events, 1)
-        ping_callback_start_event = ping_callback_start_events[0]
-        pong_callback_start_event = pong_callback_start_events[0]
-        ping_callback_end_event = ping_callback_end_events[0]
-        pong_callback_end_event = pong_callback_end_events[0]
 
         # Check pub/sub order:
         #   * /ping pub rclcpp_publish

--- a/test_tracetools/test/test_generic_subscription.py
+++ b/test_tracetools/test/test_generic_subscription.py
@@ -66,7 +66,7 @@ class TestGenericSubscription(TraceTestCase):
 
         for event in rmw_sub_init_events:
             self.assertValidHandle(event, ['rmw_subscription_handle'])
-            self.assertValidArray(event, 'gid', int)
+            self.assertValidStaticArray(event, 'gid', int, 24)
         for event in rcl_sub_init_events:
             self.assertValidHandle(
                 event,
@@ -105,13 +105,12 @@ class TestGenericSubscription(TraceTestCase):
 
         # Check that the pong test topic name exists
         # Note: using the ping node
-        test_rcl_sub_init_events = self.get_events_with_field_value(
+        test_rcl_sub_init_event = self.get_event_with_field_value_and_assert(
             'topic_name',
             '/pong',
             rcl_sub_init_events,
+            allow_multiple=False,
         )
-        self.assertNumEventsEqual(test_rcl_sub_init_events, 1, 'cannot find test topic name')
-        test_rcl_sub_init_event = test_rcl_sub_init_events[0]
 
         # Check queue_depth value
         self.assertFieldEquals(test_rcl_sub_init_event, 'queue_depth', 10)
@@ -133,34 +132,32 @@ class TestGenericSubscription(TraceTestCase):
 
         # Check that subscription handle matches between rcl_sub_init and rclcpp_sub_init
         subscription_handle = self.get_field(test_rcl_sub_init_event, 'subscription_handle')
-        rclcpp_sub_init_matching_events = self.get_events_with_field_value(
+        # Should only have 1 rclcpp_sub_init event, since intra-process is not enabled
+        rclcpp_sub_init_matching_event = self.get_event_with_field_value_and_assert(
             'subscription_handle',
             subscription_handle,
             rclcpp_sub_init_events,
+            allow_multiple=False,
         )
-        # Should only have 1 rclcpp_sub_init event, since intra-process is not enabled
-        self.assertNumEventsEqual(rclcpp_sub_init_matching_events, 1)
         # Check that the rmw subscription handle matches between rmw_sub_init and rcl_sub_init
         rmw_subscription_handle = self.get_field(
             test_rcl_sub_init_event, 'rmw_subscription_handle')
-        rmw_sub_init_events = self.get_events_with_field_value(
+        rmw_sub_init_event = self.get_event_with_field_value_and_assert(
             'rmw_subscription_handle',
             rmw_subscription_handle,
             rmw_sub_init_events,
+            allow_multiple=False,
         )
-        self.assertNumEventsEqual(rmw_sub_init_events, 1)
-        rmw_sub_init_event = rmw_sub_init_events[0]
 
         # Check that subscription pointer matches between rclcpp_sub_init and sub_callback_added
-        rclcpp_sub_init_matching_event = rclcpp_sub_init_matching_events[0]
         subscription_pointer = self.get_field(rclcpp_sub_init_matching_event, 'subscription')
-        callback_added_matching_events = self.get_events_with_field_value(
+        # There is only one callback for /pong topic in ping node
+        callback_added_matching_event = self.get_event_with_field_value_and_assert(
             'subscription',
             subscription_pointer,
             callback_added_events,
+            allow_multiple=False,
         )
-        self.assertNumEventsEqual(callback_added_matching_events, 1)
-        callback_added_matching_event = callback_added_matching_events[0]
 
         # Check that callback pointer matches between callback_added and callback_register
         callback_handle = self.get_field(callback_added_matching_event, 'callback')
@@ -168,13 +165,12 @@ class TestGenericSubscription(TraceTestCase):
             'test_generic_ping',
             callback_register_events,
         )
-        callback_register_matching_events = self.get_events_with_field_value(
+        callback_register_matching_event = self.get_event_with_field_value_and_assert(
             'callback',
             callback_handle,
             test_sub_node_callback_register_events,
+            allow_multiple=False,
         )
-        self.assertNumEventsEqual(callback_register_matching_events, 1)
-        callback_register_matching_event = callback_register_matching_events[0]
 
         # Check susbcription creation events order
         self.assertEventOrder([
@@ -186,36 +182,32 @@ class TestGenericSubscription(TraceTestCase):
         ])
 
         # Get executor_execute and *_take events, there should only be one message received
-        test_execute_events = self.get_events_with_field_value(
+        test_execute_event = self.get_event_with_field_value_and_assert(
             'handle',
             subscription_handle,
             execute_events,
+            allow_multiple=False,
         )
-        self.assertNumEventsEqual(test_execute_events, 1)
-        test_execute_event = test_execute_events[0]
-        test_rmw_take_events = self.get_events_with_field_value(
+        test_rmw_take_event = self.get_event_with_field_value_and_assert(
             'rmw_subscription_handle',
             rmw_subscription_handle,
             rmw_take_events,
+            allow_multiple=False,
         )
-        self.assertNumEventsEqual(test_execute_events, 1)
-        test_rmw_take_event = test_rmw_take_events[0]
         test_taken_msg = self.get_field(test_rmw_take_event, 'message')
         self.assertFieldEquals(test_rmw_take_event, 'taken', 1, 'test message not taken')
-        test_rcl_take_events = self.get_events_with_field_value(
+        test_rcl_take_event = self.get_event_with_field_value_and_assert(
             'message',
             test_taken_msg,
             rcl_take_events,
+            allow_multiple=False,
         )
-        self.assertNumEventsEqual(test_rcl_take_events, 1)
-        test_rcl_take_event = test_rcl_take_events[0]
-        test_rclcpp_take_events = self.get_events_with_field_value(
+        test_rclcpp_take_event = self.get_event_with_field_value_and_assert(
             'message',
             test_taken_msg,
             rclcpp_take_events,
+            allow_multiple=False,
         )
-        self.assertNumEventsEqual(test_rcl_take_events, 1)
-        test_rclcpp_take_event = test_rclcpp_take_events[0]
 
         # Check that each start:end pair has a common callback handle
         ping_events = self.get_events_with_procname('test_generic_ping')
@@ -238,24 +230,19 @@ class TestGenericSubscription(TraceTestCase):
             )
 
         # Check that callback pointer matches between sub_callback_added and callback_start/end
-        # There is only one callback for /pong topic in ping node
-        callback_added_matching_event = callback_added_matching_events[0]
-        callback_pointer = self.get_field(callback_added_matching_event, 'callback')
-        callback_start_matching_events = self.get_events_with_field_value(
+        callback_start_matching_event = self.get_event_with_field_value_and_assert(
             'callback',
-            callback_pointer,
+            callback_handle,
             ping_events_start,
+            allow_multiple=False,
         )
-        self.assertNumEventsEqual(callback_start_matching_events, 1)
-        callback_start_matching_event = callback_start_matching_events[0]
         ping_events_end = self.get_events_with_name(tp.callback_end, ping_events)
-        callback_end_matching_events = self.get_events_with_field_value(
+        callback_end_matching_event = self.get_event_with_field_value_and_assert(
             'callback',
-            callback_pointer,
+            callback_handle,
             ping_events_end,
+            allow_multiple=False,
         )
-        self.assertNumEventsEqual(callback_end_matching_events, 1)
-        callback_end_matching_event = callback_end_matching_events[0]
 
         # Check execute+take+callback order
         self.assertEventOrder([

--- a/test_tracetools/test/test_generic_subscription.py
+++ b/test_tracetools/test/test_generic_subscription.py
@@ -151,7 +151,6 @@ class TestGenericSubscription(TraceTestCase):
 
         # Check that subscription pointer matches between rclcpp_sub_init and sub_callback_added
         subscription_pointer = self.get_field(rclcpp_sub_init_matching_event, 'subscription')
-        # There is only one callback for /pong topic in ping node
         callback_added_matching_event = self.get_event_with_field_value_and_assert(
             'subscription',
             subscription_pointer,

--- a/test_tracetools/test/test_intra.py
+++ b/test_tracetools/test/test_intra.py
@@ -43,16 +43,15 @@ class TestIntra(TraceTestCase):
 
         # Check rcl_subscription_init events
         rcl_sub_init_events = self.get_events_with_name(tp.rcl_subscription_init)
-        rcl_sub_init_topic_events = self.get_events_with_field_value(
+        # Only 1 for our given topic
+        rcl_sub_init_topic_event = self.get_event_with_field_value_and_assert(
             'topic_name',
             '/the_topic',
             rcl_sub_init_events,
+            allow_multiple=False,
         )
-        # Only 1 for our given topic
-        self.assertNumEventsEqual(rcl_sub_init_topic_events, 1)
 
         # Get subscription handle
-        rcl_sub_init_topic_event = rcl_sub_init_topic_events[0]
         sub_handle_intra = self.get_field(rcl_sub_init_topic_event, 'subscription_handle')
 
         # Check rclcpp_subscription_init events

--- a/test_tracetools/test/test_intra.py
+++ b/test_tracetools/test/test_intra.py
@@ -43,7 +43,6 @@ class TestIntra(TraceTestCase):
 
         # Check rcl_subscription_init events
         rcl_sub_init_events = self.get_events_with_name(tp.rcl_subscription_init)
-        # Only 1 for our given topic
         rcl_sub_init_topic_event = self.get_event_with_field_value_and_assert(
             'topic_name',
             '/the_topic',

--- a/test_tracetools/test/test_intra_pub_sub.py
+++ b/test_tracetools/test/test_intra_pub_sub.py
@@ -64,34 +64,35 @@ class TestIntraPubSub(TraceTestCase):
         buffers = [self.get_field(e, 'buffer') for e in construct_ring_buffer_events]
         buffer_to_callback = {}
         for buffer in buffers:
-            ipb_ = self.get_events_with_field_value(
+            ipb_event = self.get_event_with_field_value_and_assert(
                 'buffer',
                 buffer,
                 buffer_to_ipb_events,
+                allow_multiple=False,
             )
-            self.assertNumEventsEqual(ipb_, 1)
 
-            subscription_ = self.get_events_with_field_value(
+            subscription_event = self.get_event_with_field_value_and_assert(
                 'ipb',
-                self.get_field(ipb_[0], 'ipb'),
+                self.get_field(ipb_event, 'ipb'),
                 ipb_to_subscription_events,
+                allow_multiple=False,
             )
-            self.assertNumEventsEqual(subscription_, 1)
 
-            callback_ = self.get_events_with_field_value(
+            subscription_callback_added_event = self.get_event_with_field_value_and_assert(
                 'subscription',
-                self.get_field(subscription_[0], 'subscription'),
+                self.get_field(subscription_event, 'subscription'),
                 rclcpp_subscription_callback_added_events,
+                allow_multiple=False,
             )
-            self.assertNumEventsEqual(callback_, 1)
-            buffer_to_callback[buffer] = self.get_field(callback_[0], 'callback')
+            buffer_to_callback[buffer] = \
+                self.get_field(subscription_callback_added_event, 'callback')
 
         # Check that intra-publish events can be linked.
         for i, intra_publish_event in enumerate(rclcpp_intra_publish_events):
             # Find corresponding intra-publish/enqueue event.
             enqueue_event_cand = self.get_events_with_field_value(
                 'vtid',
-                self.get_field(intra_publish_event, 'vtid'),
+                self.get_tid(intra_publish_event),
                 ring_buffer_enqueue_events,
             )
             target_enqueue_event = self.get_corresponding_event(

--- a/test_tracetools/test/test_lifecycle_node.py
+++ b/test_tracetools/test/test_lifecycle_node.py
@@ -47,13 +47,13 @@ class TestLifecycleNode(TraceTestCase):
             'test_lifecycle_node',
             rcl_node_init_events,
         )
-        lifecycle_node_matches = self.get_events_with_field_value(
+        lifecycle_node_match = self.get_event_with_field_value_and_assert(
             'namespace',
             '/test_tracetools',
             lifecycle_node_matches,
+            allow_multiple=False,
         )
-        self.assertNumEventsEqual(lifecycle_node_matches, 1)
-        lifecycle_node_handle = self.get_field(lifecycle_node_matches[0], 'node_handle')
+        lifecycle_node_handle = self.get_field(lifecycle_node_match, 'node_handle')
 
         # Check the state machine init event
         rcl_lifecycle_state_machine_init_events = self.get_events_with_name(

--- a/test_tracetools/test/test_pub_sub.py
+++ b/test_tracetools/test/test_pub_sub.py
@@ -52,40 +52,36 @@ class TestPubSub(TraceTestCase):
         rmw_pub_init_events = self.get_events_with_name(tp.rmw_publisher_init)
         rmw_sub_init_events = self.get_events_with_name(tp.rmw_subscription_init)
         publisher_init_events = self.get_events_with_name(tp.rcl_publisher_init)
-        ping_publisher_init_events = self.get_events_with_field_value(
+        ping_publisher_init_event = self.get_event_with_field_value_and_assert(
             'topic_name',
             '/ping',
             publisher_init_events,
+            allow_multiple=False,
         )
-        pong_publisher_init_events = self.get_events_with_field_value(
+        pong_publisher_init_event = self.get_event_with_field_value_and_assert(
             'topic_name',
             '/pong',
             publisher_init_events,
+            allow_multiple=False,
         )
-        self.assertNumEventsEqual(ping_publisher_init_events, 1)
-        self.assertNumEventsEqual(pong_publisher_init_events, 1)
-        ping_publisher_init_event = ping_publisher_init_events[0]
-        pong_publisher_init_event = pong_publisher_init_events[0]
         ping_pub_handle = self.get_field(ping_publisher_init_event, 'publisher_handle')
         ping_rmw_pub_handle = self.get_field(ping_publisher_init_event, 'rmw_publisher_handle')
         pong_pub_handle = self.get_field(pong_publisher_init_event, 'publisher_handle')
         pong_rmw_pub_handle = self.get_field(pong_publisher_init_event, 'rmw_publisher_handle')
 
         # Find corresponding rmw_pub_init events
-        ping_rmw_pub_init_events = self.get_events_with_field_value(
+        ping_rmw_pub_init_event = self.get_event_with_field_value_and_assert(
             'rmw_publisher_handle',
             ping_rmw_pub_handle,
             rmw_pub_init_events,
+            allow_multiple=False,
         )
-        pong_rmw_pub_init_events = self.get_events_with_field_value(
+        pong_rmw_pub_init_event = self.get_event_with_field_value_and_assert(
             'rmw_publisher_handle',
             pong_rmw_pub_handle,
             rmw_pub_init_events,
+            allow_multiple=False,
         )
-        self.assertNumEventsEqual(ping_rmw_pub_init_events, 1)
-        self.assertNumEventsEqual(pong_rmw_pub_init_events, 1)
-        ping_rmw_pub_init_event = ping_rmw_pub_init_events[0]
-        pong_rmw_pub_init_event = pong_rmw_pub_init_events[0]
 
         # Check publisher init order (rmw then rcl)
         self.assertEventOrder([
@@ -99,72 +95,64 @@ class TestPubSub(TraceTestCase):
 
         # Get corresponding rmw/rcl/rclcpp publish events for ping & pong
         rmw_publish_events = self.get_events_with_name(tp.rmw_publish)
-        ping_rmw_pub_events = self.get_events_with_field_value(
+        ping_rmw_pub_event = self.get_event_with_field_value_and_assert(
             'rmw_publisher_handle',
             ping_rmw_pub_handle,
             rmw_publish_events,
+            allow_multiple=False,
         )
-        pong_rmw_pub_events = self.get_events_with_field_value(
+        pong_rmw_pub_event = self.get_event_with_field_value_and_assert(
             'rmw_publisher_handle',
             pong_rmw_pub_handle,
             rmw_publish_events,
+            allow_multiple=False,
         )
-        self.assertNumEventsEqual(ping_rmw_pub_events, 1)
-        self.assertNumEventsEqual(pong_rmw_pub_events, 1)
-        ping_rmw_pub_event = ping_rmw_pub_events[0]
-        pong_rmw_pub_event = pong_rmw_pub_events[0]
         ping_pub_message = self.get_field(ping_rmw_pub_event, 'message')
         pong_pub_message = self.get_field(pong_rmw_pub_event, 'message')
 
         rclcpp_publish_events = self.get_events_with_name(tp.rclcpp_publish)
         rcl_publish_events = self.get_events_with_name(tp.rcl_publish)
-        ping_rclcpp_pub_events = self.get_events_with_field_value(
+        ping_rclcpp_pub_event = self.get_event_with_field_value_and_assert(
             'message',
             ping_pub_message,
             rclcpp_publish_events,
+            allow_multiple=False,
         )
-        pong_rclcpp_pub_events = self.get_events_with_field_value(
+        pong_rclcpp_pub_event = self.get_event_with_field_value_and_assert(
             'message',
             pong_pub_message,
             rclcpp_publish_events,
+            allow_multiple=False,
         )
-        ping_rcl_pub_events = self.get_events_with_field_value(
+        ping_rcl_pub_event = self.get_event_with_field_value_and_assert(
             'message',
             ping_pub_message,
             rcl_publish_events,
+            allow_multiple=False,
         )
-        pong_rcl_pub_events = self.get_events_with_field_value(
+        pong_rcl_pub_event = self.get_event_with_field_value_and_assert(
             'message',
             pong_pub_message,
             rcl_publish_events,
+            allow_multiple=False,
         )
-        self.assertNumEventsEqual(ping_rclcpp_pub_events, 1)
-        self.assertNumEventsEqual(pong_rclcpp_pub_events, 1)
-        self.assertNumEventsEqual(ping_rcl_pub_events, 1)
-        self.assertNumEventsEqual(pong_rcl_pub_events, 1)
-        ping_rclcpp_pub_event = ping_rclcpp_pub_events[0]
-        pong_rclcpp_pub_event = pong_rclcpp_pub_events[0]
-        ping_rcl_pub_event = ping_rcl_pub_events[0]
-        pong_rcl_pub_event = pong_rcl_pub_events[0]
         self.assertFieldEquals(ping_rcl_pub_event, 'publisher_handle', ping_pub_handle)
         self.assertFieldEquals(pong_rcl_pub_event, 'publisher_handle', pong_pub_handle)
 
         # Get subscription init events & subscription handles of test topics
         rcl_subscription_init_events = self.get_events_with_name(tp.rcl_subscription_init)
-        ping_rcl_subscription_init_events = self.get_events_with_field_value(
+        ping_rcl_subscription_init_event = self.get_event_with_field_value_and_assert(
             'topic_name',
             '/ping',
             rcl_subscription_init_events,
+            allow_multiple=False,
         )
-        pong_rcl_subscription_init_events = self.get_events_with_field_value(
+        pong_rcl_subscription_init_event = self.get_event_with_field_value_and_assert(
             'topic_name',
             '/pong',
             rcl_subscription_init_events,
+            allow_multiple=False,
         )
-        self.assertNumEventsEqual(ping_rcl_subscription_init_events, 1)
-        self.assertNumEventsEqual(pong_rcl_subscription_init_events, 1)
-        ping_rcl_subscription_init_event = ping_rcl_subscription_init_events[0]
-        pong_rcl_subscription_init_event = pong_rcl_subscription_init_events[0]
         ping_sub_handle = self.get_field(ping_rcl_subscription_init_event, 'subscription_handle')
         ping_rmw_sub_handle = \
             self.get_field(ping_rcl_subscription_init_event, 'rmw_subscription_handle')
@@ -173,39 +161,35 @@ class TestPubSub(TraceTestCase):
             self.get_field(pong_rcl_subscription_init_event, 'rmw_subscription_handle')
 
         # Find corresponding rmw_sub_init events
-        ping_rmw_sub_init_events = self.get_events_with_field_value(
+        ping_rmw_sub_init_event = self.get_event_with_field_value_and_assert(
             'rmw_subscription_handle',
             ping_rmw_sub_handle,
             rmw_sub_init_events,
+            allow_multiple=False,
         )
-        pong_rmw_sub_init_events = self.get_events_with_field_value(
+        pong_rmw_sub_init_event = self.get_event_with_field_value_and_assert(
             'rmw_subscription_handle',
             pong_rmw_sub_handle,
             rmw_sub_init_events,
+            allow_multiple=False,
         )
-        self.assertNumEventsEqual(ping_rmw_sub_init_events, 1)
-        self.assertNumEventsEqual(pong_rmw_sub_init_events, 1)
-        ping_rmw_sub_init_event = ping_rmw_sub_init_events[0]
-        pong_rmw_sub_init_event = pong_rmw_sub_init_events[0]
 
         # Get corresponding subscription objects
         rclcpp_subscription_init_events = self.get_events_with_name(
             tp.rclcpp_subscription_init,
         )
-        ping_rclcpp_subscription_init_events = self.get_events_with_field_value(
+        ping_rclcpp_subscription_init_event = self.get_event_with_field_value_and_assert(
             'subscription_handle',
             ping_sub_handle,
             rclcpp_subscription_init_events,
+            allow_multiple=False,
         )
-        pong_rclcpp_subscription_init_events = self.get_events_with_field_value(
+        pong_rclcpp_subscription_init_event = self.get_event_with_field_value_and_assert(
             'subscription_handle',
             pong_sub_handle,
             rclcpp_subscription_init_events,
+            allow_multiple=False,
         )
-        self.assertNumEventsEqual(ping_rclcpp_subscription_init_events, 1)
-        self.assertNumEventsEqual(pong_rclcpp_subscription_init_events, 1)
-        ping_rclcpp_subscription_init_event = ping_rclcpp_subscription_init_events[0]
-        pong_rclcpp_subscription_init_event = pong_rclcpp_subscription_init_events[0]
         ping_sub_object = self.get_field(ping_rclcpp_subscription_init_event, 'subscription')
         pong_sub_object = self.get_field(pong_rclcpp_subscription_init_event, 'subscription')
 
@@ -213,39 +197,35 @@ class TestPubSub(TraceTestCase):
         rclcpp_subscription_callback_events = self.get_events_with_name(
             tp.rclcpp_subscription_callback_added,
         )
-        ping_rclcpp_subscription_callback_events = self.get_events_with_field_value(
+        ping_rclcpp_subscription_callback_event = self.get_event_with_field_value_and_assert(
             'subscription',
             ping_sub_object,
             rclcpp_subscription_callback_events,
+            allow_multiple=False,
         )
-        pong_rclcpp_subscription_callback_events = self.get_events_with_field_value(
+        pong_rclcpp_subscription_callback_event = self.get_event_with_field_value_and_assert(
             'subscription',
             pong_sub_object,
             rclcpp_subscription_callback_events,
+            allow_multiple=False,
         )
-        self.assertNumEventsEqual(ping_rclcpp_subscription_callback_events, 1)
-        self.assertNumEventsEqual(pong_rclcpp_subscription_callback_events, 1)
-        ping_rclcpp_subscription_callback_event = ping_rclcpp_subscription_callback_events[0]
-        pong_rclcpp_subscription_callback_event = pong_rclcpp_subscription_callback_events[0]
         ping_callback_object = self.get_field(ping_rclcpp_subscription_callback_event, 'callback')
         pong_callback_object = self.get_field(pong_rclcpp_subscription_callback_event, 'callback')
 
         # Get rmw_take events
         rmw_take_events = self.get_events_with_name(tp.rmw_take)
-        pong_rmw_take_events = self.get_events_with_field_value(
+        pong_rmw_take_event = self.get_event_with_field_value_and_assert(
             'rmw_subscription_handle',
             pong_rmw_sub_handle,
             rmw_take_events,
+            allow_multiple=False,
         )
-        ping_rmw_take_events = self.get_events_with_field_value(
+        ping_rmw_take_event = self.get_event_with_field_value_and_assert(
             'rmw_subscription_handle',
             ping_rmw_sub_handle,
             rmw_take_events,
+            allow_multiple=False,
         )
-        self.assertNumEventsEqual(pong_rmw_take_events, 1)
-        self.assertNumEventsEqual(ping_rmw_take_events, 1)
-        pong_rmw_take_event = pong_rmw_take_events[0]
-        ping_rmw_take_event = ping_rmw_take_events[0]
 
         # Check that pub->sub timestamps match
         ping_timestamp = self.get_field(ping_rmw_pub_event, 'timestamp')
@@ -270,34 +250,30 @@ class TestPubSub(TraceTestCase):
         # Get corresponding callback start/end events
         callback_start_events = self.get_events_with_name(tp.callback_start)
         callback_end_events = self.get_events_with_name(tp.callback_end)
-        ping_callback_start_events = self.get_events_with_field_value(
+        ping_callback_start_event = self.get_event_with_field_value_and_assert(
             'callback',
             ping_callback_object,
             callback_start_events,
+            allow_multiple=False,
         )
-        pong_callback_start_events = self.get_events_with_field_value(
+        pong_callback_start_event = self.get_event_with_field_value_and_assert(
             'callback',
             pong_callback_object,
             callback_start_events,
+            allow_multiple=False,
         )
-        ping_callback_end_events = self.get_events_with_field_value(
+        ping_callback_end_event = self.get_event_with_field_value_and_assert(
             'callback',
             ping_callback_object,
             callback_end_events,
+            allow_multiple=False,
         )
-        pong_callback_end_events = self.get_events_with_field_value(
+        pong_callback_end_event = self.get_event_with_field_value_and_assert(
             'callback',
             pong_callback_object,
             callback_end_events,
+            allow_multiple=False,
         )
-        self.assertNumEventsEqual(ping_callback_start_events, 1)
-        self.assertNumEventsEqual(pong_callback_start_events, 1)
-        self.assertNumEventsEqual(ping_callback_end_events, 1)
-        self.assertNumEventsEqual(pong_callback_end_events, 1)
-        ping_callback_start_event = ping_callback_start_events[0]
-        pong_callback_start_event = pong_callback_start_events[0]
-        ping_callback_end_event = ping_callback_end_events[0]
-        pong_callback_end_event = pong_callback_end_events[0]
 
         # Check pub/sub order:
         #   * /ping pub rclcpp_publish

--- a/test_tracetools/test/test_service.py
+++ b/test_tracetools/test/test_service.py
@@ -69,28 +69,27 @@ class TestService(TraceTestCase):
             'test_service_ping',
             srv_init_events,
         )
-        ping_node_test_srv_init_events = self.get_events_with_field_value(
+        ping_node_test_srv_init_event = self.get_event_with_field_value_and_assert(
             'service_name',
             '/pong',
             ping_node_srv_init_events,
+            allow_multiple=False,
         )
-        self.assertNumEventsEqual(ping_node_test_srv_init_events, 1)
 
         pong_node_srv_init_events = self.get_events_with_procname(
             'test_service_pong',
             srv_init_events,
         )
-        pong_node_test_srv_init_events = self.get_events_with_field_value(
+        pong_node_test_srv_init_event = self.get_event_with_field_value_and_assert(
             'service_name',
             '/ping',
             pong_node_srv_init_events,
+            allow_multiple=True,
         )
-        self.assertNumEventsGreaterEqual(pong_node_test_srv_init_events, 1)
 
         # Check that the service init events have a matching node handle (with node_init events)
         node_init_events = self.get_events_with_name(tp.rcl_node_init)
 
-        ping_node_test_srv_init_event = ping_node_test_srv_init_events[0]
         self.assertMatchingField(
             ping_node_test_srv_init_event,
             'node_handle',
@@ -99,7 +98,6 @@ class TestService(TraceTestCase):
             False,
         )
 
-        pong_node_test_srv_init_event = pong_node_test_srv_init_events[0]
         self.assertMatchingField(
             pong_node_test_srv_init_event,
             'node_handle',
@@ -122,31 +120,31 @@ class TestService(TraceTestCase):
             'test_service_ping',
             callback_added_events,
         )
-        ping_node_test_srv_callback_added_events = self.get_events_with_field_value(
+        ping_node_test_srv_callback_added_event = self.get_event_with_field_value_and_assert(
             'service_handle',
             ping_node_test_service_handle,
             ping_node_srv_callback_added_events,
+            allow_multiple=False,
         )
-        self.assertNumEventsEqual(ping_node_test_srv_callback_added_events, 1)
 
         pong_node_srv_callback_added_events = self.get_events_with_procname(
             'test_service_pong',
             callback_added_events,
         )
-        pong_node_test_srv_callback_added_events = self.get_events_with_field_value(
+        pong_node_test_srv_callback_added_event = self.get_event_with_field_value_and_assert(
             'service_handle',
             pong_node_test_service_handle,
             pong_node_srv_callback_added_events,
+            allow_multiple=False,
         )
-        self.assertNumEventsEqual(pong_node_test_srv_callback_added_events, 1)
 
         # Check that there are matching rclcpp_callback_register events
         ping_node_test_callback_ref = self.get_field(
-            ping_node_test_srv_callback_added_events[0],
+            ping_node_test_srv_callback_added_event,
             'callback',
         )
         pong_node_test_callback_ref = self.get_field(
-            pong_node_test_srv_callback_added_events[0],
+            pong_node_test_srv_callback_added_event,
             'callback',
         )
 

--- a/test_tracetools/test/test_subscription.py
+++ b/test_tracetools/test/test_subscription.py
@@ -150,7 +150,6 @@ class TestSubscription(TraceTestCase):
 
         # Check that subscription pointer matches between rclcpp_sub_init and sub_callback_added
         subscription_pointer = self.get_field(rclcpp_sub_init_matching_event, 'subscription')
-        # There is only one callback for /pong topic in ping node
         callback_added_matching_event = self.get_event_with_field_value_and_assert(
             'subscription',
             subscription_pointer,

--- a/test_tracetools/test/test_timer.py
+++ b/test_tracetools/test/test_timer.py
@@ -87,43 +87,39 @@ class TestTimer(TraceTestCase):
         timer_handle = self.get_field(test_timer_init_event, 'timer_handle')
 
         # Check that the timer_init:callback_added pair exists and has a common timer handle
-        test_callback_added_events = self.get_events_with_field_value(
+        test_callback_added_event = self.get_event_with_field_value_and_assert(
             'timer_handle',
             timer_handle,
             callback_added_events,
+            allow_multiple=False,
         )
-        self.assertNumEventsEqual(test_callback_added_events, 1)
-        test_callback_added_event = test_callback_added_events[0]
 
         # Check that callback pointer matches between callback_added and callback_register
         callback_handle = self.get_field(test_callback_added_event, 'callback')
-        test_callback_register_events = self.get_events_with_field_value(
+        test_callback_register_event = self.get_event_with_field_value_and_assert(
             'callback',
             callback_handle,
             callback_register_events,
+            allow_multiple=False,
         )
-        self.assertNumEventsEqual(test_callback_register_events, 1)
-        test_callback_register_event = test_callback_register_events[0]
 
         # Check that there is a link_node event for the timer
-        test_link_node_events = self.get_events_with_field_value(
+        test_link_node_event = self.get_event_with_field_value_and_assert(
             'timer_handle',
             timer_handle,
             link_node_events,
+            allow_multiple=False,
         )
-        self.assertNumEventsEqual(test_link_node_events, 1)
-        test_link_node_event = test_link_node_events[0]
 
         # And that the node from that node handle exists
         node_handle = self.get_field(test_link_node_event, 'node_handle')
         node_init_events = self.get_events_with_name(tp.rcl_node_init)
-        test_node_inits_events = self.get_events_with_field_value(
+        test_node_inits_event = self.get_event_with_field_value_and_assert(
             'node_handle',
             node_handle,
             node_init_events,
+            allow_multiple=False,
         )
-        self.assertNumEventsEqual(test_node_inits_events, 1)
-        test_node_inits_event = test_node_inits_events[0]
 
         # Check timer creation events order
         self.assertEventOrder([

--- a/tracetools_read/tracetools_read/__init__.py
+++ b/tracetools_read/tracetools_read/__init__.py
@@ -63,6 +63,10 @@ def get_procname(event: DictEvent) -> str:
     return event['procname']
 
 
+def get_tid(event: DictEvent) -> str:
+    return event['vtid']
+
+
 def get_events_with_name(
     event_name: str,
     events: List[DictEvent],


### PR DESCRIPTION
The main/biggest improvement is the new `get_event_with_field_value_and_assert()` test method, which can simplify this very common bit of code:

```py
my_events = self.get_events_with_field_value('field', value, events)
self.assertNumEventsEqual(my_events, 1)
my_event = my_events[0]
```

into:

```py
event = self.get_event_with_field_value_and_assert('field', value, events)
```

I've therefore updated a lot of test code to use this new assert method, which makes it a lot simpler and smaller.

I also renamed `assertValidArray()` to `assertValidStaticArray()` and added length checking.