### PR TITLE
Add runtime tracing opt-out mechanism

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ For more information about LTTng, [refer to its documentation](https://lttng.org
 
 ### Disabling the tracer at runtime
 
-To avoid loading the tracer at runtime (and therefore disable all instrumentation), set the `TRACETOOLS_RUNTIME_DISABLE` environment variable:
+To avoid loading the tracer at runtime (and therefore disable all instrumentation), set the `TRACETOOLS_RUNTIME_DISABLE` environment variable to `1`:
 
 ```
 $ export TRACETOOLS_RUNTIME_DISABLE=1

--- a/README.md
+++ b/README.md
@@ -100,9 +100,9 @@ $ sudo apt-get install lttng-modules-dkms
 
 For more information about LTTng, [refer to its documentation](https://lttng.org/docs/v2.13/).
 
-### Disabling the instrumentation
+### Disabling the tracer at runtime
 
-To disable all instrumentation in runtime, set the `TRACETOOLS_RUNTIME_DISABLE` envvar:
+To avoid loading the tracer at runtime (and therefore disable all instrumentation), set the `TRACETOOLS_RUNTIME_DISABLE` environment variable:
 
 ```
 $ export TRACETOOLS_RUNTIME_DISABLE=1

--- a/README.md
+++ b/README.md
@@ -100,6 +100,16 @@ $ sudo apt-get install lttng-modules-dkms
 
 For more information about LTTng, [refer to its documentation](https://lttng.org/docs/v2.13/).
 
+### Disabling the instrumentation
+
+To disable all instrumentation in runtime, set the `TRACETOOLS_RUNTIME_DISABLE` envvar:
+
+```
+$ export TRACETOOLS_RUNTIME_DISABLE=1
+$ ros2 run tracetools status
+Tracing disabled
+```
+
 ### Removing the instrumentation
 
 To build and remove all instrumentation, use `TRACETOOLS_DISABLED`:

--- a/test_ros2trace/test/test_ros2trace/test_trace.py
+++ b/test_ros2trace/test/test_ros2trace/test_trace.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from collections.abc import Mapping
+
 import os
 import shutil
 import subprocess
@@ -109,6 +111,13 @@ class TestROS2TraceCLI(unittest.TestCase):
 
     def assertTraceNotExist(self, trace_dir: str) -> None:
         self.assertFalse(os.path.isdir(trace_dir), f'trace directory exists: {trace_dir}')
+
+    def assertTraceIsEmpty(self, trace_dir: str) -> None:
+        self.assertTraceExist(trace_dir)
+        from tracetools_read.trace import get_trace_events
+        events_all = get_trace_events(trace_dir)
+        events = get_corresponding_trace_test_events(events_all, self.trace_test_id)
+        self.assertEqual(len(events), 0, f'events found: {events_all}')
 
     def assertTraceContains(
         self,
@@ -246,23 +255,25 @@ class TestROS2TraceCLI(unittest.TestCase):
         process = self.run_command(['ros2', 'trace', *args], env=env)
         return self.wait_and_print_command_output(process)
 
-    def run_nodes(self) -> None:
+    def run_nodes(self, env: Optional[Mapping[str, str]] = None) -> None:
         # Set trace test ID env var for spawned processes
-        env = os.environ.copy()
+        if env is None:
+            env = os.environ
+        mutable_env = dict(env)
         assert self.trace_test_id
-        env[TRACE_TEST_ID_ENV_VAR] = self.trace_test_id
+        mutable_env[TRACE_TEST_ID_ENV_VAR] = self.trace_test_id
         nodes = [
             Node(
                 package='test_tracetools',
                 executable='test_ping',
                 output='screen',
-                env=env,
+                env=mutable_env,
             ),
             Node(
                 package='test_tracetools',
                 executable='test_pong',
                 output='screen',
-                env=env,
+                env=mutable_env,
             ),
         ]
         ld = LaunchDescription(nodes)
@@ -635,5 +646,30 @@ class TestROS2TraceCLI(unittest.TestCase):
         ret = self.run_trace_subcommand(['stop', session_name])
         self.assertEqual(1, ret)
         self.assertTracingSessionNotExist(session_name)
+
+        shutil.rmtree(tmpdir)
+
+    @unittest.skipIf(not are_tracepoints_included(), 'tracepoints are required')
+    def test_runtime_disable(self) -> None:
+        tmpdir = self.create_test_tmpdir('test_runtime_disable')
+        session_name = 'test_runtime_disable'
+
+        env = os.environ.copy()
+        env['TRACETOOLS_RUNTIME_DISABLE'] = '1'
+
+        process = self.run_trace_command_start(
+            [
+                '--path', tmpdir, '--session-name', session_name,
+                '--ust', tracepoints.rcl_subscription_init, TRACE_TEST_ID_TP_NAME,
+            ],
+            wait_for_start=True,
+            env=env,
+        )
+        self.run_nodes(env)
+
+        ret = self.run_trace_command_stop(process)
+        self.assertEqual(0, ret)
+
+        self.assertTraceIsEmpty(os.path.join(tmpdir, session_name))
 
         shutil.rmtree(tmpdir)

--- a/test_ros2trace/test/test_ros2trace/test_trace.py
+++ b/test_ros2trace/test/test_ros2trace/test_trace.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 from collections.abc import Mapping
-
 import os
 import shutil
 import subprocess
@@ -36,6 +35,7 @@ from tracetools_test.mark_process import TRACE_TEST_ID_ENV_VAR
 from tracetools_test.mark_process import TRACE_TEST_ID_TP_NAME
 from tracetools_trace.tools import tracepoints
 from tracetools_trace.tools.lttng import is_lttng_installed
+from tracetools_trace.tools.names import DEFAULT_EVENTS_ROS
 
 
 def are_tracepoints_included() -> bool:
@@ -112,12 +112,21 @@ class TestROS2TraceCLI(unittest.TestCase):
     def assertTraceNotExist(self, trace_dir: str) -> None:
         self.assertFalse(os.path.isdir(trace_dir), f'trace directory exists: {trace_dir}')
 
-    def assertTraceIsEmpty(self, trace_dir: str) -> None:
+    def assertTraceNotContains(self, trace_dir: str, unexpected_event_names: List[str]) -> None:
         self.assertTraceExist(trace_dir)
         from tracetools_read.trace import get_trace_events
-        events_all = get_trace_events(trace_dir)
-        events = get_corresponding_trace_test_events(events_all, self.trace_test_id)
-        self.assertEqual(len(events), 0, f'events found: {events_all}')
+        events = get_trace_events(trace_dir)
+        trace_test_events = get_corresponding_trace_test_events(events, self.trace_test_id)
+        self.assertGreater(
+            len(trace_test_events),
+            0,
+            f'no matching trace test events found: {events}')
+        for event in events:
+            event_name = get_event_name(event)
+            self.assertNotIn(
+                event_name, unexpected_event_names,
+                f'{event_name} found in events: {events}'
+            )
 
     def assertTraceContains(
         self,
@@ -257,23 +266,23 @@ class TestROS2TraceCLI(unittest.TestCase):
 
     def run_nodes(self, env: Optional[Mapping[str, str]] = None) -> None:
         # Set trace test ID env var for spawned processes
-        if env is None:
-            env = os.environ
-        mutable_env = dict(env)
+        additional_env: Dict[str, str] = {}
+        if env is not None:
+            additional_env.update(env)
         assert self.trace_test_id
-        mutable_env[TRACE_TEST_ID_ENV_VAR] = self.trace_test_id
+        additional_env[TRACE_TEST_ID_ENV_VAR] = self.trace_test_id
         nodes = [
             Node(
                 package='test_tracetools',
                 executable='test_ping',
                 output='screen',
-                env=mutable_env,
+                additional_env=additional_env,
             ),
             Node(
                 package='test_tracetools',
                 executable='test_pong',
                 output='screen',
-                env=mutable_env,
+                additional_env=additional_env,
             ),
         ]
         ld = LaunchDescription(nodes)
@@ -654,8 +663,7 @@ class TestROS2TraceCLI(unittest.TestCase):
         tmpdir = self.create_test_tmpdir('test_runtime_disable')
         session_name = 'test_runtime_disable'
 
-        env = os.environ.copy()
-        env['TRACETOOLS_RUNTIME_DISABLE'] = '1'
+        env = {'TRACETOOLS_RUNTIME_DISABLE': '1'}
 
         process = self.run_trace_command_start(
             [
@@ -670,6 +678,6 @@ class TestROS2TraceCLI(unittest.TestCase):
         ret = self.run_trace_command_stop(process)
         self.assertEqual(0, ret)
 
-        self.assertTraceIsEmpty(os.path.join(tmpdir, session_name))
+        self.assertTraceNotContains(os.path.join(tmpdir, session_name), DEFAULT_EVENTS_ROS)
 
         shutil.rmtree(tmpdir)

--- a/test_tracetools/src/mark_process.cpp
+++ b/test_tracetools/src/mark_process.cpp
@@ -34,6 +34,11 @@ namespace
 /**
  * \see tracetools_test
  */
+constexpr std::string_view tracetools_runtime_disable_env_var = "TRACETOOLS_RUNTIME_DISABLE";
+
+/**
+ * \see tracetools_test
+ */
 constexpr std::string_view trace_test_id_env_var = "TRACETOOLS_TEST_TRACE_TEST_ID";
 
 }  // namespace
@@ -42,13 +47,19 @@ void mark_trace_test_process()
 {
 #ifndef TRACETOOLS_DISABLED
   // See tracetools_test.mark_process for more details
-  const std::string env_var{trace_test_id_env_var};
-  const auto test_id = rcpputils::get_env_var(env_var.c_str());
+  const std::string runtime_disable_env_var{tracetools_runtime_disable_env_var};
+  const auto runtime_disable = rcpputils::get_env_var(runtime_disable_env_var.c_str());
+  if (!runtime_disable.empty() && runtime_disable == "1") {
+    return;
+  }
+
+  const std::string test_id_env_var{trace_test_id_env_var};
+  const auto test_id = rcpputils::get_env_var(test_id_env_var.c_str());
   if (!test_id.empty()) {
 #if LTTNG_UST_MINOR_VERSION <= 12
-    tracef("%s=%s", env_var.c_str(), test_id.c_str());
+    tracef("%s=%s", test_id_env_var.c_str(), test_id.c_str());
 #else
-    lttng_ust_tracef("%s=%s", env_var.c_str(), test_id.c_str());
+    lttng_ust_tracef("%s=%s", test_id_env_var.c_str(), test_id.c_str());
 #endif
   }
 #endif  // TRACETOOLS_DISABLED

--- a/test_tracetools/src/mark_process.cpp
+++ b/test_tracetools/src/mark_process.cpp
@@ -34,11 +34,6 @@ namespace
 /**
  * \see tracetools_test
  */
-constexpr std::string_view tracetools_runtime_disable_env_var = "TRACETOOLS_RUNTIME_DISABLE";
-
-/**
- * \see tracetools_test
- */
 constexpr std::string_view trace_test_id_env_var = "TRACETOOLS_TEST_TRACE_TEST_ID";
 
 }  // namespace
@@ -47,12 +42,6 @@ void mark_trace_test_process()
 {
 #ifndef TRACETOOLS_DISABLED
   // See tracetools_test.mark_process for more details
-  const std::string runtime_disable_env_var{tracetools_runtime_disable_env_var};
-  const auto runtime_disable = rcpputils::get_env_var(runtime_disable_env_var.c_str());
-  if (!runtime_disable.empty() && runtime_disable == "1") {
-    return;
-  }
-
   const std::string test_id_env_var{trace_test_id_env_var};
   const auto test_id = rcpputils::get_env_var(test_id_env_var.c_str());
   if (!test_id.empty()) {

--- a/tracetools/CMakeLists.txt
+++ b/tracetools/CMakeLists.txt
@@ -56,11 +56,13 @@ set(HEADERS
 if(NOT TRACETOOLS_TRACEPOINTS_EXCLUDED)
   # We only need these if we're using LTTng
   list(APPEND SOURCES
-    src/tp_call.c
+    src/tp_define.c
   )
-  list(APPEND HEADERS
-    include/${PROJECT_NAME}/tp_call.h
+  add_library(${PROJECT_NAME}_provider src/tp.c)
+  target_include_directories(${PROJECT_NAME}_provider PRIVATE
+    "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
   )
+  set_target_properties(${PROJECT_NAME}_provider PROPERTIES POSITION_INDEPENDENT_CODE TRUE)
 endif()
 
 if(NOT TRACETOOLS_DISABLED)
@@ -70,7 +72,7 @@ else()
   add_library(${PROJECT_NAME} INTERFACE)
 endif()
 if(NOT TRACETOOLS_TRACEPOINTS_EXCLUDED)
-  target_link_libraries(${PROJECT_NAME} ${LTTNG_LIBRARIES})
+  target_link_libraries(${PROJECT_NAME}_provider ${PROJECT_NAME} ${LTTNG_LIBRARIES})
 endif()
 if(NOT TRACETOOLS_DISABLED)
   # Export -rdynamic for downtream packages to use when calling
@@ -92,6 +94,9 @@ if(NOT TRACETOOLS_DISABLED)
     "$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>"
     "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>"
   )
+  target_include_directories(${PROJECT_NAME} PRIVATE
+     "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+  ) # to find tp_call.h
 else()
   target_include_directories(${PROJECT_NAME} INTERFACE
     "$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>"
@@ -157,17 +162,22 @@ install(
   ARCHIVE DESTINATION lib
   RUNTIME DESTINATION bin
 )
-
+if(NOT TRACETOOLS_TRACEPOINTS_EXCLUDED)
+  install(
+    TARGETS ${PROJECT_NAME}_provider
+    LIBRARY DESTINATION lib
+    ARCHIVE DESTINATION lib
+    RUNTIME DESTINATION bin
+  )
+endif()
 # Export old-style CMake variables
 ament_export_include_directories("include/${PROJECT_NAME}")
 
-if(NOT TRACETOOLS_TRACEPOINTS_EXCLUDED)
-  ament_export_libraries(${PROJECT_NAME} ${LTTNG_LIBRARIES})
+if(NOT TRACETOOLS_DISABLED)
   # Export -rdynamic for downstream packages using classic CMake variables
   if(NOT TRACETOOLS_NO_RDYNAMIC)
     ament_export_link_flags("-rdynamic")
   endif()
-elseif(NOT TRACETOOLS_DISABLED)
   ament_export_libraries(${PROJECT_NAME})
 endif()
 

--- a/tracetools/CMakeLists.txt
+++ b/tracetools/CMakeLists.txt
@@ -95,7 +95,7 @@ if(NOT TRACETOOLS_DISABLED)
     "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>"
   )
   target_include_directories(${PROJECT_NAME} PRIVATE
-     "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+    "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
   ) # to find tp_call.h
 else()
   target_include_directories(${PROJECT_NAME} INTERFACE

--- a/tracetools/CMakeLists.txt
+++ b/tracetools/CMakeLists.txt
@@ -67,12 +67,12 @@ endif()
 
 if(NOT TRACETOOLS_DISABLED)
   add_library(${PROJECT_NAME} ${SOURCES})
-  target_compile_definitions(${PROJECT_NAME} PRIVATE TRACETOOLS_PROVIDER_SONAME="$<TARGET_FILE_NAME:${PROJECT_NAME}_provider>")
 else()
   # only export a target with headers when disabled
   add_library(${PROJECT_NAME} INTERFACE)
 endif()
 if(NOT TRACETOOLS_TRACEPOINTS_EXCLUDED)
+  target_compile_definitions(${PROJECT_NAME} PRIVATE TRACETOOLS_PROVIDER_SONAME="$<TARGET_FILE_NAME:${PROJECT_NAME}_provider>")
   target_link_libraries(${PROJECT_NAME}_provider ${PROJECT_NAME} ${LTTNG_LIBRARIES})
 endif()
 if(NOT TRACETOOLS_DISABLED)

--- a/tracetools/CMakeLists.txt
+++ b/tracetools/CMakeLists.txt
@@ -67,6 +67,7 @@ endif()
 
 if(NOT TRACETOOLS_DISABLED)
   add_library(${PROJECT_NAME} ${SOURCES})
+  target_compile_definitions(${PROJECT_NAME} PRIVATE TRACETOOLS_PROVIDER_SONAME="$<TARGET_FILE_NAME:${PROJECT_NAME}_provider>")
 else()
   # only export a target with headers when disabled
   add_library(${PROJECT_NAME} INTERFACE)

--- a/tracetools/include/tracetools/status.h
+++ b/tracetools/include/tracetools/status.h
@@ -22,7 +22,7 @@ extern "C"
 {
 #endif
 
-int tracetools_status(bool trace_compile_status_enabled);
+int tracetools_status(bool trace_status_enabled);
 
 #ifdef __cplusplus
 }

--- a/tracetools/include/tracetools/tracetools.h
+++ b/tracetools/include/tracetools/tracetools.h
@@ -142,6 +142,12 @@ extern "C"
  */
 TRACETOOLS_PUBLIC bool ros_trace_compile_status(void);
 
+/// Get tracing runtime status.
+/**
+ * \return `true` if tracing is enabled, `false` otherwise
+ */
+TRACETOOLS_PUBLIC bool ros_trace_runtime_status(void);
+
 /// `rcl_init`
 /**
  * Initialisation for the whole process.

--- a/tracetools/src/status.c
+++ b/tracetools/src/status.c
@@ -19,11 +19,11 @@
 #include "tracetools/config.h"
 #include "tracetools/status.h"
 
-int tracetools_status(bool trace_compile_status_enabled)
+int tracetools_status(bool trace_status_enabled)
 {
 #ifndef TRACETOOLS_DISABLED
   printf("Tracing ");
-  if (trace_compile_status_enabled) {
+  if (trace_status_enabled) {
     printf("enabled\n");
     return 0;
   } else {
@@ -31,7 +31,7 @@ int tracetools_status(bool trace_compile_status_enabled)
     return 1;
   }
 #else
-  (void)trace_compile_status_enabled;
+  (void)trace_status_enabled;
   printf("Tracing disabled through configuration\n");
   return 1;
 #endif

--- a/tracetools/src/status_tool.c
+++ b/tracetools/src/status_tool.c
@@ -19,7 +19,7 @@
 int main(void)
 {
 #ifndef TRACETOOLS_DISABLED
-  return tracetools_status(ros_trace_compile_status());
+  return tracetools_status(ros_trace_runtime_status());
 #else
   return tracetools_status(false);
 #endif

--- a/tracetools/src/tp.c
+++ b/tracetools/src/tp.c
@@ -13,6 +13,4 @@
 // limitations under the License.
 
 #define TRACEPOINT_CREATE_PROBES
-
-#define TRACEPOINT_DEFINE
 #include "tracetools/tp_call.h"

--- a/tracetools/src/tp_define.c
+++ b/tracetools/src/tp_define.c
@@ -1,0 +1,17 @@
+// Copyright 2019 Robert Bosch GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#define TRACEPOINT_DEFINE
+#define TRACEPOINT_PROBE_DYNAMIC_LINKAGE
+#include "tracetools/tp_call.h"

--- a/tracetools/src/tracetools.c
+++ b/tracetools/src/tracetools.c
@@ -14,8 +14,6 @@
 // limitations under the License.
 
 #include "tracetools/tracetools.h"
-#include <dlfcn.h>
-#include <stdio.h>
 
 #ifndef TRACETOOLS_DISABLED
 
@@ -25,6 +23,10 @@
  * this fix gets merged: https://review.lttng.org/c/lttng-ust/+/9001
  */
 #ifndef TRACETOOLS_TRACEPOINTS_EXCLUDED
+# include <dlfcn.h>
+# include <stdio.h>
+# include <stdlib.h>
+
 # include "tracetools/tp_call.h"
 // *INDENT-OFF*
 # define _CONDITIONAL_TP(...) \
@@ -69,15 +71,6 @@
     _CONDITIONAL_DO_TP(event_name); \
   }
 // *INDENT-ON*
-
-bool ros_trace_compile_status(void)
-{
-#ifndef TRACETOOLS_TRACEPOINTS_EXCLUDED
-  return true;
-#else
-  return false;
-#endif
-}
 
 // Ignore unused-parameters warning when tracepoints are excluded
 #ifndef _WIN32
@@ -491,16 +484,63 @@ DEFINE_TRACEPOINT(
   TRACEPOINT_ARGS(
     buffer))
 
+#ifndef TRACETOOLS_TRACEPOINTS_EXCLUDED
+static void * tracetools_provider_handle = NULL;
+
+bool ros_trace_compile_status(void)
+{
+  return true;
+}
+
+bool ros_trace_runtime_status(void)
+{
+  return tracetools_provider_handle != NULL;
+}
+
+static bool get_boolean_env(const char *name)
+{
+  const char * value = getenv(name);
+  return value != NULL && strcmp(value, "1") == 0;
+}
+
 void __attribute__((constructor)) tracetools_init()
 {
-  if(getenv("TRACETOOLS_DISABLE")) {
-    fprintf(stderr, "ROS 2 tracing disabled\n");
+  const bool verbose = get_boolean_env("TRACETOOLS_VERBOSE");
+  if (get_boolean_env("TRACETOOLS_RUNTIME_DISABLE")) {
+    if (verbose) {
+      fprintf(stderr, "ROS 2 tracing disabled\n");
+    }
     return;
   }
-  if(!dlopen("libtracetools_provider.so", RTLD_NOW | RTLD_GLOBAL)) {
-    fprintf(stderr, "Failed to load tracepoint provider for ROS 2 tracing, disabling\n");
+  tracetools_provider_handle = dlopen(TRACETOOLS_PROVIDER_SONAME, RTLD_NOW | RTLD_GLOBAL);
+  if (tracetools_provider_handle == NULL) {
+    fprintf(stderr, "Failed to load tracepoint provider for ROS 2 tracing: %s\n", dlerror());
+    if (verbose) {
+      fprintf(stderr, "ROS 2 tracing disabled\n");
+    }
   }
 }
+
+void __attribute__((destructor)) tracetools_fini()
+{
+  if (tracetools_provider_handle != NULL) {
+    if (dlclose(tracetools_provider_handle) != 0) {
+      fprintf(stderr, "Failed to unload tracepoint provider for ROS 2 tracing: %s\n", dlerror());
+    }
+    tracetools_provider_handle = NULL;
+  }
+}
+#else
+bool ros_trace_compile_status(void)
+{
+  return false;
+}
+
+bool ros_trace_runtime_status(void)
+{
+  return false;
+}
+#endif  // TRACETOOLS_TRACEPOINTS_EXCLUDED
 
 #ifdef __clang__
 # pragma clang diagnostic pop

--- a/tracetools/src/tracetools.c
+++ b/tracetools/src/tracetools.c
@@ -14,6 +14,7 @@
 // limitations under the License.
 
 #include "tracetools/tracetools.h"
+#include "dlfcn.h"
 #include "stdio.h"
 
 #ifndef TRACETOOLS_DISABLED

--- a/tracetools/src/tracetools.c
+++ b/tracetools/src/tracetools.c
@@ -14,6 +14,7 @@
 // limitations under the License.
 
 #include "tracetools/tracetools.h"
+#include "stdio.h"
 
 #ifndef TRACETOOLS_DISABLED
 
@@ -488,6 +489,16 @@ DEFINE_TRACEPOINT(
     const void * buffer),
   TRACEPOINT_ARGS(
     buffer))
+
+void __attribute__((constructor)) tracetools_init() {
+  if(getenv("TRACETOOLS_DISABLE")) {
+    fprintf(stderr, "ROS 2 tracing disabled\n");
+    return;
+  }
+  if(!dlopen("libtracetools_provider.so", RTLD_NOW | RTLD_GLOBAL)) {
+    fprintf(stderr, "Failed to load tracepoint provider for ROS 2 tracing, disabling\n");
+  }
+}
 
 #ifdef __clang__
 # pragma clang diagnostic pop

--- a/tracetools/src/tracetools.c
+++ b/tracetools/src/tracetools.c
@@ -14,8 +14,8 @@
 // limitations under the License.
 
 #include "tracetools/tracetools.h"
-#include "dlfcn.h"
-#include "stdio.h"
+#include <dlfcn.h>
+#include <stdio.h>
 
 #ifndef TRACETOOLS_DISABLED
 
@@ -491,7 +491,8 @@ DEFINE_TRACEPOINT(
   TRACEPOINT_ARGS(
     buffer))
 
-void __attribute__((constructor)) tracetools_init() {
+void __attribute__((constructor)) tracetools_init()
+{
   if(getenv("TRACETOOLS_DISABLE")) {
     fprintf(stderr, "ROS 2 tracing disabled\n");
     return;


### PR DESCRIPTION
## Description

This patch makes ROS 2 specific tracepoint providers dynamically loadable, and then uses this functionality to opt them out on `tracetools` dload.

Closes https://github.com/ros2/rclcpp/issues/2860.

### Is this user-facing behavior change?

Not for the most part, unless the `TRACETOOLS_DISABLE` envvar is set.

### Did you use Generative AI?

No.