### PR TITLE
Refactor and split test_service into test_{service,client}

### DIFF
--- a/test_tracetools/CMakeLists.txt
+++ b/test_tracetools/CMakeLists.txt
@@ -203,6 +203,7 @@ if(BUILD_TESTING)
     # Tests to run with the default rmw implementation, which should not matter
     set(_test_tracetools_pytest_tests
       test/test_buffer.py
+      test/test_client.py
       test/test_executor.py
       test/test_intra.py
       test/test_intra_pub_sub.py

--- a/test_tracetools/src/test_service_ping.cpp
+++ b/test_tracetools/src/test_service_ping.cpp
@@ -19,71 +19,33 @@
 #include "std_srvs/srv/empty.hpp"
 #include "test_tracetools/mark_process.hpp"
 
-using namespace std::chrono_literals;
-
-#define NODE_NAME "test_service_ping"
-#define SERVICE_NAME "pong"
-#define CLIENT_NAME "ping"
-
-class PingNode : public rclcpp::Node
-{
-public:
-  explicit PingNode(rclcpp::NodeOptions options)
-  : Node(NODE_NAME, options)
-  {
-    srv_ = this->create_service<std_srvs::srv::Empty>(
-      SERVICE_NAME,
-      std::bind(
-        &PingNode::service_callback,
-        this,
-        std::placeholders::_1,
-        std::placeholders::_2,
-        std::placeholders::_3));
-    client_ = this->create_client<std_srvs::srv::Empty>(
-      CLIENT_NAME);
-    timer_ = this->create_wall_timer(
-      500ms,
-      std::bind(&PingNode::timer_callback, this));
-  }
-
-private:
-  void service_callback(
-    const std::shared_ptr<rmw_request_id_t> request_header,
-    const std::shared_ptr<std_srvs::srv::Empty::Request> request,
-    const std::shared_ptr<std_srvs::srv::Empty::Response> response)
-  {
-    (void)request_header;
-    (void)request;
-    (void)response;
-    RCLCPP_INFO(this->get_logger(), "got request");
-    rclcpp::shutdown();
-  }
-
-  void timer_callback()
-  {
-    auto req = std::make_shared<std_srvs::srv::Empty::Request>();
-    client_->async_send_request(req);
-  }
-
-  rclcpp::Service<std_srvs::srv::Empty>::SharedPtr srv_;
-  rclcpp::Client<std_srvs::srv::Empty>::SharedPtr client_;
-  rclcpp::TimerBase::SharedPtr timer_;
-};
-
 int main(int argc, char * argv[])
 {
   test_tracetools::mark_trace_test_process();
 
   rclcpp::init(argc, argv);
 
-  rclcpp::executors::SingleThreadedExecutor exec;
-  auto ping_node = std::make_shared<PingNode>(rclcpp::NodeOptions());
-  exec.add_node(ping_node);
+  auto node = rclcpp::Node::make_shared("test_service_ping");
 
-  printf("spinning\n");
-  exec.spin();
+  auto client = node->create_client<std_srvs::srv::Empty>("ping");
+  RCLCPP_INFO(node->get_logger(), "waiting for service");
+  while (!client->wait_for_service(std::chrono::seconds(10))) {
+    if (!rclcpp::ok()) {
+      return 1;
+    }
+  }
 
-  // Will actually be called inside the node's service callback
+  auto request = std::make_shared<std_srvs::srv::Empty::Request>();
+  auto result_future = client->async_send_request(request);
+  RCLCPP_INFO(node->get_logger(), "sent request");
+  if (rclcpp::spin_until_future_complete(node, result_future) !=
+    rclcpp::FutureReturnCode::SUCCESS)
+  {
+    client->remove_pending_request(result_future);
+    return 1;
+  }
+  auto result = result_future.get();
+  RCLCPP_INFO(node->get_logger(), "got response");
   rclcpp::shutdown();
   return 0;
 }

--- a/test_tracetools/test/test_client.py
+++ b/test_tracetools/test/test_client.py
@@ -1,0 +1,76 @@
+# Copyright 2024 Apex.AI, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+from tracetools_test.case import TraceTestCase
+from tracetools_trace.tools import tracepoints as tp
+from tracetools_trace.tools.lttng import is_lttng_installed
+
+
+@unittest.skipIf(not is_lttng_installed(minimum_version='2.9.0'), 'LTTng is required')
+class TestClient(TraceTestCase):
+
+    def __init__(self, *args) -> None:
+        super().__init__(
+            *args,
+            session_name_prefix='session-test-client',
+            events_ros=[
+                tp.rcl_node_init,
+                tp.rcl_client_init,
+            ],
+            package='test_tracetools',
+            nodes=['test_service_ping', 'test_service_pong'],
+        )
+
+    def test_all(self):
+        # Check events as set
+        self.assertEventsSet(self._events_ros)
+
+        # Check fields
+        client_init_events = self.get_events_with_name(tp.rcl_client_init)
+
+        for event in client_init_events:
+            self.assertValidHandle(event, ['client_handle', 'node_handle', 'rmw_client_handle'])
+            self.assertStringFieldNotEmpty(event, 'service_name')
+
+        # Find node event
+        node_init_events = self.get_events_with_name(tp.rcl_node_init)
+        # The test_service_ping node is the one that has the client
+        test_node_init_event = self.get_event_with_field_value_and_assert(
+            'node_name',
+            'test_service_ping',
+            node_init_events,
+            allow_multiple=False,
+        )
+        node_handle = self.get_field(test_node_init_event, 'node_handle')
+
+        # Find client init event and check that the node handle matches
+        test_client_init_event = self.get_event_with_field_value_and_assert(
+            'service_name',
+            '/ping',
+            client_init_events,
+            allow_multiple=False,
+        )
+        self.assertFieldEquals(test_client_init_event, 'node_handle', node_handle)
+
+        # Check events order
+        self.assertEventOrder([
+            test_node_init_event,
+            test_client_init_event,
+        ])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test_tracetools/test/test_service.py
+++ b/test_tracetools/test/test_service.py
@@ -46,8 +46,8 @@ class TestService(TraceTestCase):
         srv_init_events = self.get_events_with_name(tp.rcl_service_init)
         callback_added_events = self.get_events_with_name(tp.rclcpp_service_callback_added)
         callback_register_events = self.get_events_with_name(tp.rclcpp_callback_register)
-        start_events = self.get_events_with_name(tp.callback_start)
-        end_events = self.get_events_with_name(tp.callback_end)
+        callback_start_events = self.get_events_with_name(tp.callback_start)
+        callback_end_events = self.get_events_with_name(tp.callback_end)
 
         for event in srv_init_events:
             self.assertValidHandle(event, ['service_handle', 'node_handle', 'rmw_service_handle'])
@@ -57,147 +57,74 @@ class TestService(TraceTestCase):
         for event in callback_register_events:
             self.assertValidPointer(event, 'callback')
             self.assertStringFieldNotEmpty(event, 'symbol')
-        for event in start_events:
+        for event in callback_start_events:
             self.assertValidHandle(event, 'callback')
             # Should not be 1 for services (yet)
             self.assertFieldEquals(event, 'is_intra_process', 0)
-        for event in end_events:
+        for event in callback_end_events:
             self.assertValidHandle(event, 'callback')
 
-        # Check that the test services names exists
-        ping_node_srv_init_events = self.get_events_with_procname(
-            'test_service_ping',
-            srv_init_events,
-        )
-        ping_node_test_srv_init_event = self.get_event_with_field_value_and_assert(
-            'service_name',
-            '/pong',
-            ping_node_srv_init_events,
+        # Find node event
+        node_init_events = self.get_events_with_name(tp.rcl_node_init)
+        # The test_service_pong node is the one that has the service (server)
+        test_node_init_event = self.get_event_with_field_value_and_assert(
+            'node_name',
+            'test_service_pong',
+            node_init_events,
             allow_multiple=False,
         )
+        node_handle = self.get_field(test_node_init_event, 'node_handle')
 
-        pong_node_srv_init_events = self.get_events_with_procname(
-            'test_service_pong',
-            srv_init_events,
-        )
-        pong_node_test_srv_init_event = self.get_event_with_field_value_and_assert(
+        # Find service init event and check that the node handle matches
+        test_srv_init_event = self.get_event_with_field_value_and_assert(
             'service_name',
             '/ping',
-            pong_node_srv_init_events,
-            allow_multiple=True,
-        )
-
-        # Check that the service init events have a matching node handle (with node_init events)
-        node_init_events = self.get_events_with_name(tp.rcl_node_init)
-
-        self.assertMatchingField(
-            ping_node_test_srv_init_event,
-            'node_handle',
-            None,
-            node_init_events,
-            False,
-        )
-
-        self.assertMatchingField(
-            pong_node_test_srv_init_event,
-            'node_handle',
-            None,
-            node_init_events,
-            False,
-        )
-
-        # Check that there are matching rclcpp_service_callback_added events
-        ping_node_test_service_handle = self.get_field(
-            ping_node_test_srv_init_event,
-            'service_handle',
-        )
-        pong_node_test_service_handle = self.get_field(
-            pong_node_test_srv_init_event,
-            'service_handle',
-        )
-
-        ping_node_srv_callback_added_events = self.get_events_with_procname(
-            'test_service_ping',
-            callback_added_events,
-        )
-        ping_node_test_srv_callback_added_event = self.get_event_with_field_value_and_assert(
-            'service_handle',
-            ping_node_test_service_handle,
-            ping_node_srv_callback_added_events,
+            srv_init_events,
             allow_multiple=False,
         )
+        self.assertFieldEquals(test_srv_init_event, 'node_handle', node_handle)
 
-        pong_node_srv_callback_added_events = self.get_events_with_procname(
-            'test_service_pong',
-            callback_added_events,
-        )
-        pong_node_test_srv_callback_added_event = self.get_event_with_field_value_and_assert(
+        # Check that there is a matching rclcpp_service_callback_added event
+        service_handle = self.get_field(test_srv_init_event, 'service_handle')
+        test_srv_callback_added_event = self.get_event_with_field_value_and_assert(
             'service_handle',
-            pong_node_test_service_handle,
-            pong_node_srv_callback_added_events,
+            service_handle,
+            callback_added_events,
             allow_multiple=False,
         )
 
         # Check that there are matching rclcpp_callback_register events
-        ping_node_test_callback_ref = self.get_field(
-            ping_node_test_srv_callback_added_event,
+        callback_ref = self.get_field(test_srv_callback_added_event, 'callback')
+        test_callback_register_event = self.get_event_with_field_value_and_assert(
             'callback',
-        )
-        pong_node_test_callback_ref = self.get_field(
-            pong_node_test_srv_callback_added_event,
-            'callback',
-        )
-
-        ping_node_callback_register_events = self.get_events_with_procname(
-            'test_service_ping',
+            callback_ref,
             callback_register_events,
+            allow_multiple=False,
         )
-        ping_node_test_callback_register_events = self.get_events_with_field_value(
-            'callback',
-            ping_node_test_callback_ref,
-            ping_node_callback_register_events,
-        )
-        self.assertNumEventsEqual(ping_node_test_callback_register_events, 1)
-
-        pong_node_callback_register_events = self.get_events_with_procname(
-            'test_service_pong',
-            callback_register_events,
-        )
-        pong_node_test_callback_register_events = self.get_events_with_field_value(
-            'callback',
-            pong_node_test_callback_ref,
-            pong_node_callback_register_events,
-        )
-        self.assertNumEventsEqual(pong_node_test_callback_register_events, 1)
 
         # Check that there are corresponding callback_start/stop pairs
-        ping_node_test_callback_start_events = self.get_events_with_field_value(
+        test_callback_start_event = self.get_event_with_field_value_and_assert(
             'callback',
-            ping_node_test_callback_ref,
-            start_events,
+            callback_ref,
+            callback_start_events,
+            allow_multiple=False,
         )
-        self.assertNumEventsEqual(ping_node_test_callback_start_events, 1)
+        test_callback_end_event = self.get_event_with_field_value_and_assert(
+            'callback',
+            callback_ref,
+            callback_end_events,
+            allow_multiple=False,
+        )
 
-        pong_node_test_callback_start_events = self.get_events_with_field_value(
-            'callback',
-            pong_node_test_callback_ref,
-            start_events,
-        )
-        self.assertNumEventsEqual(pong_node_test_callback_start_events, 1)
-
-        ping_node_test_callback_end_events = self.get_events_with_field_value(
-            'callback',
-            ping_node_test_callback_ref,
-            end_events,
-        )
-        self.assertNumEventsEqual(ping_node_test_callback_end_events, 1)
-
-        pong_node_test_callback_end_events = self.get_events_with_field_value(
-            'callback',
-            pong_node_test_callback_ref,
-            end_events,
-        )
-        self.assertNumEventsEqual(pong_node_test_callback_end_events, 1)
+        # Check events order
+        self.assertEventOrder([
+            test_node_init_event,
+            test_srv_init_event,
+            test_srv_callback_added_event,
+            test_callback_register_event,
+            test_callback_start_event,
+            test_callback_end_event,
+        ])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The service/client instrumentation isn't currently complete (see #143), so the `test_service` tracing test wasn't really maintained. To be more in line with other tests:

1. Modify the `test_service_ping` and `test_service_pong` test nodes to have only 1 client in the `test_sevice_ping` node and only 1 service in the `test_service_pong` node. The goal is simply to get a ping->pong communication and then shut down. Therefore, unlike pubs/subs, we only need 1 pair of client/service: we can simply do a request->response. Also, simplify the code a bit.
2. Change `test_service.py` to only assert service-related events; nothing client-related. This is more in line with `test_publisher.py`/`test_subscription.py`.
3. Add `test_client.py` and only assert client-related events; nothing service-related. This means that the test is quite simple.

Requires https://github.com/ros2/rclcpp/pull/2670 to fix a missing tracepoint trigger.

---

action-ros-ci-repos-override: https://gist.githubusercontent.com/christophebedard/49dc900164d67c8bc994a9104e7fd0b1/raw/fb5b5ef110c38880fd5ce71a21102e0776343058/ros2.repos