### PR TITLE
tp_call.h fix field type for tracepoint event rclcpp_ring_buffer_enqueue

### DIFF
--- a/tracetools/include/tracetools/tp_call.h
+++ b/tracetools/include/tracetools/tp_call.h
@@ -477,7 +477,7 @@ TRACEPOINT_EVENT(
   ),
   TP_FIELDS(
     ctf_integer_hex(const void *, buffer, buffer_arg)
-    ctf_integer(const uint64_t *, index, index_arg)
+    ctf_integer(const uint64_t, index, index_arg)
     ctf_integer(const uint64_t, size, size_arg)
     ctf_integer(const int, overwritten, (overwritten_arg ? 1 : 0))
   )


### PR DESCRIPTION
# Reason for this pull request:

While trying to compile ros2 on my system with gcc-14 i got an integer conversion warning causing a compilation failure:

```bash
error: initialization of ‘const uint64_t *’ {aka ‘const long unsigned int *’} from ‘uint64_t’ {aka ‘long unsigned int’} makes pointer from integer without a cast [-Wint-conversion]
  474 |     ctf_integer(const uint64_t *, index, index_arg)
```
# Proposed fix:

As far as i see it, the field type should match the argument type in this case.

After applying the proposed fix locally, the compilation succeeded.
