### PR TITLE
Removed clang warning

### DIFF
--- a/tracetools/src/status_tool.c
+++ b/tracetools/src/status_tool.c
@@ -16,7 +16,7 @@
 #include "tracetools/status.h"
 #include "tracetools/tracetools.h"
 
-int main()
+int main(void)
 {
 #ifndef TRACETOOLS_DISABLED
   return tracetools_status(ros_trace_compile_status());


### PR DESCRIPTION
Related with this clang nightly job https://ci.ros2.org/view/nightly/job/nightly_linux_clang_libcxx/2219/clang/folder.106785574/fileName.1002051409/