### PR TITLE
Update Connext version in skipped rosdep keys in GitHub actions

### DIFF
--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -76,7 +76,7 @@ jobs:
         vcs import src/ --input https://raw.githubusercontent.com/ros2/ros2/${{ matrix.distro }}/ros2.repos --skip-existing
         vcs log -l1 src/
         rosdep update
-        rosdep install -r --from-paths src --ignore-src -y --rosdistro ${{ matrix.distro }} --skip-keys "fastcdr rti-connext-dds-6.0.1 urdfdom_headers"
+        rosdep install -r --from-paths src --ignore-src -y --rosdistro ${{ matrix.distro }} --skip-keys "fastcdr rti-connext-dds-7.3.0 urdfdom_headers"
         colcon build --packages-up-to tracetools ros2run ros2launch demo_nodes_cpp tracetools_launch test_tracetools
     - name: Make sure that tracing instrumentation is available
       run: |


### PR DESCRIPTION
ROS 2 Rolling switched to version 7.3.0 (before Kilted): https://github.com/ros2/rmw_connextdds/pull/181.

This PR is similar to https://github.com/ros2/ros2_documentation/pull/5227. Just ignore the rosdep key for RTI Connext DDS 7.3.0, otherwise the job fails.