### PR TITLE
Run test_tracetools tests against rmw_zenoh_cpp

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ The following `rmw` implementations are supported:
 * `rmw_cyclonedds_cpp`
 * `rmw_fastrtps_cpp`
 * `rmw_fastrtps_dynamic_cpp`
+* `rmw_zenoh_cpp`
 
 To make sure that the instrumentation and tracepoints are available:
 

--- a/test_tracetools/CMakeLists.txt
+++ b/test_tracetools/CMakeLists.txt
@@ -235,6 +235,7 @@ if(BUILD_TESTING)
       rmw_cyclonedds_cpp
       rmw_fastrtps_cpp
       rmw_fastrtps_dynamic_cpp
+      rmw_zenoh_cpp
     )
     get_available_rmw_implementations(rmw_implementations)
     foreach(_test_path ${_test_tracetools_pytest_tests_multi_rmw})


### PR DESCRIPTION
Requires https://github.com/ros2/rmw_zenoh/pull/294

This adds `rmw_zenoh_cpp` to the allowlist of `rmw` implementations against which to run tracing tests.

Requires #159 for the Zenoh router to be started through `rmw` test isolation when running the tracing tests with `rmw_zenoh_cpp`, otherwise the tests time out.

Requires https://github.com/colcon/colcon-ros-domain-id-coordinator/pull/8 if `colcon-ros-domain-id-coordinator` is installed, otherwise `rmw` test isolation gets disabled.