### PR TITLE
Fixed warnings - strict-prototypes

### DIFF
--- a/tracetools/include/tracetools/tracetools.h
+++ b/tracetools/include/tracetools/tracetools.h
@@ -46,20 +46,20 @@
 
 // *INDENT-OFF*
 #  define _TRACEPOINT_NOARGS(event_name) \
-  (ros_trace_ ## event_name)()
+  (ros_trace_ ## event_name)(void)
 #  define _TRACEPOINT_ARGS(event_name, ...) \
   (ros_trace_ ## event_name)(__VA_ARGS__)
 #  define _DO_TRACEPOINT_NOARGS(event_name) \
-  (ros_trace_do_ ## event_name)()
+  (ros_trace_do_ ## event_name)(void)
 #  define _DO_TRACEPOINT_ARGS(event_name, ...) \
   (ros_trace_do_ ## event_name)(__VA_ARGS__)
 #  define _DECLARE_TRACEPOINT_NOARGS(event_name) \
-  TRACETOOLS_PUBLIC void ros_trace_ ## event_name(); \
-  TRACETOOLS_PUBLIC bool ros_trace_enabled_ ## event_name(); \
-  TRACETOOLS_PUBLIC void ros_trace_do_ ## event_name();
+  TRACETOOLS_PUBLIC void ros_trace_ ## event_name(void); \
+  TRACETOOLS_PUBLIC bool ros_trace_enabled_ ## event_name(void); \
+  TRACETOOLS_PUBLIC void ros_trace_do_ ## event_name(void);
 #  define _DECLARE_TRACEPOINT_ARGS(event_name, ...) \
   TRACETOOLS_PUBLIC void ros_trace_ ## event_name(__VA_ARGS__); \
-  TRACETOOLS_PUBLIC bool ros_trace_enabled_ ## event_name(); \
+  TRACETOOLS_PUBLIC bool ros_trace_enabled_ ## event_name(void); \
   TRACETOOLS_PUBLIC void ros_trace_do_ ## event_name(__VA_ARGS__);
 
 #  define _GET_MACRO_TRACEPOINT(...) \
@@ -103,7 +103,7 @@
  * This is the preferred method over calling the underlying function directly.
  */
 #  define TRACETOOLS_TRACEPOINT_ENABLED(event_name) \
-  ros_trace_enabled_ ## event_name()
+  ros_trace_enabled_ ## event_name(void)
 /// Call a tracepoint, without checking if it is enabled.
 /**
  * Combine this with `TRACEPOINT_ENABLED()` to check if a tracepoint is enabled before triggering
@@ -164,7 +164,7 @@ extern "C"
 /**
  * \return `true` if tracing is enabled, `false` otherwise
  */
-TRACETOOLS_PUBLIC bool ros_trace_compile_status();
+TRACETOOLS_PUBLIC bool ros_trace_compile_status(void);
 
 /// `rcl_init`
 /**

--- a/tracetools/src/status_tool.c
+++ b/tracetools/src/status_tool.c
@@ -16,8 +16,10 @@
 #include "tracetools/status.h"
 #include "tracetools/tracetools.h"
 
-int main()
+int main(int argc, char * argv[])
 {
+  (void)argc;
+  (void)argv;
 #ifndef TRACETOOLS_DISABLED
   return tracetools_status(ros_trace_compile_status());
 #else

--- a/tracetools/src/tracetools.c
+++ b/tracetools/src/tracetools.c
@@ -68,7 +68,7 @@
   }
 // *INDENT-ON*
 
-bool ros_trace_compile_status()
+bool ros_trace_compile_status(void)
 {
 #ifndef TRACETOOLS_TRACEPOINTS_EXCLUDED
   return true;


### PR DESCRIPTION
There are new warnings on CI related with this compiler option `strict-prototypes`

https://ci.ros2.org/view/nightly/job/nightly_linux_clang_libcxx/1860/gcc/new/