### PR TITLE
Install test_tracetools_mark_process

### DIFF
--- a/test_tracetools/CMakeLists.txt
+++ b/test_tracetools/CMakeLists.txt
@@ -60,6 +60,12 @@ if(BUILD_TESTING)
     DIRECTORY include/
     DESTINATION include/${PROJECT_NAME}
   )
+  install(
+    TARGETS ${PROJECT_NAME}_mark_process
+    LIBRARY DESTINATION lib
+    ARCHIVE DESTINATION lib
+    RUNTIME DESTINATION bin
+  )
 
   add_executable(test_publisher
     src/test_publisher.cpp


### PR DESCRIPTION
This is needed if the `build/` directory is not available when running the `test_tracetools` tests.