### PR TITLE
Add missing dependency on pkg-config to lttngpy

### DIFF
--- a/lttngpy/package.xml
+++ b/lttngpy/package.xml
@@ -12,6 +12,7 @@
   <author email="christophe.bedard@apex.ai">Christophe Bedard</author>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>pkg-config</buildtool_depend>
   <buildtool_depend>python_cmake_module</buildtool_depend>
 
   <depend>liblttng-ctl-dev</depend>


### PR DESCRIPTION
The `lttngpy` package depends on `pkg-config` for finding the `lttng-ctl` libraries, but didn't list it in its `package.xml`. Without the explicit dependency, some strict build environments will fail.