### PR TITLE
Bump versions of actions in GitHub CI

### DIFF
--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -5,9 +5,9 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python 3.x
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v5
       with:
         python-version: '3.x'
     - name: Check DCO

--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -21,7 +21,7 @@ jobs:
         distro:
           - rolling
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         path: ws/src/ros2/ros2_tracing
     - uses: ros-tooling/setup-ros@master
@@ -66,7 +66,7 @@ jobs:
         distro:
           - rolling
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         path: ws/src/ros2/ros2_tracing
     - uses: ros-tooling/setup-ros@master

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,7 +46,7 @@ jobs:
     env:
       ROS2_REPOS_FILE_URL: 'https://raw.githubusercontent.com/ros2/ros2/${{ matrix.distro }}/ros2.repos'
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: ros-tooling/setup-ros@master
       with:
         required-ros-distributions: ${{ matrix.build-type == 'binary' && matrix.distro || '' }}


### PR DESCRIPTION
This takes care of some deprecation warnings.