### PR TITLE
Some features added to live tracing session.

### DIFF
--- a/lttngpy/src/lttngpy/_lttngpy_pybind11.cpp
+++ b/lttngpy/src/lttngpy/_lttngpy_pybind11.cpp
@@ -69,7 +69,7 @@ PYBIND11_MODULE(_lttngpy_pybind11, m) {
   m.def(
     "lttng_create_session_live",
     &lttng_create_session_live,
-    "Create session.",
+    "Create live session.",
     py::kw_only(),
     py::arg("session_name"),
     py::arg("url"),

--- a/lttngpy/test/test_session.py
+++ b/lttngpy/test/test_session.py
@@ -60,8 +60,37 @@ class TestSession(unittest.TestCase):
         shutil.rmtree(tmpdir)
 
     def test_session_live_list_create_start_stop_destroy(self):
-        # TODO(christophebedard): add test for lttngpy.lttng_create_session_live()
-        pass
+        session_name = 'test_session_live_list_create_start_stop_destroy'
+        tmpdir = self.create_test_tmpdir(session_name)
+
+        self.assertSetEqual(set(), lttngpy.get_session_names())
+        self.assertEqual(0, lttngpy.lttng_create_session_live(session_name=session_name, url=None, timer_interval=1000000))
+        self.assertSetEqual({session_name}, lttngpy.get_session_names())
+        self.assertEqual(
+            0,
+            lttngpy.enable_channel(
+                session_name=session_name,
+                domain_type=lttngpy.LTTNG_DOMAIN_UST,
+                buffer_type=lttngpy.LTTNG_BUFFER_PER_UID,
+                channel_name='dummy_channel_live',
+                overwrite=None,
+                subbuf_size=None,
+                num_subbuf=None,
+                switch_timer_interval=None,
+                read_timer_interval=None,
+                output=None,
+            ),
+        )
+        self.assertEqual(0, lttngpy.lttng_start_tracing(session_name=session_name))
+        self.assertEqual(0, lttngpy.lttng_stop_tracing(session_name=session_name))
+        self.assertEqual(0, lttngpy.lttng_destroy_session(session_name=session_name))
+        self.assertSetEqual(set(), lttngpy.get_session_names())
+
+        self.assertEqual(0, lttngpy.lttng_create_session_live(session_name=session_name, url=None, timer_interval=1000000))
+        self.assertEqual(0, lttngpy.destroy_all_sessions())
+        self.assertSetEqual(set(), lttngpy.get_session_names())
+
+        shutil.rmtree(tmpdir)
 
     def test_error(self):
         session_name = 'test_error'

--- a/lttngpy/test/test_session.py
+++ b/lttngpy/test/test_session.py
@@ -64,7 +64,12 @@ class TestSession(unittest.TestCase):
         tmpdir = self.create_test_tmpdir(session_name)
 
         self.assertSetEqual(set(), lttngpy.get_session_names())
-        self.assertEqual(0, lttngpy.lttng_create_session_live(session_name=session_name, url=None, timer_interval=1000000))
+        result = lttngpy.lttng_create_session_live(
+            session_name=session_name,
+            url=None,
+            timer_interval=1000000
+        )
+        self.assertEqual(0, result)
         self.assertSetEqual({session_name}, lttngpy.get_session_names())
         self.assertEqual(
             0,
@@ -86,7 +91,12 @@ class TestSession(unittest.TestCase):
         self.assertEqual(0, lttngpy.lttng_destroy_session(session_name=session_name))
         self.assertSetEqual(set(), lttngpy.get_session_names())
 
-        self.assertEqual(0, lttngpy.lttng_create_session_live(session_name=session_name, url=None, timer_interval=1000000))
+        result = lttngpy.lttng_create_session_live(
+            session_name=session_name,
+            url=None,
+            timer_interval=1000000
+        )
+        self.assertEqual(0, result)
         self.assertEqual(0, lttngpy.destroy_all_sessions())
         self.assertSetEqual(set(), lttngpy.get_session_names())
 

--- a/tracetools_trace/tracetools_trace/tools/args.py
+++ b/tracetools_trace/tracetools_trace/tools/args.py
@@ -80,21 +80,14 @@ def _add_arguments_configure(parser: argparse.ArgumentParser) -> None:
     parser.add_argument(
         '-a', '--append-trace', dest='append_trace', action='store_true',
         help='append to trace if it already exists, otherwise error out (default: %(default)s)')
-    # parser.add_argument(
-    #     '--live', dest='live_timer_interval', type=int, nargs='?',
-    #     # Default value for 'lttng create-session --live':
-    #     # https://lttng.org/man/1/lttng-create/v2.13/#doc-opt--live
-    #     default=1000000,
-    #     help='TODO (default: %(default)s)')
     parser.add_argument(
-        '--live', dest='live_mode', action='store_true',
-        help='Enable live mode (default: %(default)s)')
-    parser.add_argument(
-        '--live-timer-interval', dest='live_timer_interval', type=int,
-        default=100000,
+        '--live', dest='live_timer_interval', type=int, nargs='?',
+        # Default value for 'lttng create-session --live':
+        # https://lttng.org/man/1/lttng-create/v2.13/#doc-opt--live
+        const=100000,
         help='Set the live timer interval (default: %(default)s)')
     parser.add_argument(
-        '--live-tracing-url-origin', dest='live_tracing_url_origin', type=str,
+        '--live-url', dest='live_url', type=str,
         default='net://localhost',
         help='Set the live tracing URL origin (default: %(default)s)')
 

--- a/tracetools_trace/tracetools_trace/tools/args.py
+++ b/tracetools_trace/tracetools_trace/tools/args.py
@@ -95,8 +95,9 @@ def _add_arguments_configure(parser: argparse.ArgumentParser) -> None:
         help='Set the live timer interval (default: %(default)s)')
     parser.add_argument(
         '--live-tracing-url-origin', dest='live_tracing_url_origin', type=str,
-        default="net://localhost",
+        default='net://localhost',
         help='Set the live tracing URL origin (default: %(default)s)')
+
 
 def _add_arguments_default_session_name(parser: argparse.ArgumentParser) -> None:
     parser.add_argument(

--- a/tracetools_trace/tracetools_trace/tools/args.py
+++ b/tracetools_trace/tracetools_trace/tools/args.py
@@ -85,7 +85,8 @@ def _add_arguments_configure(parser: argparse.ArgumentParser) -> None:
         # Default value for 'lttng create-session --live':
         # https://lttng.org/man/1/lttng-create/v2.13/#doc-opt--live
         const=100000,
-        help='Set the live timer interval (default: %(default)s)')
+        help='Create a live tracing session. Optionally set the live timer interval '
+             '(default: %(default)s)')
     parser.add_argument(
         '--live-url', dest='live_url', type=str,
         default='net://localhost',

--- a/tracetools_trace/tracetools_trace/tools/args.py
+++ b/tracetools_trace/tracetools_trace/tools/args.py
@@ -80,13 +80,23 @@ def _add_arguments_configure(parser: argparse.ArgumentParser) -> None:
     parser.add_argument(
         '-a', '--append-trace', dest='append_trace', action='store_true',
         help='append to trace if it already exists, otherwise error out (default: %(default)s)')
+    # parser.add_argument(
+    #     '--live', dest='live_timer_interval', type=int, nargs='?',
+    #     # Default value for 'lttng create-session --live':
+    #     # https://lttng.org/man/1/lttng-create/v2.13/#doc-opt--live
+    #     default=1000000,
+    #     help='TODO (default: %(default)s)')
     parser.add_argument(
-        '--live', dest='live_timer_interval', type=int, nargs='?',
-        # Default value for 'lttng create-session --live':
-        # https://lttng.org/man/1/lttng-create/v2.13/#doc-opt--live
-        default=1000000,
-        help='TODO (default: %(default)s)')
-
+        '--live', dest='live_mode', action='store_true',
+        help='Enable live mode (default: %(default)s)')
+    parser.add_argument(
+        '--live-timer-interval', dest='live_timer_interval', type=int,
+        default=100000,
+        help='Set the live timer interval (default: %(default)s)')
+    parser.add_argument(
+        '--live-tracing-url-origin', dest='live_tracing_url_origin', type=str,
+        default="net://localhost",
+        help='Set the live tracing URL origin (default: %(default)s)')
 
 def _add_arguments_default_session_name(parser: argparse.ArgumentParser) -> None:
     parser.add_argument(

--- a/tracetools_trace/tracetools_trace/tools/lttng_impl.py
+++ b/tracetools_trace/tracetools_trace/tools/lttng_impl.py
@@ -193,10 +193,10 @@ def setup(
     :param subbuffer_size_kernel: the size of the subbuffers for kernel events (defaults to 32
         times the usual page size, since there can be way more kernel events than UST events)
     :param live_timer_interval: the time interval at which the data should be flushed from the
-        buffer and sent to the LTTng relay. This is in microseconds.
-        Used only if live_timer_interval is `True`.
-    :param live_url: the URL to which the tracing output will be sent.
-        Used only if live_timer_interval is `True`.
+        buffer and sent to the LTTng relay daemon. This is in microseconds.
+        The created tracing session will be in live mode if this value is not `None`.
+    :param live_url: the URL of the relay daemon to which the tracing output will be sent.
+        Used only if live_timer_interval is not `None`.
     :return: the full path to the trace directory, or `None` if initialization failed
     """
     # Validate parameters
@@ -258,11 +258,7 @@ def setup(
             full_path=full_path,
         )
     else:
-        # TODO(christophebedard): do we need to join the
-        #   base_path with session_name for a live session?
-        #   We need to return a path, so maybe format it like:
-        #   "net://localhost/host/$hostname/$session_name"
-        live_tracing_url =  'net://localhost/host/' + socket.gethostname() + '/' + session_name
+        live_tracing_url = f'{live_url}/host/{socket.gethostname()}/{session_name}'
         full_path = live_tracing_url
         _create_session_live(
             session_name=session_name,
@@ -458,9 +454,6 @@ def _create_session_live(
     """
     result = lttngpy.lttng_create_session_live(
         session_name=session_name,
-        # TODO(christophebedard): figure out what to provide here as the URL
-        #   This depends on how we expect users to use live tracing
-        #   See the documentation for the url param of lttng_create_session_live()
         url=url,
         timer_interval=timer_interval,
     )

--- a/tracetools_trace/tracetools_trace/tools/lttng_impl.py
+++ b/tracetools_trace/tracetools_trace/tools/lttng_impl.py
@@ -18,6 +18,7 @@
 import os
 import shlex
 import subprocess
+import socket
 from typing import Dict
 from typing import List
 from typing import Optional
@@ -157,7 +158,9 @@ def setup(
     channel_name_kernel: str = 'kchan',
     subbuffer_size_ust: int = 8 * 4096,
     subbuffer_size_kernel: int = 32 * 4096,
+    live_mode: Optional[bool] = False,
     live_timer_interval: Optional[int] = None,
+    live_tracing_url_origin: Optional[str] = None,
 ) -> Optional[str]:
     """
     Set up LTTng session, with events and context.
@@ -190,6 +193,10 @@ def setup(
         the usual page size)
     :param subbuffer_size_kernel: the size of the subbuffers for kernel events (defaults to 32
         times the usual page size, since there can be way more kernel events than UST events)
+    :param live_mode: whether to create a live session
+    :param live_timer_interval: the time interval at which the data should be flushed from the
+        buffer and sent to the LTTng relay. This is in microseconds. Used only if live_mode is `True`.
+    :param live_tracing_url_origin: the URL to which the tracing output will be sent. Used only if live_mode is `True`.
     :return: the full path to the trace directory, or `None` if initialization failed
     """
     # Validate parameters
@@ -199,6 +206,7 @@ def setup(
     # TODO(christophebedard): do we need to join the base_path with session_name for a live session?
     #   We need to return a path, so maybe format it like:
     #   "net://localhost/host/$hostname/$session_name"
+    live_tracing_url = live_tracing_url_origin + '/' + 'host/' + socket.gethostname() + '/' + session_name
     full_path = os.path.join(base_path, session_name)
     if os.path.isdir(full_path) and not append_trace:
         raise RuntimeError(
@@ -247,7 +255,7 @@ def setup(
         raise RuntimeError('no events enabled')
 
     # Create session
-    if live_timer_interval is None:
+    if not live_mode:
         # LTTng will create the parent directories if needed
         _create_session(
             session_name=session_name,
@@ -256,7 +264,7 @@ def setup(
     else:
         _create_session_live(
             session_name=session_name,
-            full_path=full_path,
+            live_tracing_url_origin=live_tracing_url_origin,
             timer_interval=live_timer_interval,
         )
 
@@ -342,6 +350,9 @@ def setup(
             context_fields=contexts_dict.get(domain),
         )
 
+    if live_mode:
+        # TODO(suchetanrs) is there a better way to do this?
+        full_path = live_tracing_url
     return full_path
 
 
@@ -440,7 +451,7 @@ def _create_session(
 def _create_session_live(
     *,
     session_name: str,
-    full_path: str,
+    live_tracing_url_origin: str,
     timer_interval: int,
 ) -> None:
     """
@@ -451,7 +462,7 @@ def _create_session_live(
         # TODO(christophebedard): figure out what to provide here as the URL
         #   This depends on how we expect users to use live tracing
         #   See the documentation for the url param of lttng_create_session_live()
-        url=None,
+        url=live_tracing_url_origin,
         timer_interval=timer_interval,
     )
     if result < 0:

--- a/tracetools_trace/tracetools_trace/tools/lttng_impl.py
+++ b/tracetools_trace/tracetools_trace/tools/lttng_impl.py
@@ -158,9 +158,8 @@ def setup(
     channel_name_kernel: str = 'kchan',
     subbuffer_size_ust: int = 8 * 4096,
     subbuffer_size_kernel: int = 32 * 4096,
-    live_mode: Optional[bool] = False,
     live_timer_interval: Optional[int] = None,
-    live_tracing_url_origin: Optional[str] = None,
+    live_url: Optional[str] = None,
 ) -> Optional[str]:
     """
     Set up LTTng session, with events and context.
@@ -193,31 +192,16 @@ def setup(
         the usual page size)
     :param subbuffer_size_kernel: the size of the subbuffers for kernel events (defaults to 32
         times the usual page size, since there can be way more kernel events than UST events)
-    :param live_mode: whether to create a live session
     :param live_timer_interval: the time interval at which the data should be flushed from the
         buffer and sent to the LTTng relay. This is in microseconds.
-        Used only if live_mode is `True`.
-    :param live_tracing_url_origin: the URL to which the tracing output will be sent.
-        Used only if live_mode is `True`.
+        Used only if live_timer_interval is `True`.
+    :param live_url: the URL to which the tracing output will be sent.
+        Used only if live_timer_interval is `True`.
     :return: the full path to the trace directory, or `None` if initialization failed
     """
     # Validate parameters
     if not session_name:
         raise RuntimeError('empty session name')
-    # Resolve full tracing directory path
-    # TODO(christophebedard): do we need to join the
-    #   base_path with session_name for a live session?
-    #   We need to return a path, so maybe format it like:
-    #   "net://localhost/host/$hostname/$session_name"
-    live_tracing_url = (
-        live_tracing_url_origin + '/' +
-        'host/' + socket.gethostname() + '/' +
-        session_name
-    )
-    full_path = os.path.join(base_path, session_name)
-    if os.path.isdir(full_path) and not append_trace:
-        raise RuntimeError(
-            f'trace directory already exists, use the append option to append to it: {full_path}')
 
     # If there is no session daemon running, try to spawn one
     if is_session_daemon_not_alive():
@@ -262,16 +246,27 @@ def setup(
         raise RuntimeError('no events enabled')
 
     # Create session
-    if not live_mode:
+    if not live_timer_interval:
+        # Resolve full tracing directory path
+        full_path = os.path.join(base_path, session_name)
+        if os.path.isdir(full_path) and not append_trace:
+            raise RuntimeError(
+                f'trace directory already exists, use the append option to append to it: {full_path}')
         # LTTng will create the parent directories if needed
         _create_session(
             session_name=session_name,
             full_path=full_path,
         )
     else:
+        # TODO(christophebedard): do we need to join the
+        #   base_path with session_name for a live session?
+        #   We need to return a path, so maybe format it like:
+        #   "net://localhost/host/$hostname/$session_name"
+        live_tracing_url =  'net://localhost/host/' + socket.gethostname() + '/' + session_name
+        full_path = live_tracing_url
         _create_session_live(
             session_name=session_name,
-            live_tracing_url_origin=live_tracing_url_origin,
+            url=live_url,
             timer_interval=live_timer_interval,
         )
 
@@ -357,9 +352,6 @@ def setup(
             context_fields=contexts_dict.get(domain),
         )
 
-    if live_mode:
-        # TODO(suchetanrs) is there a better way to do this?
-        full_path = live_tracing_url
     return full_path
 
 
@@ -458,7 +450,7 @@ def _create_session(
 def _create_session_live(
     *,
     session_name: str,
-    live_tracing_url_origin: str,
+    url: str,
     timer_interval: int,
 ) -> None:
     """
@@ -469,7 +461,7 @@ def _create_session_live(
         # TODO(christophebedard): figure out what to provide here as the URL
         #   This depends on how we expect users to use live tracing
         #   See the documentation for the url param of lttng_create_session_live()
-        url=live_tracing_url_origin,
+        url=url,
         timer_interval=timer_interval,
     )
     if result < 0:

--- a/tracetools_trace/tracetools_trace/tools/lttng_impl.py
+++ b/tracetools_trace/tracetools_trace/tools/lttng_impl.py
@@ -246,7 +246,7 @@ def setup(
         raise RuntimeError('no events enabled')
 
     # Create session
-    if not live_timer_interval:
+    if live_timer_interval is None:
         # Resolve full tracing directory path
         full_path = os.path.join(base_path, session_name)
         if os.path.isdir(full_path) and not append_trace:

--- a/tracetools_trace/tracetools_trace/tools/lttng_impl.py
+++ b/tracetools_trace/tracetools_trace/tools/lttng_impl.py
@@ -17,8 +17,8 @@
 
 import os
 import shlex
-import subprocess
 import socket
+import subprocess
 from typing import Dict
 from typing import List
 from typing import Optional
@@ -195,18 +195,25 @@ def setup(
         times the usual page size, since there can be way more kernel events than UST events)
     :param live_mode: whether to create a live session
     :param live_timer_interval: the time interval at which the data should be flushed from the
-        buffer and sent to the LTTng relay. This is in microseconds. Used only if live_mode is `True`.
-    :param live_tracing_url_origin: the URL to which the tracing output will be sent. Used only if live_mode is `True`.
+        buffer and sent to the LTTng relay. This is in microseconds.
+        Used only if live_mode is `True`.
+    :param live_tracing_url_origin: the URL to which the tracing output will be sent.
+        Used only if live_mode is `True`.
     :return: the full path to the trace directory, or `None` if initialization failed
     """
     # Validate parameters
     if not session_name:
         raise RuntimeError('empty session name')
     # Resolve full tracing directory path
-    # TODO(christophebedard): do we need to join the base_path with session_name for a live session?
+    # TODO(christophebedard): do we need to join the
+    #   base_path with session_name for a live session?
     #   We need to return a path, so maybe format it like:
     #   "net://localhost/host/$hostname/$session_name"
-    live_tracing_url = live_tracing_url_origin + '/' + 'host/' + socket.gethostname() + '/' + session_name
+    live_tracing_url = (
+        live_tracing_url_origin + '/' +
+        'host/' + socket.gethostname() + '/' +
+        session_name
+    )
     full_path = os.path.join(base_path, session_name)
     if os.path.isdir(full_path) and not append_trace:
         raise RuntimeError(

--- a/tracetools_trace/tracetools_trace/trace.py
+++ b/tracetools_trace/tracetools_trace/trace.py
@@ -89,7 +89,9 @@ def init(
     kernel_events: List[str],
     syscalls: List[str],
     context_fields: List[str],
+    live_mode: Optional[bool],
     live_timer_interval: Optional[int],
+    live_tracing_url_origin: Optional[str],
     display_list: bool,
     interactive: bool,
 ) -> bool:
@@ -137,12 +139,19 @@ def init(
         kernel_events=kernel_events,
         syscalls=syscalls,
         context_fields=context_fields,
+        live_mode=live_mode,
         live_timer_interval=live_timer_interval,
+        live_tracing_url_origin=live_tracing_url_origin,
     )
     if trace_directory is None:
         return False
     # Simple sanity check
-    assert trace_directory == full_session_path
+    print(f"Trace directory: {trace_directory}")
+    print(f"Full session path: {full_session_path}")
+    # TODO(suchetanrs): There should be a sanity check for live_mode as well. 
+    # Should there be a _resolve_url_live just like  _resolve_session_path
+    if not live_mode:
+        assert trace_directory == full_session_path
     return True
 
 
@@ -226,7 +235,9 @@ def trace(args: argparse.Namespace) -> int:
             kernel_events=args.events_kernel,
             syscalls=args.syscalls,
             context_fields=args.context_fields,
+            live_mode=args.live_mode,
             live_timer_interval=args.live_timer_interval,
+            live_tracing_url_origin=args.live_tracing_url_origin,
             display_list=args.list,
             interactive=True,
         ):
@@ -256,6 +267,9 @@ def start(args: argparse.Namespace) -> int:
                 kernel_events=args.events_kernel,
                 syscalls=args.syscalls,
                 context_fields=args.context_fields,
+                live_mode=args.live_mode,
+                live_timer_interval=args.live_timer_interval,
+                live_tracing_url_origin=args.live_tracing_url_origin,
                 display_list=args.list,
                 interactive=False,
             )

--- a/tracetools_trace/tracetools_trace/trace.py
+++ b/tracetools_trace/tracetools_trace/trace.py
@@ -137,7 +137,7 @@ def init(
         live_timer_interval=live_timer_interval,
     )
 
-    if not live_timer_interval:
+    if live_timer_interval is None:
         base_path, full_session_path = _resolve_session_path(
             session_name=session_name,
             base_path=base_path,
@@ -163,7 +163,7 @@ def init(
     if trace_directory is None:
         return False
     # Simple sanity check
-    if not live_timer_interval:
+    if live_timer_interval is None:
         assert trace_directory == full_session_path
     return True
 

--- a/tracetools_trace/tracetools_trace/trace.py
+++ b/tracetools_trace/tracetools_trace/trace.py
@@ -146,10 +146,10 @@ def init(
     if trace_directory is None:
         return False
     # Simple sanity check
-    print(f"Trace directory: {trace_directory}")
-    print(f"Full session path: {full_session_path}")
-    # TODO(suchetanrs): There should be a sanity check for live_mode as well. 
-    # Should there be a _resolve_url_live just like  _resolve_session_path
+    print(f'Trace directory: {trace_directory}')
+    print(f'Full session path: {full_session_path}')
+    # TODO(suchetanrs): There should be a sanity check for live_mode as well.
+    # Should there be a _resolve_url_live just like  _resolve_session_path?
     if not live_mode:
         assert trace_directory == full_session_path
     return True

--- a/tracetools_trace/tracetools_trace/trace.py
+++ b/tracetools_trace/tracetools_trace/trace.py
@@ -18,6 +18,7 @@
 
 import argparse
 import os
+import socket
 import sys
 from typing import Callable
 from typing import List
@@ -43,6 +44,7 @@ def _display_info(
     syscalls: List[str],
     context_fields: List[str],
     display_list: bool,
+    live_timer_interval: int = None,
 ) -> None:
     if ros_events:
         print(f'userspace tracing enabled ({len(ros_events)} events)')
@@ -66,6 +68,8 @@ def _display_info(
         print(f'context ({len(context_fields)} fields)')
         if display_list:
             print_names_list(context_fields)
+    if live_timer_interval:
+        print(f'live timer interval set to: {live_timer_interval}')
 
 
 def _resolve_session_path(
@@ -79,6 +83,15 @@ def _resolve_session_path(
     print(f'writing tracing session to: {full_session_path}')
     return base_path, full_session_path
 
+def _resolve_session_live_url(
+    *,
+    session_name: str,
+) -> str:
+    live_tracing_url = (
+        'net://localhost/host/' + socket.gethostname() + '/' +
+        session_name
+    )
+    print(f'live trace data will be sent to: {live_tracing_url} on the system running lttng-relayd')
 
 def init(
     *,
@@ -89,9 +102,8 @@ def init(
     kernel_events: List[str],
     syscalls: List[str],
     context_fields: List[str],
-    live_mode: Optional[bool],
     live_timer_interval: Optional[int],
-    live_tracing_url_origin: Optional[str],
+    live_url: Optional[str],
     display_list: bool,
     interactive: bool,
 ) -> bool:
@@ -122,12 +134,18 @@ def init(
         syscalls=syscalls,
         context_fields=context_fields,
         display_list=display_list,
+        live_timer_interval=live_timer_interval,
     )
 
-    base_path, full_session_path = _resolve_session_path(
-        session_name=session_name,
-        base_path=base_path,
-    )
+    if not live_timer_interval:
+        base_path, full_session_path = _resolve_session_path(
+            session_name=session_name,
+            base_path=base_path,
+        )
+    else:
+        full_live_url = _resolve_session_live_url(
+            session_name=session_name,
+        )
 
     if interactive:
         input('press enter to start...')
@@ -139,18 +157,13 @@ def init(
         kernel_events=kernel_events,
         syscalls=syscalls,
         context_fields=context_fields,
-        live_mode=live_mode,
         live_timer_interval=live_timer_interval,
-        live_tracing_url_origin=live_tracing_url_origin,
+        live_url=live_url,
     )
     if trace_directory is None:
         return False
     # Simple sanity check
-    print(f'Trace directory: {trace_directory}')
-    print(f'Full session path: {full_session_path}')
-    # TODO(suchetanrs): There should be a sanity check for live_mode as well.
-    # Should there be a _resolve_url_live just like  _resolve_session_path?
-    if not live_mode:
+    if not live_timer_interval:
         assert trace_directory == full_session_path
     return True
 
@@ -235,9 +248,8 @@ def trace(args: argparse.Namespace) -> int:
             kernel_events=args.events_kernel,
             syscalls=args.syscalls,
             context_fields=args.context_fields,
-            live_mode=args.live_mode,
             live_timer_interval=args.live_timer_interval,
-            live_tracing_url_origin=args.live_tracing_url_origin,
+            live_url=args.live_url,
             display_list=args.list,
             interactive=True,
         ):
@@ -267,9 +279,8 @@ def start(args: argparse.Namespace) -> int:
                 kernel_events=args.events_kernel,
                 syscalls=args.syscalls,
                 context_fields=args.context_fields,
-                live_mode=args.live_mode,
                 live_timer_interval=args.live_timer_interval,
-                live_tracing_url_origin=args.live_tracing_url_origin,
+                live_url=args.live_url,
                 display_list=args.list,
                 interactive=False,
             )

--- a/tracetools_trace/tracetools_trace/trace.py
+++ b/tracetools_trace/tracetools_trace/trace.py
@@ -85,13 +85,12 @@ def _resolve_session_path(
 
 def _resolve_session_live_url(
     *,
+    live_url: Optional[str],
     session_name: str,
 ) -> str:
-    live_tracing_url = (
-        'net://localhost/host/' + socket.gethostname() + '/' +
-        session_name
-    )
-    print(f'live trace data will be sent to: {live_tracing_url} on the system running lttng-relayd')
+    full_live_url = f'{live_url}/host/{socket.gethostname()}/{session_name}'
+    print(f'live trace data will be sent to the relay daemon at {full_live_url}')
+    return full_live_url
 
 def init(
     *,
@@ -144,6 +143,7 @@ def init(
         )
     else:
         full_live_url = _resolve_session_live_url(
+            live_url=live_url,
             session_name=session_name,
         )
 
@@ -165,6 +165,8 @@ def init(
     # Simple sanity check
     if live_timer_interval is None:
         assert trace_directory == full_session_path
+    else:
+        assert trace_directory == full_live_url
     return True
 
 


### PR DESCRIPTION
Hello! @christophebedard 

The changes in this PR are as follows:

- Add test to `lttngpy` for creating and destroying a live session
- I changed the `--live` argument and added the arguments `--live-timer-interval` and `--live-tracing-url-origin`
- Live tracing can be triggered with the `start` verb.