### PR TITLE
Make test_tracetools ping pubs/subs transient_local

### DIFF
--- a/test_tracetools/src/test_generic_ping.cpp
+++ b/test_tracetools/src/test_generic_ping.cpp
@@ -69,6 +69,7 @@ private:
     rclcpp::SerializedMessage serialized_msg;
     serialized_msg.reserve(1024);
     serializer_->serialize_message(&msg, &serialized_msg);
+    RCLCPP_INFO(this->get_logger(), "ping");
     pub_->publish(serialized_msg);
     if (do_only_one_) {
       timer_->cancel();

--- a/test_tracetools/src/test_generic_ping.cpp
+++ b/test_tracetools/src/test_generic_ping.cpp
@@ -41,7 +41,7 @@ public:
     pub_ = this->create_generic_publisher(
       PUB_TOPIC_NAME,
       "std_msgs/msg/String",
-      rclcpp::QoS(QUEUE_DEPTH));
+      rclcpp::QoS(QUEUE_DEPTH).transient_local());
     timer_ = this->create_wall_timer(
       500ms,
       std::bind(&PingNode::timer_callback, this));
@@ -70,6 +70,9 @@ private:
     serialized_msg.reserve(1024);
     serializer_->serialize_message(&msg, &serialized_msg);
     pub_->publish(serialized_msg);
+    if (do_only_one_) {
+      timer_->cancel();
+    }
   }
 
   rclcpp::GenericSubscription::SharedPtr sub_;

--- a/test_tracetools/src/test_generic_pong.cpp
+++ b/test_tracetools/src/test_generic_pong.cpp
@@ -32,7 +32,7 @@ public:
     sub_ = this->create_generic_subscription(
       SUB_TOPIC_NAME,
       "std_msgs/msg/String",
-      rclcpp::QoS(10),
+      rclcpp::QoS(10).transient_local(),
       std::bind(&PongNode::callback, this, std::placeholders::_1));
     pub_ = this->create_generic_publisher(
       PUB_TOPIC_NAME,

--- a/test_tracetools/src/test_generic_pong.cpp
+++ b/test_tracetools/src/test_generic_pong.cpp
@@ -55,6 +55,7 @@ private:
     rclcpp::SerializedMessage serialized_msg;
     serialized_msg.reserve(1024);
     serializer_->serialize_message(&next_msg, &serialized_msg);
+    RCLCPP_INFO(this->get_logger(), "pong");
     pub_->publish(serialized_msg);
     if (do_only_one_) {
       rclcpp::shutdown();

--- a/test_tracetools/src/test_ping.cpp
+++ b/test_tracetools/src/test_ping.cpp
@@ -38,7 +38,7 @@ public:
       std::bind(&PingNode::callback, this, std::placeholders::_1));
     pub_ = this->create_publisher<std_msgs::msg::String>(
       PUB_TOPIC_NAME,
-      rclcpp::QoS(QUEUE_DEPTH));
+      rclcpp::QoS(QUEUE_DEPTH).transient_local());
     timer_ = this->create_wall_timer(
       500ms,
       std::bind(&PingNode::timer_callback, this));
@@ -61,6 +61,9 @@ private:
     auto msg = std::make_shared<std_msgs::msg::String>();
     msg->data = "some random ping string";
     pub_->publish(*msg);
+    if (do_only_one_) {
+      timer_->cancel();
+    }
   }
 
   rclcpp::Subscription<std_msgs::msg::String>::SharedPtr sub_;

--- a/test_tracetools/src/test_ping.cpp
+++ b/test_tracetools/src/test_ping.cpp
@@ -60,6 +60,7 @@ private:
   {
     auto msg = std::make_shared<std_msgs::msg::String>();
     msg->data = "some random ping string";
+    RCLCPP_INFO(this->get_logger(), "ping");
     pub_->publish(*msg);
     if (do_only_one_) {
       timer_->cancel();

--- a/test_tracetools/src/test_pong.cpp
+++ b/test_tracetools/src/test_pong.cpp
@@ -46,6 +46,7 @@ private:
     RCLCPP_INFO(this->get_logger(), "[output] %s", msg->data.c_str());
     auto next_msg = std::make_shared<std_msgs::msg::String>();
     next_msg->data = "some random pong string";
+    RCLCPP_INFO(this->get_logger(), "pong");
     pub_->publish(*next_msg);
     if (do_only_one_) {
       rclcpp::shutdown();

--- a/test_tracetools/src/test_pong.cpp
+++ b/test_tracetools/src/test_pong.cpp
@@ -30,7 +30,7 @@ public:
   {
     sub_ = this->create_subscription<std_msgs::msg::String>(
       SUB_TOPIC_NAME,
-      rclcpp::QoS(10),
+      rclcpp::QoS(10).transient_local(),
       std::bind(&PongNode::callback, this, std::placeholders::_1));
     pub_ = this->create_publisher<std_msgs::msg::String>(
       PUB_TOPIC_NAME,


### PR DESCRIPTION
Fixes #124

See an overview of the tests in https://github.com/ros2/ros2_tracing/issues/124#issuecomment-2207132572

This will make sure that the initial `/ping` message is received no matter the launch order of the `*ping` and `*pong` executables.

Also, given this guarantee, cancel the timer after the initial `/ping` message.

Finally, add some helpful debug logs.