### PR TITLE
Fix Clang warnings by using proper function prototypes in macros

### DIFF
--- a/tracetools/include/tracetools/tracetools.h
+++ b/tracetools/include/tracetools/tracetools.h
@@ -46,20 +46,20 @@
 
 // *INDENT-OFF*
 #  define _TRACEPOINT_NOARGS(event_name) \
-  (ros_trace_ ## event_name)()
+  (ros_trace_ ## event_name)(void)
 #  define _TRACEPOINT_ARGS(event_name, ...) \
   (ros_trace_ ## event_name)(__VA_ARGS__)
 #  define _DO_TRACEPOINT_NOARGS(event_name) \
-  (ros_trace_do_ ## event_name)()
+  (ros_trace_do_ ## event_name)(void)
 #  define _DO_TRACEPOINT_ARGS(event_name, ...) \
   (ros_trace_do_ ## event_name)(__VA_ARGS__)
 #  define _DECLARE_TRACEPOINT_NOARGS(event_name) \
-  TRACETOOLS_PUBLIC void ros_trace_ ## event_name(); \
-  TRACETOOLS_PUBLIC bool ros_trace_enabled_ ## event_name(); \
-  TRACETOOLS_PUBLIC void ros_trace_do_ ## event_name();
+  TRACETOOLS_PUBLIC void ros_trace_ ## event_name(void); \
+  TRACETOOLS_PUBLIC bool ros_trace_enabled_ ## event_name(void); \
+  TRACETOOLS_PUBLIC void ros_trace_do_ ## event_name(void);
 #  define _DECLARE_TRACEPOINT_ARGS(event_name, ...) \
   TRACETOOLS_PUBLIC void ros_trace_ ## event_name(__VA_ARGS__); \
-  TRACETOOLS_PUBLIC bool ros_trace_enabled_ ## event_name(); \
+  TRACETOOLS_PUBLIC bool ros_trace_enabled_ ## event_name(void); \
   TRACETOOLS_PUBLIC void ros_trace_do_ ## event_name(__VA_ARGS__);
 
 #  define _GET_MACRO_TRACEPOINT(...) \
@@ -103,7 +103,7 @@
  * This is the preferred method over calling the underlying function directly.
  */
 #  define TRACETOOLS_TRACEPOINT_ENABLED(event_name) \
-  ros_trace_enabled_ ## event_name()
+  ros_trace_enabled_ ## event_name(void)
 /// Call a tracepoint, without checking if it is enabled.
 /**
  * Combine this with `TRACEPOINT_ENABLED()` to check if a tracepoint is enabled before triggering

--- a/tracetools/include/tracetools/tracetools.h
+++ b/tracetools/include/tracetools/tracetools.h
@@ -45,22 +45,28 @@
 #  define _GET_MACRO(_1, _2, _3, _4, _5, _6, _7, _8, _9, _10, NAME, ...) NAME
 
 // *INDENT-OFF*
+#  define _FUNC_TRACEPOINT(event_name) \
+  (ros_trace_ ## event_name)
+#  define _FUNC_TRACEPOINT_ENABLED(event_name) \
+  (ros_trace_enabled_ ## event_name)
+#  define _FUNC_DO_TRACEPOINT(event_name)\
+  (ros_trace_do_ ## event_name)
 #  define _TRACEPOINT_NOARGS(event_name) \
-  (ros_trace_ ## event_name)()
+  _FUNC_TRACEPOINT(event_name)()
 #  define _TRACEPOINT_ARGS(event_name, ...) \
-  (ros_trace_ ## event_name)(__VA_ARGS__)
+  _FUNC_TRACEPOINT(event_name)(__VA_ARGS__)
 #  define _DO_TRACEPOINT_NOARGS(event_name) \
-  (ros_trace_do_ ## event_name)()
+  _FUNC_DO_TRACEPOINT(event_name)()
 #  define _DO_TRACEPOINT_ARGS(event_name, ...) \
-  (ros_trace_do_ ## event_name)(__VA_ARGS__)
+  _FUNC_DO_TRACEPOINT(event_name)(__VA_ARGS__)
 #  define _DECLARE_TRACEPOINT_NOARGS(event_name) \
-  TRACETOOLS_PUBLIC void ros_trace_ ## event_name(void); \
-  TRACETOOLS_PUBLIC bool ros_trace_enabled_ ## event_name(void); \
-  TRACETOOLS_PUBLIC void ros_trace_do_ ## event_name(void);
+  TRACETOOLS_PUBLIC void _FUNC_TRACEPOINT(event_name)(void); \
+  TRACETOOLS_PUBLIC bool _FUNC_TRACEPOINT_ENABLED(event_name)(void); \
+  TRACETOOLS_PUBLIC void _FUNC_DO_TRACEPOINT(event_name)(void);
 #  define _DECLARE_TRACEPOINT_ARGS(event_name, ...) \
-  TRACETOOLS_PUBLIC void ros_trace_ ## event_name(__VA_ARGS__); \
-  TRACETOOLS_PUBLIC bool ros_trace_enabled_ ## event_name(void); \
-  TRACETOOLS_PUBLIC void ros_trace_do_ ## event_name(__VA_ARGS__);
+  TRACETOOLS_PUBLIC void _FUNC_TRACEPOINT(event_name)(__VA_ARGS__); \
+  TRACETOOLS_PUBLIC bool _FUNC_TRACEPOINT_ENABLED(event_name)(void); \
+  TRACETOOLS_PUBLIC void _FUNC_DO_TRACEPOINT(event_name)(__VA_ARGS__);
 
 #  define _GET_MACRO_TRACEPOINT(...) \
   _GET_MACRO( \

--- a/tracetools/include/tracetools/tracetools.h
+++ b/tracetools/include/tracetools/tracetools.h
@@ -49,7 +49,7 @@
   (ros_trace_ ## event_name)
 #  define _FUNC_TRACEPOINT_ENABLED(event_name) \
   (ros_trace_enabled_ ## event_name)
-#  define _FUNC_DO_TRACEPOINT(event_name)\
+#  define _FUNC_DO_TRACEPOINT(event_name) \
   (ros_trace_do_ ## event_name)
 #  define _TRACEPOINT_NOARGS(event_name) \
   _FUNC_TRACEPOINT(event_name)()

--- a/tracetools/include/tracetools/tracetools.h
+++ b/tracetools/include/tracetools/tracetools.h
@@ -103,7 +103,7 @@
  * This is the preferred method over calling the underlying function directly.
  */
 #  define TRACETOOLS_TRACEPOINT_ENABLED(event_name) \
-  ros_trace_enabled_ ## event_name(void)
+  ros_trace_enabled_ ## event_name()
 /// Call a tracepoint, without checking if it is enabled.
 /**
  * Combine this with `TRACEPOINT_ENABLED()` to check if a tracepoint is enabled before triggering

--- a/tracetools/include/tracetools/tracetools.h
+++ b/tracetools/include/tracetools/tracetools.h
@@ -46,11 +46,11 @@
 
 // *INDENT-OFF*
 #  define _TRACEPOINT_NOARGS(event_name) \
-  (ros_trace_ ## event_name)(void)
+  (ros_trace_ ## event_name)()
 #  define _TRACEPOINT_ARGS(event_name, ...) \
   (ros_trace_ ## event_name)(__VA_ARGS__)
 #  define _DO_TRACEPOINT_NOARGS(event_name) \
-  (ros_trace_do_ ## event_name)(void)
+  (ros_trace_do_ ## event_name)()
 #  define _DO_TRACEPOINT_ARGS(event_name, ...) \
   (ros_trace_do_ ## event_name)(__VA_ARGS__)
 #  define _DECLARE_TRACEPOINT_NOARGS(event_name) \

--- a/tracetools/include/tracetools/tracetools.h
+++ b/tracetools/include/tracetools/tracetools.h
@@ -109,7 +109,7 @@
  * This is the preferred method over calling the underlying function directly.
  */
 #  define TRACETOOLS_TRACEPOINT_ENABLED(event_name) \
-  ros_trace_enabled_ ## event_name()
+  _FUNC_TRACEPOINT_ENABLED(event_name)()
 /// Call a tracepoint, without checking if it is enabled.
 /**
  * Combine this with `TRACEPOINT_ENABLED()` to check if a tracepoint is enabled before triggering

--- a/tracetools/src/tracetools.c
+++ b/tracetools/src/tracetools.c
@@ -41,28 +41,28 @@
 #define TRACEPOINT_PARAMS(...) __VA_ARGS__
 
 #define DEFINE_TRACEPOINT(event_name, _TP_PARAMS, _TP_ARGS) \
-  void TRACETOOLS_TRACEPOINT(event_name, _TP_PARAMS) \
+  void _FUNC_TRACEPOINT(event_name)(_TP_PARAMS) \
   { \
     _CONDITIONAL_TP(event_name, _TP_ARGS); \
   } \
-  bool TRACETOOLS_TRACEPOINT_ENABLED(event_name) \
+  bool _FUNC_TRACEPOINT_ENABLED(event_name)(void) \
   { \
     return _CONDITIONAL_TP_ENABLED(event_name); \
   } \
-  void TRACETOOLS_DO_TRACEPOINT(event_name, _TP_PARAMS) \
+  void _FUNC_DO_TRACEPOINT(event_name)(_TP_PARAMS) \
   { \
     _CONDITIONAL_DO_TP(event_name, _TP_ARGS); \
   }
 #define DEFINE_TRACEPOINT_NO_ARGS(event_name) \
-  void TRACETOOLS_TRACEPOINT(event_name) \
+  void _FUNC_TRACEPOINT(event_name)(void) \
   { \
     _CONDITIONAL_TP(event_name); \
   } \
-  bool TRACETOOLS_TRACEPOINT_ENABLED(event_name) \
+  bool _FUNC_TRACEPOINT_ENABLED(event_name)(void) \
   { \
     return _CONDITIONAL_TP_ENABLED(event_name); \
   } \
-  void TRACETOOLS_DO_TRACEPOINT(event_name) \
+  void _FUNC_DO_TRACEPOINT(event_name)(void) \
   { \
     _CONDITIONAL_DO_TP(event_name); \
   }


### PR DESCRIPTION
This PR updates the macros to specify (void) in argument lists for functions that take no arguments. This resolves warnings from
Clang(-Wstrict-prototypes).

Tested locally with Clang; no build issues observed.

Closes https://github.com/ros2/ros2_tracing/issues/178
Supersedes https://github.com/ros2/ros2_tracing/pull/115