### PR TITLE
Address typing issues reported by mypy in tracetools_launch

### DIFF
--- a/ros2trace/ros2trace/command/trace.py
+++ b/ros2trace/ros2trace/command/trace.py
@@ -23,7 +23,7 @@ from tracetools_trace.trace import trace
 class TraceCommand(CommandExtension):
     """Trace ROS 2 nodes to get information on their execution. The main 'trace' command requires user interaction; to trace non-interactively, use the 'start'/'stop'/'pause'/'resume' sub-commands."""  # noqa: E501
 
-    def add_arguments(self, parser, cli_name) -> None:
+    def add_arguments(self, parser, cli_name, *, argv=None) -> None:
         self._subparser = parser
         args.add_arguments(parser)
 

--- a/ros2trace/setup.py
+++ b/ros2trace/setup.py
@@ -12,6 +12,7 @@ setup(
         ('share/ament_index/resource_index/packages',
             ['resource/' + package_name]),
     ],
+    package_data={'': ['py.typed']},
     install_requires=['ros2cli'],
     zip_safe=True,
     maintainer=(

--- a/test_tracetools_launch/test/test_tracetools_launch/test_trace_action.py
+++ b/test_tracetools_launch/test/test_tracetools_launch/test_trace_action.py
@@ -21,15 +21,21 @@ import tempfile
 import textwrap
 from typing import List
 from typing import Optional
+from typing import TextIO
+from typing import Tuple
 import unittest
 
+from launch import Action
+from launch import LaunchContext
 from launch import LaunchDescription
 from launch import LaunchService
 from launch.actions import DeclareLaunchArgument
+from launch.actions import SetEnvironmentVariable
 from launch.frontend import Parser
 from launch.substitutions import EnvironmentVariable
 from launch.substitutions import LaunchConfiguration
 from launch.substitutions import TextSubstitution
+from launch.utilities import perform_substitutions
 from launch_ros.actions import Node
 
 from tracetools_launch.action import Trace
@@ -51,19 +57,23 @@ class TestTraceAction(unittest.TestCase):
         if 'LD_PRELOAD' in os.environ:
             del os.environ['LD_PRELOAD']
 
-    def _assert_launch(self, actions) -> int:
+    def _assert_launch(self, actions: List[Action]) -> Tuple[int, LaunchContext]:
         ld = LaunchDescription(actions)
         ls = LaunchService(debug=True)
         ls.include_launch_description(ld)
-        return ls.run()
+        return ls.run(), ls.context
 
-    def _assert_launch_no_errors(self, actions) -> None:
-        self.assertEqual(0, self._assert_launch(actions), 'expected no errors')
+    def _assert_launch_no_errors(self, actions: List[Action]) -> LaunchContext:
+        ret, context = self._assert_launch(actions)
+        self.assertEqual(0, ret, 'expected no errors')
+        return context
 
-    def _assert_launch_errors(self, actions) -> None:
-        self.assertEqual(1, self._assert_launch(actions), 'expected errors')
+    def _assert_launch_errors(self, actions: List[Action]) -> LaunchContext:
+        ret, context = self._assert_launch(actions)
+        self.assertEqual(1, ret, 'expected errors')
+        return context
 
-    def _assert_launch_frontend_no_errors(self, file) -> Trace:
+    def _assert_launch_frontend_no_errors(self, file: TextIO) -> Tuple[Trace, LaunchContext]:
         root_entity, parser = Parser.load(file)
         ld = parser.parse_description(root_entity)
         ls = LaunchService()
@@ -71,12 +81,13 @@ class TestTraceAction(unittest.TestCase):
         self.assertEqual(0, ls.run(), 'expected no errors')
         trace_action = ld.describe_sub_entities()[0]
         assert isinstance(trace_action, Trace), f'expected Trace action, got: {trace_action}'
-        return trace_action
+        return trace_action, ls.context
 
     def _check_trace_action(
         self,
-        action,
-        tmpdir,
+        action: Trace,
+        context: LaunchContext,
+        tmpdir: Optional[str] = None,
         *,
         session_name: Optional[str] = 'my-session-name',
         append_trace: bool = False,
@@ -85,13 +96,16 @@ class TestTraceAction(unittest.TestCase):
         subbuffer_size_kernel: int = 1048576,
     ) -> None:
         if session_name is not None:
-            self.assertEqual(session_name, action.session_name)
-        self.assertEqual(tmpdir, action.base_path)
-        self.assertTrue(action.trace_directory.startswith(tmpdir))
+            self.assertEqual(session_name, perform_substitutions(context, action.session_name))
+        if tmpdir is not None:
+            self.assertEqual(tmpdir, perform_substitutions(context, action.base_path))
+            assert action.trace_directory
+            self.assertTrue(action.trace_directory.startswith(tmpdir))
+            self.assertTrue(pathlib.Path(tmpdir).exists())
         self.assertEqual(append_trace, action.append_trace)
-        self.assertEqual([], action.events_kernel)
-        self.assertEqual(events_ust, action.events_ust)
-        self.assertTrue(pathlib.Path(tmpdir).exists())
+        self.assertEqual(0, len(action.events_kernel))
+        self.assertEqual(
+            events_ust, [perform_substitutions(context, x) for x in action.events_ust])
         self.assertEqual(subbuffer_size_ust, action.subbuffer_size_ust)
         self.assertEqual(subbuffer_size_kernel, action.subbuffer_size_kernel)
 
@@ -111,8 +125,8 @@ class TestTraceAction(unittest.TestCase):
             subbuffer_size_ust=524288,
             subbuffer_size_kernel=1048576,
         )
