### PR TITLE
Update tp_call.h to fix simple type without cast error

### DIFF
--- a/tracetools/include/tracetools/tp_call.h
+++ b/tracetools/include/tracetools/tp_call.h
@@ -471,7 +471,7 @@ TRACEPOINT_EVENT(
   ),
   TP_FIELDS(
     ctf_integer_hex(const void *, buffer, buffer_arg)
-    ctf_integer(const uint64_t *, index, index_arg)
+    ctf_integer(uint64_t, index, index_arg)
     ctf_integer(const uint64_t, size, size_arg)
     ctf_integer(const int, overwritten, (overwritten_arg ? 1 : 0))
   )


### PR DESCRIPTION
While building ROS2 Iron on Arch with an updated PKGBUILD, there seems to be a type mismatch without cast from uin64_t to const uint64_t *, so I just changed it. Perhaps this could be something on my end but I would like to propose the change regardless. Please let me know if you want more details. I am building using colcon with the following PKGBUILD: https://github.com/DragonflyRobotics/ros2-iron-fork. 

Disclaimer: I am not at all familiar with this codebase, but I am familiar with C++. This resolves the compile error but may break functionality, which I cannot anticipate, so any input is appreciated. 