### PR TITLE
Add python3-dev build_depend to lttngpy.

### DIFF
--- a/lttngpy/package.xml
+++ b/lttngpy/package.xml
@@ -17,6 +17,7 @@
   <depend>liblttng-ctl-dev</depend>
 
   <build_depend>pybind11_vendor</build_depend>
+  <build_depend>python3-dev</build_depend>
 
   <exec_depend>rpyutils</exec_depend>
 


### PR DESCRIPTION
This is needed because the CMakeLists.txt file for this package does:

find_package(Python3 REQUIRED COMPONENTS Interpreter Development)

Otherwise, it may fail to build on certain platforms on the buildfarm (like RHEL-9).

I believe this will fix the failing build in https://build.ros2.org/view/Rbin_rhel_el964/job/Rbin_rhel_el964__lttngpy__rhel_9_x86_64__binary/