-        self._assert_launch_no_errors([action])
-        self._check_trace_action(action, tmpdir)
+        context = self._assert_launch_no_errors([action])
+        self._check_trace_action(action, context, tmpdir)
 
         shutil.rmtree(tmpdir)
 
@@ -139,9 +153,9 @@ class TestTraceAction(unittest.TestCase):
 
         trace_action = None
         with io.StringIO(xml_file) as f:
-            trace_action = self._assert_launch_frontend_no_errors(f)
+            trace_action, context = self._assert_launch_frontend_no_errors(f)
 
-        self._check_trace_action(trace_action, tmpdir, append_trace=True)
+        self._check_trace_action(trace_action, context, tmpdir, append_trace=True)
 
         shutil.rmtree(tmpdir)
 
@@ -166,9 +180,9 @@ class TestTraceAction(unittest.TestCase):
 
         trace_action = None
         with io.StringIO(yaml_file) as f:
-            trace_action = self._assert_launch_frontend_no_errors(f)
+            trace_action, context = self._assert_launch_frontend_no_errors(f)
 
-        self._check_trace_action(trace_action, tmpdir, append_trace=True)
+        self._check_trace_action(trace_action, context, tmpdir, append_trace=True)
 
         shutil.rmtree(tmpdir)
 
@@ -210,11 +224,15 @@ class TestTraceAction(unittest.TestCase):
             subbuffer_size_ust=524288,
             subbuffer_size_kernel=1048576,
         )
-        self._assert_launch_no_errors([action])
-        self._check_trace_action(action, tmpdir)
+        context = self._assert_launch_no_errors([action])
+        self._check_trace_action(action, context, tmpdir)
 
