### PR TITLE
Don't try to build on BSD

### DIFF
--- a/lttngpy/CMakeLists.txt
+++ b/lttngpy/CMakeLists.txt
@@ -17,7 +17,7 @@ endif()
 
 find_package(ament_cmake REQUIRED)
 
-if(WIN32 OR APPLE OR ANDROID)
+if(WIN32 OR APPLE OR ANDROID OR BSD)
   set(DISABLED_DEFAULT ON)
 else()
   set(DISABLED_DEFAULT OFF)
@@ -92,7 +92,7 @@ endif()
 
 pybind11_add_module(_lttngpy_pybind11 SHARED ${SOURCES})
 
-if(CMAKE_C_COMPILER_ID MATCHES "Clang" AND NOT APPLE)
+if(CMAKE_C_COMPILER_ID MATCHES "Clang" AND NOT APPLE AND NOT BSD)
   target_link_libraries(_lttngpy_pybind11 PRIVATE atomic)
 endif()
 

--- a/test_tracetools/CMakeLists.txt
+++ b/test_tracetools/CMakeLists.txt
@@ -13,7 +13,7 @@ endif()
 
 find_package(ament_cmake REQUIRED)
 
-if(WIN32 OR APPLE OR ANDROID)
+if(WIN32 OR APPLE OR ANDROID OR BSD)
   set(DISABLED_DEFAULT ON)
 else()
   set(DISABLED_DEFAULT OFF)

--- a/tracetools/CMakeLists.txt
+++ b/tracetools/CMakeLists.txt
@@ -16,7 +16,7 @@ endif()
 find_package(ament_cmake_gen_version_h REQUIRED)
 find_package(ament_cmake_ros REQUIRED)
 
-if(WIN32 OR APPLE OR ANDROID)
+if(WIN32 OR APPLE OR ANDROID OR BSD)
   set(DISABLED_DEFAULT ON)
   set(STATUS_CHECKING_TOOL_DEFAULT OFF)
 else()


### PR DESCRIPTION
The 'BSD' variable was [added in CMake 3.25](https://cmake.org/cmake/help/latest/variable/BSD.html). Note that variables which are not defined will evaluate to 'False', so this shouldn't regress platforms using CMake versions older than 3.25.