### PR TITLE
Change expected rmw GID array size to 16 bytes

### DIFF
--- a/test_tracetools/test/test_generic_subscription.py
+++ b/test_tracetools/test/test_generic_subscription.py
@@ -66,7 +66,7 @@ class TestGenericSubscription(TraceTestCase):
 
         for event in rmw_sub_init_events:
             self.assertValidHandle(event, ['rmw_subscription_handle'])
-            self.assertValidStaticArray(event, 'gid', int, 24)
+            self.assertValidStaticArray(event, 'gid', int, 16)
         for event in rcl_sub_init_events:
             self.assertValidHandle(
                 event,

--- a/test_tracetools/test/test_publisher.py
+++ b/test_tracetools/test/test_publisher.py
@@ -47,7 +47,7 @@ class TestPublisher(TraceTestCase):
         rmw_pub_init_events = self.get_events_with_name(tp.rmw_publisher_init)
         for event in rmw_pub_init_events:
             self.assertValidHandle(event, ['rmw_publisher_handle'])
-            self.assertValidStaticArray(event, 'gid', int, 24)
+            self.assertValidStaticArray(event, 'gid', int, 16)
         pub_init_events = self.get_events_with_name(tp.rcl_publisher_init)
         for event in pub_init_events:
             self.assertValidHandle(

--- a/test_tracetools/test/test_subscription.py
+++ b/test_tracetools/test/test_subscription.py
@@ -65,7 +65,7 @@ class TestSubscription(TraceTestCase):
 
         for event in rmw_sub_init_events:
             self.assertValidHandle(event, ['rmw_subscription_handle'])
-            self.assertValidStaticArray(event, 'gid', int, 24)
+            self.assertValidStaticArray(event, 'gid', int, 16)
         for event in rcl_sub_init_events:
             self.assertValidHandle(
                 event,

--- a/tracetools/include/tracetools/tp_call.h
+++ b/tracetools/include/tracetools/tp_call.h
@@ -35,7 +35,7 @@
 #include "tracetools/version.h"
 
 /// See RMW_GID_STORAGE_SIZE in rmw.
-#define TRACETOOLS_GID_STORAGE_SIZE 24u
+#define TRACETOOLS_GID_STORAGE_SIZE 16u
 
 #ifdef __clang__
 # pragma clang diagnostic push


### PR DESCRIPTION
The size changed from 24 to 16 bytes in ros2/rmw#345. The same size is defined in `tracetools`, and it was never updated.

In practice, reading 24-16=8 random extra bytes didn't change much, since nothing is currently relying on the GID values, at least not relying on getting the same GID for the same object from two different systems, because it doesn't work with `rmw_cyclonedds`, see ros2/rmw_cyclonedds#377.