+        assert isinstance(action.context_fields, dict)
         self.assertDictEqual(
-            action.context_fields,  # type: ignore[arg-type]
+            {
+                domain: [perform_substitutions(context, field) for field in fields]
+                for domain, fields in action.context_fields.items()
+            },
             {
                 'kernel': [],
                 'userspace': ['vpid', 'vtid'],
@@ -255,11 +273,15 @@ class TestTraceAction(unittest.TestCase):
             subbuffer_size_ust=524288,
             subbuffer_size_kernel=1048576,
         )
-        self._assert_launch_no_errors([session_name_arg, action])
-        self._check_trace_action(action, tmpdir)
+        context = self._assert_launch_no_errors([session_name_arg, action])
+        self._check_trace_action(action, context, tmpdir)
 
+        assert isinstance(action.context_fields, dict)
         self.assertDictEqual(
-            action.context_fields,  # type: ignore[arg-type]
+            {
+                domain: [perform_substitutions(context, field) for field in fields]
+                for domain, fields in action.context_fields.items()
+            },
             {
                 'kernel': [],
                 'userspace': ['vpid', 'vtid'],
@@ -298,9 +320,10 @@ class TestTraceAction(unittest.TestCase):
             executable='test_pong',
             output='screen',
         )
-        self._assert_launch_no_errors([action, node_ping_action, node_pong_action])
+        context = self._assert_launch_no_errors([action, node_ping_action, node_pong_action])
         self._check_trace_action(
             action,
+            context,
             tmpdir,
             events_ust=[
                 'lttng_ust_cyg_profile_fast:*',
@@ -339,13 +362,45 @@ class TestTraceAction(unittest.TestCase):
             subbuffer_size_ust=524288,
             subbuffer_size_kernel=1048576,
         )
-        self._assert_launch_no_errors([action])
-        self._check_trace_action(action, tmpdir, session_name=None)
-        # Session name should start with the given prefix and end with the timestamp, but don't
-        # bother validating the timestamp here
-        self.assertTrue(
-            action.session_name.startswith('my-session-name-'))  # type: ignore[attr-defined]
-        self.assertNotEqual('my-session-name-', action.session_name)
+        context = self._assert_launch_no_errors([action])
+        self._check_trace_action(action, context, tmpdir, session_name=None)
+        # Session name should start with the given prefix and end with the timestamp
+        session_name = perform_substitutions(context, action.session_name)
+        self.assertTrue(session_name.startswith('my-session-name-'))
+        session_name_timestamp = session_name[len('my-session-name-'):]
+        self.assertNotEqual(0, len(session_name_timestamp))
+        self.assertTrue(all(c.isdigit() for c in session_name_timestamp))
+
+        shutil.rmtree(tmpdir)
+
+    def test_base_path_trace_directory(self) -> None:
+        tmpdir = tempfile.mkdtemp(prefix='TestTraceAction__test_base_path_trace_directory')
+
+        # Let it rely on the ROS_HOME env var for the base path
+        os.environ.pop('ROS_HOME', None)
+        tmpdir_home = os.path.join(tmpdir, 'home')
+        set_ros_home = SetEnvironmentVariable('ROS_HOME', tmpdir_home)
+        action = Trace(
+            session_name='my-session-name',
+            base_path=None,
+            events_kernel=[],
+            syscalls=[],
+            events_ust=[
+                'ros2:*',
+                '*',
+            ],
+            subbuffer_size_ust=524288,
+            subbuffer_size_kernel=1048576,
+        )
+        self.assertIsNone(action.trace_directory)
+        context = self._assert_launch_no_errors([set_ros_home, action])
+        self._check_trace_action(action, context, tmpdir=None, session_name=None)
+        base_path = os.path.join(tmpdir_home, 'tracing')
+        self.assertEqual(base_path, perform_substitutions(context, action.base_path))
+        assert action.trace_directory
+        self.assertTrue(action.trace_directory.startswith(base_path + os.path.sep))
+        self.assertTrue(pathlib.Path(base_path).exists())
+        os.environ.pop('ROS_HOME', None)
 
         shutil.rmtree(tmpdir)
 
@@ -366,8 +421,8 @@ class TestTraceAction(unittest.TestCase):
             subbuffer_size_ust=524288,
             subbuffer_size_kernel=1048576,
         )
-        self._assert_launch_no_errors([action])
-        self._check_trace_action(action, tmpdir, append_trace=False)
+        context = self._assert_launch_no_errors([action])
+        self._check_trace_action(action, context, tmpdir, append_trace=False)
 
         # Generating another trace with the same path should error out
         self._assert_launch_errors([action])
@@ -386,8 +441,8 @@ class TestTraceAction(unittest.TestCase):
             subbuffer_size_ust=524288,
             subbuffer_size_kernel=1048576,
         )
-        self._assert_launch_no_errors([action])
-        self._check_trace_action(action, tmpdir, append_trace=True)
+        context = self._assert_launch_no_errors([action])
+        self._check_trace_action(action, context, tmpdir, append_trace=True)
 
         shutil.rmtree(tmpdir)
 

--- a/tracetools_launch/setup.py
+++ b/tracetools_launch/setup.py
@@ -15,6 +15,7 @@ setup(
         ('share/ament_index/resource_index/packages',
             ['resource/' + package_name]),
     ],
+    package_data={'': ['py.typed']},
     install_requires=['setuptools'],
     maintainer=(
         'Christophe Bedard, '

--- a/tracetools_launch/test/tracetools_launch/test_trace_action.py
+++ b/tracetools_launch/test/tracetools_launch/test_trace_action.py
@@ -13,10 +13,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
+import pathlib
 from typing import List
 import unittest
 
+from launch.launch_context import LaunchContext
 from tracetools_launch.action import Trace
+from tracetools_trace.tools.path import get_tracing_directory
 
 
 class TestTraceAction(unittest.TestCase):
@@ -175,6 +179,16 @@ class TestTraceAction(unittest.TestCase):
             self.assertTrue(Trace.has_dl_events(events), events)
         for events in events_lists_no_match:
             self.assertFalse(Trace.has_dl_events(events), events)
+
+    def test_trace_directory_substitution(self) -> None:
+        os.environ.pop('ROS_TRACE_DIR', None)
+        os.environ.pop('ROS_HOME', None)
+        home = pathlib.Path.home()
+        self.assertTrue(str(home))
+        # Just test the default case here
+        trace_dir = get_tracing_directory()
+        self.assertNotEqual(0, len(trace_dir))
+        self.assertEqual(trace_dir, Trace.TraceDirectory().perform(LaunchContext()))
 
 
 if __name__ == '__main__':

--- a/tracetools_launch/tracetools_launch/action.py
+++ b/tracetools_launch/tracetools_launch/action.py
@@ -18,7 +18,6 @@
 import fnmatch
 import re
 import shlex
-from typing import Dict
 from typing import Iterable
 from typing import List
 from typing import Mapping
@@ -36,6 +35,7 @@ from launch.frontend import Parser
 from launch.launch_context import LaunchContext
 from launch.some_substitutions_type import SomeSubstitutionsType
 from launch.substitution import Substitution
+from launch.substitutions import IfElseSubstitution
 from launch.substitutions import TextSubstitution
 from launch.utilities import normalize_to_list_of_substitutions
 from launch.utilities import perform_substitutions
@@ -116,7 +116,7 @@ class Trace(Action):
         events_kernel: Iterable[SomeSubstitutionsType] = [],
         syscalls: Iterable[SomeSubstitutionsType] = [],
         context_fields:
-            Union[Iterable[SomeSubstitutionsType], Dict[str, Iterable[SomeSubstitutionsType]]]
+            Union[Iterable[SomeSubstitutionsType], Mapping[str, Iterable[SomeSubstitutionsType]]]
             = names.DEFAULT_CONTEXT,
         subbuffer_size_ust: int = 8 * 4096,
         subbuffer_size_kernel: int = 32 * 4096,
@@ -156,16 +156,25 @@ class Trace(Action):
         """
         super().__init__(**kwargs)
         self._logger = logging.get_logger(__name__)
-        self._append_timestamp = append_timestamp
-        self._session_name = normalize_to_list_of_substitutions(session_name)
-        self._base_path = base_path \
-            if base_path is None else normalize_to_list_of_substitutions(base_path)
+        self._session_name: List[Substitution] = [
+            IfElseSubstitution(
+                str(append_timestamp), Trace.AppendTimestamp(session_name), session_name)
+        ]
+        self._base_path: List[Substitution] = [
+            IfElseSubstitution(
+                str(base_path is not None),
+                normalize_to_list_of_substitutions(base_path or []),
+                Trace.TraceDirectory(),
+            )
+        ]
         self._append_trace = append_trace
         self._trace_directory: Optional[str] = None
         self._events_ust = [normalize_to_list_of_substitutions(x) for x in events_ust]
         self._events_kernel = [normalize_to_list_of_substitutions(x) for x in events_kernel]
         self._syscalls = [normalize_to_list_of_substitutions(x) for x in syscalls]
-        self._context_fields = (
+        self._context_fields: Union[
+            Mapping[str, List[List[Substitution]]], List[List[Substitution]]
+        ] = (
             {
                 domain: [normalize_to_list_of_substitutions(field) for field in fields]
                 for domain, fields in context_fields.items()
@@ -182,7 +191,7 @@ class Trace(Action):
         return self._session_name
 
     @property
-    def base_path(self) -> Optional[List[Substitution]]:
+    def base_path(self) -> List[Substitution]:
         return self._base_path
 
     @property
@@ -194,21 +203,21 @@ class Trace(Action):
         return self._trace_directory
 
     @property
-    def events_ust(self) -> Iterable[List[Substitution]]:
+    def events_ust(self) -> List[List[Substitution]]:
         return self._events_ust
 
     @property
-    def events_kernel(self) -> Iterable[List[Substitution]]:
+    def events_kernel(self) -> List[List[Substitution]]:
         return self._events_kernel
 
     @property
-    def syscalls(self) -> Iterable[List[Substitution]]:
+    def syscalls(self) -> List[List[Substitution]]:
         return self._syscalls
 
     @property
     def context_fields(
         self,
-    ) -> Union[Mapping[str, Iterable[List[Substitution]]], Iterable[List[Substitution]]]:
+    ) -> Union[Mapping[str, List[List[Substitution]]], List[List[Substitution]]]:
         return self._context_fields
 
     @property
@@ -382,87 +391,87 @@ class Trace(Action):
         """Check if the events list contains at least one dl event."""
         return cls.any_events_match(events, cls.EVENTS_DL)
 
-    def _perform_substitutions(self, context: LaunchContext) -> None:
-        self._session_name = perform_substitutions(context, self._session_name)
-        if self._append_timestamp:
-            self._session_name = path.append_timestamp(self._session_name)
-        self._base_path = perform_substitutions(context, self._base_path) \
-            if self._base_path else path.get_tracing_directory()
-        self._events_ust = [perform_substitutions(context, x) for x in self._events_ust]
-        self._events_kernel = [perform_substitutions(context, x) for x in self._events_kernel]
-        self._syscalls = [perform_substitutions(context, x) for x in self._syscalls]
-        self._context_fields = \
+    def execute(self, context: LaunchContext) -> List[Action]:
+        session_name = perform_substitutions(context, self._session_name)
+        base_path = perform_substitutions(context, self._base_path)
+        events_ust = [perform_substitutions(context, x) for x in self._events_ust]
+        events_kernel = [perform_substitutions(context, x) for x in self._events_kernel]
+        syscalls = [perform_substitutions(context, x) for x in self._syscalls]
+        context_fields = (
             {
                 domain: [perform_substitutions(context, field) for field in fields]
                 for domain, fields in self._context_fields.items()
-            } \
-            if isinstance(self._context_fields, dict) \
+            }
+            if isinstance(self._context_fields, Mapping)
             else [perform_substitutions(context, field) for field in self._context_fields]
+        )
+        self._ld_preload_actions = self._get_ld_preload_actions(events_ust)
 
-        # Add LD_PRELOAD actions if corresponding events are enabled
-        if self.has_libc_wrapper_events(self._events_ust):
-            self._ld_preload_actions.append(LdPreload(self.LIB_LIBC_WRAPPER))
-        if self.has_pthread_wrapper_events(self._events_ust):
-            self._ld_preload_actions.append(LdPreload(self.LIB_PTHREAD_WRAPPER))
-        if self.has_dl_events(self._events_ust):
-            self._ld_preload_actions.append(LdPreload(self.LIB_DL))
-        # Warn if events match both normal AND fast profiling libs
-        has_fast_profiling_events = self.has_profiling_events(self._events_ust, True)
-        has_normal_profiling_events = self.has_profiling_events(self._events_ust, False)
-        # In practice, the first lib in the LD_PRELOAD list will be used, so the fast one here
-        if has_fast_profiling_events:
-            self._ld_preload_actions.append(LdPreload(self.LIB_PROFILE_FAST))
-        if has_normal_profiling_events:
-            self._ld_preload_actions.append(LdPreload(self.LIB_PROFILE_NORMAL))
-        if has_normal_profiling_events and has_fast_profiling_events:
-            self._logger.warning('events match both normal and fast profiling shared libraries')
+        def setup() -> bool:
+            try:
+                self._trace_directory = lttng.lttng_init(
+                    session_name=session_name,
+                    base_path=base_path,
+                    append_trace=self._append_trace,
+                    ros_events=events_ust,
+                    kernel_events=events_kernel,
+                    syscalls=syscalls,
+                    context_fields=context_fields,
+                    subbuffer_size_ust=self._subbuffer_size_ust,
+                    subbuffer_size_kernel=self._subbuffer_size_kernel,
+                )
+                if self._trace_directory is None:
+                    return False
+                self._logger.info(f'Writing tracing session to: {self._trace_directory}')
+                self._logger.debug(f'UST events: {events_ust}')
+                self._logger.debug(f'Kernel events: {events_kernel}')
+                self._logger.debug(f'Syscalls: {syscalls}')
+                self._logger.debug(f'Context fields: {context_fields}')
+                self._logger.debug(f'LD_PRELOAD: {self._ld_preload_actions}')
+                self._logger.debug(f'UST subbuffer size: {self._subbuffer_size_ust}')
+                self._logger.debug(f'Kernel subbuffer size: {self._subbuffer_size_kernel}')
+                return True
+            except RuntimeError as e:
+                self._logger.error(str(e))
+                # Make sure to clean up tracing session
+                lttng.lttng_fini(
+                    session_name=session_name,
+                    ignore_error=True,
+                )
+                return False
 
-    def execute(self, context: LaunchContext) -> Optional[List[Action]]:
-        self._perform_substitutions(context)
+        def destroy(event: Event, context: LaunchContext) -> None:
+            self._logger.debug(f'Finalizing tracing session: {session_name}')
+            lttng.lttng_fini(session_name=session_name)
+
         # TODO make sure this is done as early as possible
-        if not self._setup():
+        if not setup():
             # Fail right away if tracing setup fails
             raise RuntimeError('tracing setup failed, see errors above')
         # TODO make sure this is done as late as possible
-        context.register_event_handler(OnShutdown(on_shutdown=self._destroy))
+        context.register_event_handler(OnShutdown(on_shutdown=destroy))
         return self._ld_preload_actions
 
-    def _setup(self) -> bool:
-        try:
-            self._trace_directory = lttng.lttng_init(
-                session_name=self._session_name,
-                base_path=self._base_path,
-                append_trace=self._append_trace,
-                ros_events=self._events_ust,
-                kernel_events=self._events_kernel,
-                syscalls=self._syscalls,
-                context_fields=self._context_fields,
-                subbuffer_size_ust=self._subbuffer_size_ust,
-                subbuffer_size_kernel=self._subbuffer_size_kernel,
-            )
-            if self._trace_directory is None:
-                return False
-            self._logger.info(f'Writing tracing session to: {self._trace_directory}')
-            self._logger.debug(f'UST events: {self._events_ust}')
-            self._logger.debug(f'Kernel events: {self._events_kernel}')
-            self._logger.debug(f'Syscalls: {self._syscalls}')
-            self._logger.debug(f'Context fields: {self._context_fields}')
-            self._logger.debug(f'LD_PRELOAD: {self._ld_preload_actions}')
-            self._logger.debug(f'UST subbuffer size: {self._subbuffer_size_ust}')
-            self._logger.debug(f'Kernel subbuffer size: {self._subbuffer_size_kernel}')
-            return True
-        except RuntimeError as e:
-            self._logger.error(str(e))
-            # Make sure to clean up tracing session
-            lttng.lttng_fini(
-                session_name=self._session_name,
-                ignore_error=True,
-            )
-            return False
-
-    def _destroy(self, event: Event, context: LaunchContext) -> None:
-        self._logger.debug(f'Finalizing tracing session: {self._session_name}')
-        lttng.lttng_fini(session_name=self._session_name)
+    def _get_ld_preload_actions(self, events_ust: List[str]) -> List[Action]:
+        ld_preload_actions: List[Action] = []
+        # Add LD_PRELOAD actions if corresponding events are enabled
+        if self.has_libc_wrapper_events(events_ust):
+            ld_preload_actions.append(LdPreload(self.LIB_LIBC_WRAPPER))
+        if self.has_pthread_wrapper_events(events_ust):
+            ld_preload_actions.append(LdPreload(self.LIB_PTHREAD_WRAPPER))
+        if self.has_dl_events(events_ust):
+            ld_preload_actions.append(LdPreload(self.LIB_DL))
+        # Warn if events match both normal AND fast profiling libs
+        has_fast_profiling_events = self.has_profiling_events(events_ust, True)
+        has_normal_profiling_events = self.has_profiling_events(events_ust, False)
+        # In practice, the first lib in the LD_PRELOAD list will be used, so the fast one here
+        if has_fast_profiling_events:
+            ld_preload_actions.append(LdPreload(self.LIB_PROFILE_FAST))
+        if has_normal_profiling_events:
+            ld_preload_actions.append(LdPreload(self.LIB_PROFILE_NORMAL))
+        if has_normal_profiling_events and has_fast_profiling_events:
+            self._logger.warning('events match both normal and fast profiling shared libraries')
+        return ld_preload_actions
 
     def __repr__(self) -> Text:
         return (
@@ -479,3 +488,27 @@ class Trace(Action):
             f'subbuffer_size_ust={self._subbuffer_size_ust}, '
             f'subbuffer_size_kernel={self._subbuffer_size_kernel})'
         )
+
+    class AppendTimestamp(Substitution):
+        """Substitution which appends a timestamp."""
+
+        def __init__(self, prefix: SomeSubstitutionsType) -> None:
+            super().__init__()
+            self._prefix = normalize_to_list_of_substitutions(prefix)
+
+        def perform(self, context: LaunchContext) -> Text:
+            return path.append_timestamp(perform_substitutions(context, self._prefix))
+
+        def describe(self) -> Text:
+            return f'AppendTimestamp({self._prefix})'
+
+    class TraceDirectory(Substitution):
+        """Substitution for the trace directory."""
+
+        def perform(self, context: LaunchContext) -> Text:
+            # This depends on the context.environment being os.environ, because
+            # get_tracing_directory() directly uses os.environ
+            return path.get_tracing_directory()
+
+        def describe(self) -> Text:
+            return 'TraceDirectory()'

--- a/tracetools_read/setup.py
+++ b/tracetools_read/setup.py
@@ -12,6 +12,7 @@ setup(
         ('share/ament_index/resource_index/packages',
             ['resource/' + package_name]),
     ],
+    package_data={'': ['py.typed']},
     install_requires=['setuptools'],
     maintainer=(
         'Christophe Bedard, '

--- a/tracetools_test/setup.py
+++ b/tracetools_test/setup.py
@@ -12,6 +12,7 @@ setup(
         ('share/ament_index/resource_index/packages',
             ['resource/' + package_name]),
     ],
+    package_data={'': ['py.typed']},
     install_requires=['setuptools'],
     maintainer=(
         'Christophe Bedard, '

--- a/tracetools_trace/setup.py
+++ b/tracetools_trace/setup.py
@@ -12,6 +12,7 @@ setup(
         ('share/ament_index/resource_index/packages',
             ['resource/' + package_name]),
     ],
+    package_data={'': ['py.typed']},
     install_requires=['setuptools'],
     maintainer=(
         'Christophe Bedard, '


### PR DESCRIPTION
## Description

Fixes #160

This is needed before https://github.com/ros2/launch/pull/886 can be merged.

Given what I wrote in https://github.com/ros2/ros2_tracing/issues/160#issuecomment-2971204451, this PR is valid if GitHub CI passes OR if ci.ros2.org passes with this PR and https://github.com/ros2/launch/pull/886 (but of course we expect both to pass).

### Is this user-facing behavior change?

No.

### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

### Additional Information

I decided to just merge `_perform_substitutions()` into `Trace.execute()`. I also moved `_setup()` + `_destroy()` into `execute()`. The explicit type annotation for `self._context_fields` in the constructor seemed to be necessary.

I also changed the `Trace` action to not assign the substituted values to the corresponding attributes, otherwise this makes the typing annotation and validation more complex. Looking at other launch actions, this is what they do. That means that the tests sometimes need to manually perform the substitutions to get actual values. I also took this opportunity to wrap the appending of a timestamp to the session name with a substitution. Same for the logic with the base path.

I switched from `dict`/`typing.Dict` to `Mapping` because that is apparently better, especially for input value types. It doesn't necessarily need to be a `dict`, it just needs to behave like a dictionary. `typing.Mapping` is actually a deprecated alias to `collections.abc.Mapping` as of Python 3.9, but some platforms for Kilted/Rolling in REP 2000 still use Python <3.9, and `collections.abc.Mapping` only supports subscripting (`Mapping[]`) in Python >=3.9.