### PR TITLE
Run relevant test_tracetools tests with all instrumented rmw impls

### DIFF
--- a/test_tracetools/CMakeLists.txt
+++ b/test_tracetools/CMakeLists.txt
@@ -198,6 +198,9 @@ if(BUILD_TESTING)
   # Only run tracing tests if instrumentation and tracepoints are included
   if(NOT TRACETOOLS_TRACEPOINTS_EXCLUDED)
     find_package(ament_cmake_pytest REQUIRED)
+    find_package(rmw_implementation_cmake REQUIRED)
+
+    # Tests to run with the default rmw implementation, which should not matter
     set(_test_tracetools_pytest_tests
       test/test_buffer.py
       test/test_executor.py
@@ -205,12 +208,7 @@ if(BUILD_TESTING)
       test/test_intra_pub_sub.py
       test/test_lifecycle_node.py
       test/test_node.py
-      test/test_pub_sub.py
-      test/test_generic_pub_sub.py
-      test/test_publisher.py
       test/test_service.py
-      test/test_subscription.py
-      test/test_generic_subscription.py
       test/test_timer.py
     )
     foreach(_test_path ${_test_tracetools_pytest_tests})
@@ -220,6 +218,37 @@ if(BUILD_TESTING)
         TIMEOUT 60
         WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
       )
+    endforeach()
+
+    # Tests to run with all instrumented/supported rmw implementations
+    set(_test_tracetools_pytest_tests_multi_rmw
+      test/test_generic_pub_sub.py
+      test/test_generic_subscription.py
+      test/test_pub_sub.py
+      test/test_publisher.py
+      test/test_subscription.py
+    )
+    set(_test_tracetools_rmw_implementations
+      rmw_connextdds
+      rmw_cyclonedds_cpp
+      rmw_fastrtps_cpp
+    )
+    get_available_rmw_implementations(rmw_implementations)
+    foreach(_test_path ${_test_tracetools_pytest_tests_multi_rmw})
+      get_filename_component(_test_name ${_test_path} NAME_WE)
+      foreach(rmw_implementation ${_test_tracetools_rmw_implementations})
+        if(rmw_implementation IN_LIST rmw_implementations)
+          ament_add_pytest_test(${_test_name}__${rmw_implementation} ${_test_path}
+            ENV RMW_IMPLEMENTATION=${rmw_implementation}
+            APPEND_ENV PYTHONPATH=${CMAKE_CURRENT_BINARY_DIR}
+            TIMEOUT 60
+            WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+          )
+        else()
+          message(
+            "rmw implementation '${rmw_implementation}' not available for test '${_test_name}'")
+        endif()
+      endforeach()
     endforeach()
   endif()
 endif()

--- a/test_tracetools/package.xml
+++ b/test_tracetools/package.xml
@@ -40,6 +40,7 @@
   <test_depend>rclcpp</test_depend>
   <test_depend>rclcpp_lifecycle</test_depend>
   <test_depend>rcpputils</test_depend>
+  <test_depend>rmw_implementation_cmake</test_depend>
   <test_depend>std_msgs</test_depend>
   <test_depend>std_srvs</test_depend>
   <test_depend>tracetools</test_depend>

--- a/tracetools_test/tracetools_test/case.py
+++ b/tracetools_test/tracetools_test/case.py
@@ -75,7 +75,10 @@ class TraceTestCase(unittest.TestCase):
         """Create a TraceTestCase."""
         super().__init__(methodName=args[0])
         self._base_path = base_path or tempfile.gettempdir()
-        self._session_name_prefix = session_name_prefix
+        # Append rmw implementation name to session name if one is explicitly set
+        rmw_implementation = os.environ.get('RMW_IMPLEMENTATION', None)
+        self._session_name_prefix = \
+            session_name_prefix + ('__' + rmw_implementation if rmw_implementation else '')
         self._events_ros = events_ros + [TRACE_TEST_ID_TP_NAME]
         self._events_kernel = events_kernel
         self._package = package


### PR DESCRIPTION
The `test_tracetools` tracing tests only currently run using the default `rmw` implementation. However, all "main" `rmw` implementations are instrumented, so we should run the tests that cover `rmw` instrumentation against all supported implementations.

Requires #104 for CI to pass.