### PR TITLE
Run relevant test_tracetools tests with all instrumented rmw impls

### DIFF
--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -3,7 +3,7 @@ on:
   pull_request:
   push:
     branches:
-      - rolling
+      - iron
   schedule:
     - cron: "0 5 * * *"
 jobs:
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         distro:
-          - rolling
+          - iron
     steps:
     - uses: actions/checkout@v3
       with:
@@ -57,7 +57,7 @@ jobs:
       fail-fast: false
       matrix:
         distro:
-          - rolling
+          - iron
     steps:
     - uses: actions/checkout@v3
       with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,7 @@ on:
   pull_request:
   push:
     branches:
-      - rolling
+      - iron
   schedule:
     - cron: "0 5 * * *"
 jobs:
@@ -16,25 +16,25 @@ jobs:
         include:
           # Normal build (binary)
           - os: ubuntu-22.04
-            distro: rolling
+            distro: iron
             build-type: binary
             instrumentation: instr-enabled
             tracepoints: tp-included
           # Normal build (source)
           - os: ubuntu-22.04
-            distro: rolling
+            distro: iron
             build-type: source
             instrumentation: instr-enabled
             tracepoints: tp-included
           # Build with instrumentation disabled
           - os: ubuntu-22.04
-            distro: rolling
+            distro: iron
             build-type: source
             instrumentation: instr-disabled
             tracepoints: tp-included
           # Normal build with tracepoints excluded
           - os: ubuntu-22.04
-            distro: rolling
+            distro: iron
             build-type: source
             instrumentation: instr-enabled
             tracepoints: tp-excluded

--- a/test_tracetools/CMakeLists.txt
+++ b/test_tracetools/CMakeLists.txt
@@ -133,6 +133,9 @@ if(BUILD_TESTING)
   # Only run tracing tests if instrumentation and tracepoints are included
   if(NOT TRACETOOLS_TRACEPOINTS_EXCLUDED)
     find_package(ament_cmake_pytest REQUIRED)
+    find_package(rmw_implementation_cmake REQUIRED)
+
+    # Tests to run with the default rmw implementation, which should not matter
     set(_test_tracetools_pytest_tests
       test/test_buffer.py
       test/test_executor.py
@@ -140,10 +143,7 @@ if(BUILD_TESTING)
       test/test_intra_pub_sub.py
       test/test_lifecycle_node.py
       test/test_node.py
-      test/test_pub_sub.py
-      test/test_publisher.py
       test/test_service.py
-      test/test_subscription.py
       test/test_timer.py
     )
     foreach(_test_path ${_test_tracetools_pytest_tests})
@@ -153,6 +153,34 @@ if(BUILD_TESTING)
         TIMEOUT 60
         WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
       )
+    endforeach()
+
+    # Tests to run with all instrumented/supported rmw implementations
+    set(_test_tracetools_pytest_tests_multi_rmw
+      test/test_pub_sub.py
+      test/test_publisher.py
+      test/test_subscription.py
+    )
+    set(_test_tracetools_rmw_implementations
+      rmw_cyclonedds_cpp
+      rmw_fastrtps_cpp
+    )
+    get_available_rmw_implementations(rmw_implementations)
+    foreach(_test_path ${_test_tracetools_pytest_tests_multi_rmw})
+      get_filename_component(_test_name ${_test_path} NAME_WE)
+      foreach(rmw_implementation ${_test_tracetools_rmw_implementations})
+        if(rmw_implementation IN_LIST rmw_implementations)
+          ament_add_pytest_test(${_test_name}__${rmw_implementation} ${_test_path}
+            ENV RMW_IMPLEMENTATION=${rmw_implementation}
+            APPEND_ENV PYTHONPATH=${CMAKE_CURRENT_BINARY_DIR}
+            TIMEOUT 60
+            WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+          )
+        else()
+          message(
+            "rmw implementation '${rmw_implementation}' not available for test '${_test_name}'")
+        endif()
+      endforeach()
     endforeach()
   endif()
 endif()


### PR DESCRIPTION
Fixes #131

This is ~~equivalent~~ similar to #116 but for Iron.

As mentioned in my comment here https://github.com/ros2/ros2_tracing/issues/131#issuecomment-2303049471, the issue is that not all `rmw` instrumentation are instrumented with tracepoints. The tests here only run against the "default" `rmw` implementation. Some CI jobs like the one listed in #131 set a specific `rmw` implementation different from the default one for Iron (`rmw_fastrtps_dynamic_cpp`, `rmw_connextdds`). If that `rmw` implementation is not instrumented, then the tests will fail.

Do what we did for #116 and only run the `rmw` instrumentation-dependent tests if the `rmw` implementation is (known to be) instrumented. Compared to Rolling, only `rmw_fastrtps_cpp` (default) and `rmw_cyclonedds_cpp` are supported.