### PR TITLE
Allow enabling syscalls through `ros2 trace` or the Trace action

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ $ ros2 trace stop session_name    # Stop tracing after starting or resuming
 
 Run each command with `-h` for more information.
 
-You must [install the kernel tracer](#building) if you want to enable kernel events (using the `-k`/`--kernel-events` option).
+You must [install the kernel tracer](#building) if you want to enable [kernel](https://lttng.org/docs/v2.13/#doc-tracing-the-linux-kernel) events (using the `-k`/`--kernel-events` option) or syscalls (using the `--syscalls` option).
 If you have installed the kernel tracer, use kernel tracing, and still encounter an error here, make sure to [add your user to the `tracing` group](#tracing).
 
 ### Launch file trace action
@@ -185,7 +185,7 @@ $ ros2 launch tracetools_launch example.launch.py
 The `Trace` action will also set the `LD_PRELOAD` environment to preload [LTTng's userspace tracing helper(s)](https://lttng.org/docs/v2.13/#doc-prebuilt-ust-helpers) if the corresponding event(s) are enabled.
 For more information, see [this example launch file](./tracetools_launch/launch/example.launch.py) and the [`Trace` action](./tracetools_launch/tracetools_launch/action.py).
 
-You must [install the kernel tracer](#building) if you want to enable kernel events (`events_kernel` in Python, `events-kernel` in XML or YAML).
+You must [install the kernel tracer](#building) if you want to enable [kernel](https://lttng.org/docs/v2.13/#doc-tracing-the-linux-kernel) events (`events_kernel` in Python, `events-kernel` in XML or YAML) or syscalls (`syscalls` in Python, XML, or YAML).
 If you have installed the kernel tracer, use kernel tracing, and still encounter an error here, make sure to [add your user to the `tracing` group](#tracing).
 
 ## Design

--- a/lttngpy/src/lttngpy/_lttngpy_pybind11.cpp
+++ b/lttngpy/src/lttngpy/_lttngpy_pybind11.cpp
@@ -130,6 +130,16 @@ PYBIND11_MODULE(_lttngpy_pybind11, m) {
     py::arg("output"));
 
   // Event
+  py::enum_<lttng_event_type>(m, "lttng_event_type")
+  .value("LTTNG_EVENT_ALL", LTTNG_EVENT_ALL)
+  .value("LTTNG_EVENT_TRACEPOINT", LTTNG_EVENT_TRACEPOINT)
+  .value("LTTNG_EVENT_PROBE", LTTNG_EVENT_PROBE)
+  .value("LTTNG_EVENT_FUNCTION", LTTNG_EVENT_FUNCTION)
+  .value("LTTNG_EVENT_FUNCTION_ENTRY", LTTNG_EVENT_FUNCTION_ENTRY)
+  .value("LTTNG_EVENT_NOOP", LTTNG_EVENT_NOOP)
+  .value("LTTNG_EVENT_SYSCALL", LTTNG_EVENT_SYSCALL)
+  .value("LTTNG_EVENT_USERSPACE_PROBE", LTTNG_EVENT_USERSPACE_PROBE)
+  .export_values();
   py::enum_<lttng_event_output>(m, "lttng_event_output")
   .value("LTTNG_EVENT_SPLICE", LTTNG_EVENT_SPLICE)
   .value("LTTNG_EVENT_MMAP", LTTNG_EVENT_MMAP)
@@ -141,6 +151,7 @@ PYBIND11_MODULE(_lttngpy_pybind11, m) {
     py::kw_only(),
     py::arg("session_name"),
     py::arg("domain_type"),
+    py::arg("event_type"),
     py::arg("channel_name"),
     py::arg("events"));
   m.def(
@@ -149,6 +160,10 @@ PYBIND11_MODULE(_lttngpy_pybind11, m) {
     "Get tracepoints.",
     py::kw_only(),
     py::arg("domain_type"));
+  m.def(
+    "get_syscalls",
+    &lttngpy::get_syscalls,
+    "Get syscalls.");
   m.def(
     "add_contexts",
     &lttngpy::add_contexts,

--- a/lttngpy/src/lttngpy/event.hpp
+++ b/lttngpy/src/lttngpy/event.hpp
@@ -30,6 +30,7 @@ namespace lttngpy
  *
  * \param session_name the session name
  * \param domain_type the domain type
+ * \param event_type the event type
  * \param channel_name the channel name
  * \param events the set of event names
  * \return 0 on success, else a negative LTTng error code
@@ -37,6 +38,7 @@ namespace lttngpy
 int enable_events(
   const std::string & session_name,
   const enum lttng_domain_type domain_type,
+  const enum lttng_event_type event_type,
   const std::string & channel_name,
   const std::set<std::string> & events);
 
@@ -48,6 +50,14 @@ int enable_events(
  *   available when providing the kernel domain)
  */
 std::variant<int, std::set<std::string>> get_tracepoints(const enum lttng_domain_type domain_type);
+
+/**
+ * Get syscalls.
+ *
+ * \return the set of syscalls, else a negative LTTng error code (e.g., if kernel tracer is not
+ *   available)
+ */
+std::variant<int, std::set<std::string>> get_syscalls();
 
 /**
  * Add contexts.

--- a/test_tracetools_launch/test/test_tracetools_launch/test_trace_action.py
+++ b/test_tracetools_launch/test/test_tracetools_launch/test_trace_action.py
@@ -102,6 +102,7 @@ class TestTraceAction(unittest.TestCase):
             session_name='my-session-name',
             base_path=tmpdir,
             events_kernel=[],
+            syscalls=[],
             events_ust=[
                 'ros2:*',
                 '*',
@@ -126,6 +127,7 @@ class TestTraceAction(unittest.TestCase):
                     base-path="{}"
                     append-trace="true"
                     events-kernel=""
+                    syscalls=""
                     events-ust="ros2:* *"
                     subbuffer-size-ust="524288"
                     subbuffer-size-kernel="1048576"
@@ -154,6 +156,7 @@ class TestTraceAction(unittest.TestCase):
                 base-path: {}
                 append-trace: true
                 events-kernel: ""
+                syscalls: ""
                 events-ust: ros2:* *
                 subbuffer-size-ust: 524288
                 subbuffer-size-kernel: 1048576
@@ -176,6 +179,7 @@ class TestTraceAction(unittest.TestCase):
             session_name='my-session-name',
             base_path=tmpdir,
             events_kernel=[],
+            syscalls=[],
             events_ust=[
                 'ros2:*',
                 '*',
@@ -193,6 +197,7 @@ class TestTraceAction(unittest.TestCase):
             session_name='my-session-name',
             base_path=tmpdir,
             events_kernel=[],
+            syscalls=[],
             events_ust=[
                 'ros2:*',
                 '*',
@@ -234,6 +239,7 @@ class TestTraceAction(unittest.TestCase):
             session_name=LaunchConfiguration(session_name_arg.name),
             base_path=TextSubstitution(text=tmpdir),
             events_kernel=[],
+            syscalls=[],
             events_ust=[
                 EnvironmentVariable(name='TestTraceAction__event_ust'),
                 TextSubstitution(text='*'),
@@ -270,6 +276,7 @@ class TestTraceAction(unittest.TestCase):
             session_name='my-session-name',
             base_path=tmpdir,
             events_kernel=[],
+            syscalls=[],
             events_ust=[
                 'lttng_ust_cyg_profile_fast:*',
                 'lttng_ust_libc:*',
@@ -323,6 +330,7 @@ class TestTraceAction(unittest.TestCase):
             append_timestamp=True,
             base_path=tmpdir,
             events_kernel=[],
+            syscalls=[],
             events_ust=[
                 'ros2:*',
                 '*',
@@ -348,6 +356,7 @@ class TestTraceAction(unittest.TestCase):
             base_path=tmpdir,
             append_trace=False,
             events_kernel=[],
+            syscalls=[],
             events_ust=[
                 'ros2:*',
                 '*',
@@ -367,6 +376,7 @@ class TestTraceAction(unittest.TestCase):
             base_path=tmpdir,
             append_trace=True,
             events_kernel=[],
+            syscalls=[],
             events_ust=[
                 'ros2:*',
                 '*',

--- a/tracetools_trace/test/tracetools_trace/test_lttng_tracing.py
+++ b/tracetools_trace/test/tracetools_trace/test_lttng_tracing.py
@@ -74,6 +74,12 @@ class TestLttngTracing(unittest.TestCase):
                     base_path='/tmp',
                     kernel_events=['sched_switch'],
                 )
+            with self.assertRaises(RuntimeError):
+                setup(
+                    session_name='test-session',
+                    base_path='/tmp',
+                    syscalls=['open'],
+                )
 
     def test_get_lttng_home(self):
         from tracetools_trace.tools.lttng_impl import get_lttng_home

--- a/tracetools_trace/tracetools_trace/tools/args.py
+++ b/tracetools_trace/tracetools_trace/tools/args.py
@@ -63,6 +63,10 @@ def _add_arguments_configure(parser: argparse.ArgumentParser) -> None:
         default=[],
         help='the kernel events to enable (default: no kernel events)')
     events_kernel_arg.completer = ArgCompleter(names.EVENTS_KERNEL)  # type: ignore
+    parser.add_argument(
+        '--syscall', nargs='*', dest='syscalls', metavar='SYSCALL',
+        default=[],
+        help='the syscalls to enable (default: no syscalls)')
     context_arg = parser.add_argument(  # type: ignore
         '-c', '--context', nargs='*', dest='context_fields', metavar='CONTEXT',
         default=names.DEFAULT_CONTEXT,

--- a/tracetools_trace/tracetools_trace/trace.py
+++ b/tracetools_trace/tracetools_trace/trace.py
@@ -40,23 +40,28 @@ def _display_info(
     *,
     ros_events: List[str],
     kernel_events: List[str],
+    syscalls: List[str],
     context_fields: List[str],
     display_list: bool,
 ) -> None:
-    ust_enabled = len(ros_events) > 0
-    kernel_enabled = len(kernel_events) > 0
-    if ust_enabled:
-        print(f'UST tracing enabled ({len(ros_events)} events)')
+    if ros_events:
+        print(f'userspace tracing enabled ({len(ros_events)} events)')
         if display_list:
             print_names_list(ros_events)
     else:
-        print('UST tracing disabled')
-    if kernel_enabled:
+        print('userspace tracing disabled')
+    if kernel_events:
         print(f'kernel tracing enabled ({len(kernel_events)} events)')
         if display_list:
             print_names_list(kernel_events)
     else:
         print('kernel tracing disabled')
+    if syscalls:
+        print(f'syscall tracing enabled ({len(syscalls)} syscalls)')
+        if display_list:
+            print_names_list(syscalls)
+    else:
+        print('syscalls tracing disabled')
     if len(context_fields) > 0:
         print(f'context ({len(context_fields)} fields)')
         if display_list:
@@ -82,6 +87,7 @@ def init(
     append_trace: bool,
     ros_events: List[str],
     kernel_events: List[str],
+    syscalls: List[str],
     context_fields: List[str],
     display_list: bool,
     interactive: bool,
@@ -101,6 +107,7 @@ def init(
         an error is reported
     :param ros_events: list of ROS events to enable
     :param kernel_events: list of kernel events to enable
+    :param syscalls: list of syscalls to enable
     :param context_fields: list of context fields to enable
     :param display_list: whether to display list(s) of enabled events and context names
     :param interactive: whether to require user interaction to start tracing
@@ -109,6 +116,7 @@ def init(
     _display_info(
         ros_events=ros_events,
         kernel_events=kernel_events,
+        syscalls=syscalls,
         context_fields=context_fields,
         display_list=display_list,
     )
@@ -126,6 +134,7 @@ def init(
         append_trace=append_trace,
         ros_events=ros_events,
         kernel_events=kernel_events,
+        syscalls=syscalls,
         context_fields=context_fields,
     )
     if trace_directory is None:
@@ -213,6 +222,7 @@ def trace(args: argparse.Namespace) -> int:
             append_trace=args.append_trace,
             ros_events=args.events_ust,
             kernel_events=args.events_kernel,
+            syscalls=args.syscalls,
             context_fields=args.context_fields,
             display_list=args.list,
             interactive=True,
@@ -241,6 +251,7 @@ def start(args: argparse.Namespace) -> int:
                 append_trace=args.append_trace,
                 ros_events=args.events_ust,
                 kernel_events=args.events_kernel,
+                syscalls=args.syscalls,
                 context_fields=args.context_fields,
                 display_list=args.list,
                 interactive=False,


### PR DESCRIPTION
This adds support for enabling syscall tracing with the `ros2 trace` command or the `Trace` launch action.

While system calls are separate from kernel events, both can be traced using the LTTng kernel tracer: https://lttng.org/docs/v2.13/#doc-tracing-the-linux-kernel. Kernel events are "tracepoints" while system calls are their own kind of trace event. This explains why this PR adds a separate option for syscalls instead of just using the kernel events option. See the changes to `lttngpy::enable_events` in `lttngpy/src/lttngpy/event.cpp`.

How to use:

1. `ros2 trace` command:
    ```
    $ ros2 trace --syscall openat  # interactive
    $ ros2 trace start my-session-name --syscall openat  # non-interactive
    ```
2. Launch files (Python, XML, and YAML): `syscalls` arg

Note that, when enabling a syscall, e.g., `openat`, the resulting trace has syscall entry and exit events: `syscall_entry_openat` and `syscall_exit_openat`.