### PR TITLE
Remove SHARED from pybind11_add_module

### DIFF
--- a/lttngpy/CMakeLists.txt
+++ b/lttngpy/CMakeLists.txt
@@ -90,7 +90,7 @@ if(NOT LTTNGPY_DISABLED)
   )
 endif()
 
-pybind11_add_module(_lttngpy_pybind11 SHARED ${SOURCES})
+pybind11_add_module(_lttngpy_pybind11 ${SOURCES})
 
 if(CMAKE_C_COMPILER_ID MATCHES "Clang" AND NOT APPLE AND NOT BSD)
   target_link_libraries(_lttngpy_pybind11 PRIVATE atomic)


### PR DESCRIPTION
See https://github.com/ros2/rclpy/pull/1305 and https://github.com/ros2/rclpy/pull/1418 for more context.

In a nutshell, passing `SHARED` to `pybind11_add_module` results in a segfault on macOS on Python with libpython statically linked, as the python package shipped by conda-forge.