### PR TITLE
Switch to ament_generate_version_header for tracetools

### DIFF
--- a/tracetools/CMakeLists.txt
+++ b/tracetools/CMakeLists.txt
@@ -103,7 +103,9 @@ if(NOT TRACETOOLS_DISABLED)
   set(export_target_options "HAS_LIBRARY_TARGET")
 endif()
 ament_export_targets(${PROJECT_NAME}_export ${export_target_options})
-ament_generate_version_header(${PROJECT_NAME})
+if(NOT TRACETOOLS_DISABLED)
+  ament_generate_version_header(${PROJECT_NAME})
+endif()
 
 if(TRACETOOLS_STATUS_CHECKING_TOOL)
   # Lib for status checking

--- a/tracetools/CMakeLists.txt
+++ b/tracetools/CMakeLists.txt
@@ -13,6 +13,7 @@ elseif(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
   add_compile_options(/W4)
 endif()
 
+find_package(ament_cmake_gen_version_h REQUIRED)
 find_package(ament_cmake_ros REQUIRED)
 
 if(WIN32 OR APPLE OR ANDROID)
@@ -102,6 +103,7 @@ if(NOT TRACETOOLS_DISABLED)
   set(export_target_options "HAS_LIBRARY_TARGET")
 endif()
 ament_export_targets(${PROJECT_NAME}_export ${export_target_options})
+ament_generate_version_header(${PROJECT_NAME})
 
 if(TRACETOOLS_STATUS_CHECKING_TOOL)
   # Lib for status checking
@@ -187,7 +189,3 @@ if(BUILD_TESTING)
 endif()
 
 ament_package()
-
-if(NOT TRACETOOLS_DISABLED)
-  target_compile_definitions(${PROJECT_NAME} PRIVATE ${PROJECT_NAME}_VERSION="${${PROJECT_NAME}_VERSION}")
-endif()

--- a/tracetools/include/tracetools/tp_call.h
+++ b/tracetools/include/tracetools/tp_call.h
@@ -32,6 +32,8 @@
 #include <stdint.h>
 #include <stdbool.h>
 
+#include "tracetools/version.h"
+
 /// See RMW_GID_STORAGE_SIZE in rmw.
 #define TRACETOOLS_GID_STORAGE_SIZE 24u
 
@@ -43,7 +45,7 @@ TRACEPOINT_EVENT(
   ),
   TP_FIELDS(
     ctf_integer_hex(const void *, context_handle, context_handle_arg)
-    ctf_string(version, tracetools_VERSION)
+    ctf_string(version, TRACETOOLS_VERSION_STR)
   )
 )
 

--- a/tracetools/package.xml
+++ b/tracetools/package.xml
@@ -13,6 +13,7 @@
   <author email="ingo.luetkebohle@de.bosch.com">Ingo Lütkebohle</author>
   <author email="fixed-term.christophe.bourquebedard@de.bosch.com">Christophe Bedard</author>
 
+  <buildtool_depend>ament_cmake_gen_version_h</buildtool_depend>
   <buildtool_depend>ament_cmake_ros</buildtool_depend>
   <buildtool_depend>pkg-config</buildtool_depend>
 


### PR DESCRIPTION
Instead of manually defining a private compile definition.