### PR TITLE
Run test_tracetools tests against rmw_fastrtps_dynamic_cpp too

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,8 +69,14 @@ Finally, check out the following presentations:
 
 ## Building
 
-As of Iron, the LTTng tracer is a ROS 2 dependency.
+Starting from ROS 2 Iron Irwini, the LTTng tracer is a ROS 2 dependency.
 Therefore, ROS 2 can be traced out-of-the-box on Linux; this package does not need to be re-built.
+The following `rmw` implementations are supported:
+
+* `rmw_connextdds`
+* `rmw_cyclonedds_cpp`
+* `rmw_fastrtps_cpp`
+* `rmw_fastrtps_dynamic_cpp`
 
 To make sure that the instrumentation and tracepoints are available:
 

--- a/test_tracetools/CMakeLists.txt
+++ b/test_tracetools/CMakeLists.txt
@@ -232,6 +232,7 @@ if(BUILD_TESTING)
       rmw_connextdds
       rmw_cyclonedds_cpp
       rmw_fastrtps_cpp
+      rmw_fastrtps_dynamic_cpp
     )
     get_available_rmw_implementations(rmw_implementations)
     foreach(_test_path ${_test_tracetools_pytest_tests_multi_rmw})


### PR DESCRIPTION
This is sort of a follow-up to #116, see https://github.com/ros2/ros2_tracing/pull/116#discussion_r1645042581

Requires https://github.com/ros2/rmw_fastrtps/pull/772 for the `rmw_fastrtps_dynamic_cpp` tracing instrumentation

action-ros-ci-repos-override: https://gist.githubusercontent.com/christophebedard/c07fa52c22a5d4af1c0b88755409344b/raw/a0d726f66dcca91cb26b77ef5ef3e35a135ed9e2/ros2.repos