### PR TITLE
Set envars to run tests with rmw_zenoh_cpp with multicast discovery

### DIFF
--- a/test_tracetools/CMakeLists.txt
+++ b/test_tracetools/CMakeLists.txt
@@ -235,14 +235,28 @@ if(BUILD_TESTING)
       rmw_cyclonedds_cpp
       rmw_fastrtps_cpp
       rmw_fastrtps_dynamic_cpp
+      rmw_zenoh_cpp
     )
     get_available_rmw_implementations(rmw_implementations)
     foreach(_test_path ${_test_tracetools_pytest_tests_multi_rmw})
       get_filename_component(_test_name ${_test_path} NAME_WE)
       foreach(rmw_implementation ${_test_tracetools_rmw_implementations})
         if(rmw_implementation IN_LIST rmw_implementations)
+
+          # If the rmw_implementation is rmw_zenoh_cpp, run the tests with
+          # multicast discovery enabled.
+          if(rmw_implementation STREQUAL "rmw_zenoh_cpp")
+            list(APPEND rmw_implementation_env_var
+              ZENOH_ROUTER_CHECK_ATTEMPTS=-1
+              ZENOH_CONFIG_OVERRIDE=scouting/multicast/enabled=true
+              RUST_LOG=z=error
+            )
+          endif()
+
           ament_add_pytest_test(${_test_name}__${rmw_implementation} ${_test_path}
-            ENV RMW_IMPLEMENTATION=${rmw_implementation}
+            ENV
+              RMW_IMPLEMENTATION=${rmw_implementation}
+              ${rmw_implementation_env_var}
             APPEND_ENV PYTHONPATH=${CMAKE_CURRENT_BINARY_DIR}
             TIMEOUT 60
             WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}


### PR DESCRIPTION
 See https://github.com/ros2/rmw_zenoh/issues/567

To test this PR, we can run the usual CI jobs to show there are no regressions and additionally run a CI job with a copy of the ros2.repos file from https://github.com/ros2/ros2/pull/1649 with CI Scripts branch set to yadu/cargo