### PR TITLE
Fix pluralization in ros2 trace output

### DIFF
--- a/tracetools_trace/tracetools_trace/trace.py
+++ b/tracetools_trace/tracetools_trace/trace.py
@@ -45,25 +45,29 @@ def _display_info(
     display_list: bool,
 ) -> None:
     if ros_events:
-        print(f'userspace tracing enabled ({len(ros_events)} events)')
+        event_str = 'events' if len(ros_events) > 1 else 'event'
+        print(f'userspace tracing enabled ({len(ros_events)} {event_str})')
         if display_list:
             print_names_list(ros_events)
     else:
         print('userspace tracing disabled')
     if kernel_events:
-        print(f'kernel tracing enabled ({len(kernel_events)} events)')
+        event_str = 'events' if len(kernel_events) > 1 else 'event'
+        print(f'kernel tracing enabled ({len(kernel_events)} {event_str})')
         if display_list:
             print_names_list(kernel_events)
     else:
         print('kernel tracing disabled')
     if syscalls:
-        print(f'syscall tracing enabled ({len(syscalls)} syscalls)')
+        syscall_str = 'syscalls' if len(syscalls) > 1 else 'syscall'
+        print(f'syscall tracing enabled ({len(syscalls)} {syscall_str})')
         if display_list:
             print_names_list(syscalls)
     else:
         print('syscalls tracing disabled')
     if len(context_fields) > 0:
-        print(f'context ({len(context_fields)} fields)')
+        field_str = 'fields' if len(context_fields) > 1 else 'field'
+        print(f'context tracing enabled ({len(context_fields)} {field_str})')
         if display_list:
             print_names_list(context_fields)
 

--- a/tracetools_trace/tracetools_trace/trace.py
+++ b/tracetools_trace/tracetools_trace/trace.py
@@ -67,7 +67,7 @@ def _display_info(
         print('syscalls tracing disabled')
     if len(context_fields) > 0:
         field_str = 'fields' if len(context_fields) > 1 else 'field'
-        print(f'context tracing enabled ({len(context_fields)} {field_str})')
+        print(f'context ({len(context_fields)} {field_str})')
         if display_list:
             print_names_list(context_fields)
 


### PR DESCRIPTION
This PR fixes a small issue in the output of the `ros2 trace` command. Earlier, even when only one event was enabled, the terminal would display:

`userspace tracing enabled (1 events)`

This has now been updated to correctly handle singular and plural forms:

`userspace tracing enabled (1 event)`

I’ve tested this locally using a source build of ROS 2 Rolling. Attached below is the terminal output for reference.

Let me know if any changes are needed!

![Screenshot from 2025-04-25 02-45-11](https://github.com/user-attachments/assets/0161117e-3d4e-462f-bf90-a05bd3be3830)

