### PR TITLE
Ignore zero-variadic-macro-arguments warnings from lttng-ust macros

### DIFF
--- a/tracetools/include/tracetools/tp_call.h
+++ b/tracetools/include/tracetools/tp_call.h
@@ -37,6 +37,11 @@
 /// See RMW_GID_STORAGE_SIZE in rmw.
 #define TRACETOOLS_GID_STORAGE_SIZE 24u
 
+#ifdef __clang__
+# pragma clang diagnostic push
+# pragma clang diagnostic ignored "-Wgnu-zero-variadic-macro-arguments"
+#endif
+
 TRACEPOINT_EVENT(
   TRACEPOINT_PROVIDER,
   rcl_init,
@@ -508,6 +513,10 @@ TRACEPOINT_EVENT(
     ctf_integer_hex(const void *, buffer, buffer_arg)
   )
 )
+
+#ifdef __clang__
+# pragma clang diagnostic pop
+#endif
 
 #endif  // _TRACETOOLS__TP_CALL_H_
 

--- a/tracetools/src/tracetools.c
+++ b/tracetools/src/tracetools.c
@@ -35,7 +35,7 @@
 # define _CONDITIONAL_TP(...) ((void) (0))
 # define _CONDITIONAL_TP_ENABLED(...) false
 # define _CONDITIONAL_DO_TP(...) ((void) (0))
-#endif
+#endif  // TRACETOOLS_TRACEPOINTS_EXCLUDED
 
 #define TRACEPOINT_ARGS(...) __VA_ARGS__
 #define TRACEPOINT_PARAMS(...) __VA_ARGS__
@@ -77,12 +77,19 @@ bool ros_trace_compile_status()
 #endif
 }
 
+// Ignore unused-parameters warning when tracepoints are excluded
 #ifndef _WIN32
 # pragma GCC diagnostic push
 # pragma GCC diagnostic ignored "-Wunused-parameter"
 #else
 # pragma warning(push)
 # pragma warning(disable: 4100)
+#endif
+
+// Ignore zero-variadic-macro-arguments clang warnings caused by lttng-ust macros
+#ifdef __clang__
+# pragma clang diagnostic push
+# pragma clang diagnostic ignored "-Wgnu-zero-variadic-macro-arguments"
 #endif
 
 DEFINE_TRACEPOINT(
@@ -416,6 +423,10 @@ DEFINE_TRACEPOINT(
     const void * buffer),
   TRACEPOINT_ARGS(
     buffer))
+
+#ifdef __clang__
+# pragma clang diagnostic pop
+#endif
 
 #ifndef _WIN32
 # pragma GCC diagnostic pop


### PR DESCRIPTION
Fixes #105

The warnings are due to the lttng-ust macros. While the relevant `tracetools` macros have two variants to handle tracepoints _with_ and _without_ arguments (see comment in `tracetools.h`), the lttng-ust macros do not:

```c
#define lttng_ust_do_tracepoint(provider, name, ...)
```

This will be called without any variadic arguments by the `tracetools` `_CONDITIONAL_DO_TP()` macro (see `tracetools.c`). For example, in rough order of expansion:

```c
// 1.
DEFINE_TRACEPOINT_NO_ARGS(
  rclcpp_executor_get_next_ready)

// 2.
_CONDITIONAL_DO_TP(rclcpp_executor_get_next_ready)

// 3.
do_tracepoint(ros2, rclcpp_executor_get_next_ready)

// 4.
lttng_ust_do_tracepoint(ros2, rclcpp_executor_get_next_ready)
```

Therefore, ignore the `gnu-zero-variadic-macro-arguments` warning with clang in `tp_call.h` (where lttng-ust macros are used to define tracepoint events) and in `tracetools.c` (where lttng-ust macros are used to trigger tracepoint events).