### PR TITLE
Make trace action parameters substitutable

### DIFF
--- a/test_tracetools_launch/test/test_tracetools_launch/test_trace_action.py
+++ b/test_tracetools_launch/test/test_tracetools_launch/test_trace_action.py
@@ -255,6 +255,11 @@ class TestTraceAction(unittest.TestCase):
             default_value='my-session-name',
             description='the session name',
         )
+        append_timestamp_arg = DeclareLaunchArgument(
+            'append-timestamp',
+            default_value='False',
+            description='whether to append a timestamp to the session name',
+        )
         append_trace_arg = DeclareLaunchArgument(
             'append-trace',
             default_value='False',
@@ -272,6 +277,7 @@ class TestTraceAction(unittest.TestCase):
         )
         action = Trace(
             session_name=LaunchConfiguration(session_name_arg.name),
+            append_timestamp=LaunchConfiguration(append_timestamp_arg.name),
             base_path=TextSubstitution(text=tmpdir),
             append_trace=LaunchConfiguration(append_trace_arg.name),
             events_kernel=[],
@@ -292,6 +298,7 @@ class TestTraceAction(unittest.TestCase):
         )
         context = self._assert_launch_no_errors([
             session_name_arg, 
+            append_timestamp_arg,
             append_trace_arg,
             subbuffer_size_ust_arg,
             subbuffer_size_kernel_arg,

--- a/test_tracetools_launch/test/test_tracetools_launch/test_trace_action.py
+++ b/test_tracetools_launch/test/test_tracetools_launch/test_trace_action.py
@@ -36,6 +36,7 @@ from launch.substitutions import EnvironmentVariable
 from launch.substitutions import LaunchConfiguration
 from launch.substitutions import TextSubstitution
 from launch.utilities import perform_substitutions
+from launch.utilities.type_utils import perform_typed_substitution
 from launch_ros.actions import Node
 
 from tracetools_launch.action import Trace
@@ -102,12 +103,12 @@ class TestTraceAction(unittest.TestCase):
             assert action.trace_directory
             self.assertTrue(action.trace_directory.startswith(tmpdir))
             self.assertTrue(pathlib.Path(tmpdir).exists())
-        self.assertEqual(append_trace, action.append_trace)
+        self.assertEqual(append_trace, perform_typed_substitution(context, action.append_trace, bool))
         self.assertEqual(0, len(action.events_kernel))
         self.assertEqual(
             events_ust, [perform_substitutions(context, x) for x in action.events_ust])
-        self.assertEqual(subbuffer_size_ust, action.subbuffer_size_ust)
-        self.assertEqual(subbuffer_size_kernel, action.subbuffer_size_kernel)
+        self.assertEqual(subbuffer_size_ust, perform_typed_substitution(context, action.subbuffer_size_ust, int))
+        self.assertEqual(subbuffer_size_kernel, perform_typed_substitution(context, action.subbuffer_size_kernel, int))
 
     def test_action(self) -> None:
         tmpdir = tempfile.mkdtemp(prefix='TestTraceAction__test_action')
@@ -254,9 +255,25 @@ class TestTraceAction(unittest.TestCase):
             default_value='my-session-name',
             description='the session name',
         )
+        append_trace_arg = DeclareLaunchArgument(
+            'append-trace',
+            default_value='False',
+            description='whether to append to an existing trace',
+        )
+        subbuffer_size_ust_arg = DeclareLaunchArgument(
+            'subbuffer-size-ust',
+            default_value='524288',
+            description='the subbuffer size for userspace traces',
+        )
+        subbuffer_size_kernel_arg = DeclareLaunchArgument(
+            'subbuffer-size-kernel',
+            default_value='1048576',
+            description='the subbuffer size for kernel traces',
+        )
         action = Trace(
             session_name=LaunchConfiguration(session_name_arg.name),
             base_path=TextSubstitution(text=tmpdir),
+            append_trace=LaunchConfiguration(append_trace_arg.name),
             events_kernel=[],
             syscalls=[],
             events_ust=[
@@ -270,10 +287,17 @@ class TestTraceAction(unittest.TestCase):
                     TextSubstitution(text='vtid'),
                 ],
             },
-            subbuffer_size_ust=524288,
-            subbuffer_size_kernel=1048576,
+            subbuffer_size_ust=LaunchConfiguration(subbuffer_size_ust_arg.name),
+            subbuffer_size_kernel=LaunchConfiguration(subbuffer_size_kernel_arg.name)
         )
-        context = self._assert_launch_no_errors([session_name_arg, action])
+        context = self._assert_launch_no_errors([
+            session_name_arg, 
+            append_trace_arg,
+            subbuffer_size_ust_arg,
+            subbuffer_size_kernel_arg,
+            action
+        ])
+        
         self._check_trace_action(action, context, tmpdir)
 
         assert isinstance(action.context_fields, dict)

--- a/test_tracetools_launch/test/test_tracetools_launch/test_trace_action.py
+++ b/test_tracetools_launch/test/test_tracetools_launch/test_trace_action.py
@@ -103,12 +103,21 @@ class TestTraceAction(unittest.TestCase):
             assert action.trace_directory
             self.assertTrue(action.trace_directory.startswith(tmpdir))
             self.assertTrue(pathlib.Path(tmpdir).exists())
-        self.assertEqual(append_trace, perform_typed_substitution(context, action.append_trace, bool))
+        self.assertEqual(
+            append_trace,
+            perform_typed_substitution(context, action.append_trace, bool)
+        )
         self.assertEqual(0, len(action.events_kernel))
         self.assertEqual(
             events_ust, [perform_substitutions(context, x) for x in action.events_ust])
-        self.assertEqual(subbuffer_size_ust, perform_typed_substitution(context, action.subbuffer_size_ust, int))
-        self.assertEqual(subbuffer_size_kernel, perform_typed_substitution(context, action.subbuffer_size_kernel, int))
+        self.assertEqual(
+            subbuffer_size_ust,
+            perform_typed_substitution(context, action.subbuffer_size_ust, int)
+        )
+        self.assertEqual(
+            subbuffer_size_kernel,
+            perform_typed_substitution(context, action.subbuffer_size_kernel, int)
+        )
 
     def test_action(self) -> None:
         tmpdir = tempfile.mkdtemp(prefix='TestTraceAction__test_action')
@@ -297,14 +306,14 @@ class TestTraceAction(unittest.TestCase):
             subbuffer_size_kernel=LaunchConfiguration(subbuffer_size_kernel_arg.name)
         )
         context = self._assert_launch_no_errors([
-            session_name_arg, 
+            session_name_arg,
             append_timestamp_arg,
             append_trace_arg,
             subbuffer_size_ust_arg,
             subbuffer_size_kernel_arg,
             action
         ])
-        
+
         self._check_trace_action(action, context, tmpdir)
 
         assert isinstance(action.context_fields, dict)

--- a/tracetools_launch/tracetools_launch/action.py
+++ b/tracetools_launch/tracetools_launch/action.py
@@ -127,8 +127,7 @@ class Trace(Action):
         """
         Create a Trace.
 
-        Substitutions are supported for the session name,
-        base path, and the lists of events and context fields.
+        Substitutions are supported for all parameters.
 
         For the lists of events, wildcards can be used, e.g., 'ros2:*' for
         all events from the 'ros2' tracepoint provider or '*' for all events.

--- a/tracetools_launch/tracetools_launch/action.py
+++ b/tracetools_launch/tracetools_launch/action.py
@@ -18,6 +18,7 @@
 import fnmatch
 import re
 import shlex
+from typing import cast
 from typing import Iterable
 from typing import List
 from typing import Mapping
@@ -161,7 +162,10 @@ class Trace(Action):
         self._session_name: List[Substitution] = [
             IfElseSubstitution(
                 str(append_timestamp) if isinstance(append_timestamp, bool)
-                else normalize_typed_substitution(append_timestamp, bool),
+                else cast(
+                    List[Substitution],
+                    normalize_typed_substitution(append_timestamp, bool)
+                ),
                 Trace.AppendTimestamp(session_name),
                 session_name
             )

--- a/tracetools_launch/tracetools_launch/action.py
+++ b/tracetools_launch/tracetools_launch/action.py
@@ -41,6 +41,7 @@ from launch.utilities import normalize_to_list_of_substitutions
 from launch.utilities import perform_substitutions
 from launch.utilities.type_utils import normalize_typed_substitution
 from launch.utilities.type_utils import perform_typed_substitution
+from launch.utilities.type_utils import NormalizedValueType
 from tracetools_trace.tools import lttng
 from tracetools_trace.tools import names
 from tracetools_trace.tools import path
@@ -200,7 +201,7 @@ class Trace(Action):
         return self._base_path
 
     @property
-    def append_trace(self) -> Union[bool, List[Substitution]]:
+    def append_trace(self) -> NormalizedValueType:
         return self._append_trace
 
     @property
@@ -226,11 +227,11 @@ class Trace(Action):
         return self._context_fields
 
     @property
-    def subbuffer_size_ust(self) -> Union[int, List[SomeSubstitutionsType]]:
+    def subbuffer_size_ust(self) -> NormalizedValueType:
         return self._subbuffer_size_ust
 
     @property
-    def subbuffer_size_kernel(self) -> Union[int, List[SomeSubstitutionsType]]:
+    def subbuffer_size_kernel(self) -> NormalizedValueType:
         return self._subbuffer_size_kernel
 
     @classmethod

--- a/tracetools_launch/tracetools_launch/action.py
+++ b/tracetools_launch/tracetools_launch/action.py
@@ -40,8 +40,8 @@ from launch.substitutions import TextSubstitution
 from launch.utilities import normalize_to_list_of_substitutions
 from launch.utilities import perform_substitutions
 from launch.utilities.type_utils import normalize_typed_substitution
-from launch.utilities.type_utils import perform_typed_substitution
 from launch.utilities.type_utils import NormalizedValueType
+from launch.utilities.type_utils import perform_typed_substitution
 from tracetools_trace.tools import lttng
 from tracetools_trace.tools import names
 from tracetools_trace.tools import path

--- a/tracetools_launch/tracetools_launch/action.py
+++ b/tracetools_launch/tracetools_launch/action.py
@@ -39,6 +39,8 @@ from launch.substitutions import IfElseSubstitution
 from launch.substitutions import TextSubstitution
 from launch.utilities import normalize_to_list_of_substitutions
 from launch.utilities import perform_substitutions
+from launch.utilities.type_utils import normalize_typed_substitution
+from launch.utilities.type_utils import perform_typed_substitution
 from tracetools_trace.tools import lttng
 from tracetools_trace.tools import names
 from tracetools_trace.tools import path
@@ -111,15 +113,15 @@ class Trace(Action):
         session_name: SomeSubstitutionsType,
         append_timestamp: bool = False,
         base_path: Optional[SomeSubstitutionsType] = None,
-        append_trace: bool = False,
+        append_trace: Union[bool, SomeSubstitutionsType] = False,
         events_ust: Iterable[SomeSubstitutionsType] = names.DEFAULT_EVENTS_ROS,
         events_kernel: Iterable[SomeSubstitutionsType] = [],
         syscalls: Iterable[SomeSubstitutionsType] = [],
         context_fields:
             Union[Iterable[SomeSubstitutionsType], Mapping[str, Iterable[SomeSubstitutionsType]]]
             = names.DEFAULT_CONTEXT,
-        subbuffer_size_ust: int = 8 * 4096,
-        subbuffer_size_kernel: int = 32 * 4096,
+        subbuffer_size_ust: Union[int, SomeSubstitutionsType] = 8 * 4096,
+        subbuffer_size_kernel: Union[int, SomeSubstitutionsType] = 32 * 4096,
         **kwargs,
     ) -> None:
         """
@@ -167,7 +169,7 @@ class Trace(Action):
                 Trace.TraceDirectory(),
             )
         ]
-        self._append_trace = append_trace
+        self._append_trace = normalize_typed_substitution(append_trace, bool)
         self._trace_directory: Optional[str] = None
         self._events_ust = [normalize_to_list_of_substitutions(x) for x in events_ust]
         self._events_kernel = [normalize_to_list_of_substitutions(x) for x in events_kernel]
@@ -183,8 +185,8 @@ class Trace(Action):
             else [normalize_to_list_of_substitutions(field) for field in context_fields]
         )
         self._ld_preload_actions: List[Action] = []
-        self._subbuffer_size_ust = subbuffer_size_ust
-        self._subbuffer_size_kernel = subbuffer_size_kernel
+        self._subbuffer_size_ust = normalize_typed_substitution(subbuffer_size_ust, int)
+        self._subbuffer_size_kernel = normalize_typed_substitution(subbuffer_size_kernel, int)
 
     @property
     def session_name(self) -> List[Substitution]:
@@ -195,7 +197,7 @@ class Trace(Action):
         return self._base_path
 
     @property
-    def append_trace(self) -> bool:
+    def append_trace(self) -> Union[bool, List[Substitution]]:  
         return self._append_trace
 
     @property
@@ -221,11 +223,11 @@ class Trace(Action):
         return self._context_fields
 
     @property
-    def subbuffer_size_ust(self) -> int:
+    def subbuffer_size_ust(self) -> Union[int, List[SomeSubstitutionsType]]:
         return self._subbuffer_size_ust
 
     @property
-    def subbuffer_size_kernel(self) -> int:
+    def subbuffer_size_kernel(self) -> Union[int, List[SomeSubstitutionsType]]:
         return self._subbuffer_size_kernel
 
     @classmethod
@@ -394,6 +396,7 @@ class Trace(Action):
     def execute(self, context: LaunchContext) -> List[Action]:
         session_name = perform_substitutions(context, self._session_name)
         base_path = perform_substitutions(context, self._base_path)
+        append_trace = perform_typed_substitution(context, self._append_trace, bool)
         events_ust = [perform_substitutions(context, x) for x in self._events_ust]
         events_kernel = [perform_substitutions(context, x) for x in self._events_kernel]
         syscalls = [perform_substitutions(context, x) for x in self._syscalls]
@@ -405,6 +408,8 @@ class Trace(Action):
             if isinstance(self._context_fields, Mapping)
             else [perform_substitutions(context, field) for field in self._context_fields]
         )
+        subbuffersize_ust = perform_typed_substitution(context, self._subbuffer_size_ust, int)
+        subbuffersize_kernel = perform_typed_substitution(context, self._subbuffer_size_kernel, int)
         self._ld_preload_actions = self._get_ld_preload_actions(events_ust)
 
         def setup() -> bool:
@@ -412,13 +417,13 @@ class Trace(Action):
                 self._trace_directory = lttng.lttng_init(
                     session_name=session_name,
                     base_path=base_path,
-                    append_trace=self._append_trace,
+                    append_trace=append_trace,
                     ros_events=events_ust,
                     kernel_events=events_kernel,
                     syscalls=syscalls,
                     context_fields=context_fields,
-                    subbuffer_size_ust=self._subbuffer_size_ust,
-                    subbuffer_size_kernel=self._subbuffer_size_kernel,
+                    subbuffer_size_ust=subbuffersize_ust,
+                    subbuffer_size_kernel=subbuffersize_kernel,
                 )
                 if self._trace_directory is None:
                     return False

--- a/tracetools_launch/tracetools_launch/action.py
+++ b/tracetools_launch/tracetools_launch/action.py
@@ -111,7 +111,7 @@ class Trace(Action):
         self,
         *,
         session_name: SomeSubstitutionsType,
-        append_timestamp: bool = False,
+        append_timestamp: Union[bool, SomeSubstitutionsType] = False,
         base_path: Optional[SomeSubstitutionsType] = None,
         append_trace: Union[bool, SomeSubstitutionsType] = False,
         events_ust: Iterable[SomeSubstitutionsType] = names.DEFAULT_EVENTS_ROS,
@@ -160,7 +160,11 @@ class Trace(Action):
         self._logger = logging.get_logger(__name__)
         self._session_name: List[Substitution] = [
             IfElseSubstitution(
-                str(append_timestamp), Trace.AppendTimestamp(session_name), session_name)
+                str(append_timestamp) if isinstance(append_timestamp, bool) 
+                                      else normalize_typed_substitution(append_timestamp, bool),
+                Trace.AppendTimestamp(session_name),
+                session_name
+            )
         ]
         self._base_path: List[Substitution] = [
             IfElseSubstitution(

--- a/tracetools_launch/tracetools_launch/action.py
+++ b/tracetools_launch/tracetools_launch/action.py
@@ -159,8 +159,8 @@ class Trace(Action):
         self._logger = logging.get_logger(__name__)
         self._session_name: List[Substitution] = [
             IfElseSubstitution(
-                str(append_timestamp) if isinstance(append_timestamp, bool) 
-                                      else normalize_typed_substitution(append_timestamp, bool),
+                str(append_timestamp) if isinstance(append_timestamp, bool)
+                else normalize_typed_substitution(append_timestamp, bool),
                 Trace.AppendTimestamp(session_name),
                 session_name
             )
@@ -200,7 +200,7 @@ class Trace(Action):
         return self._base_path
 
     @property
-    def append_trace(self) -> Union[bool, List[Substitution]]:  
+    def append_trace(self) -> Union[bool, List[Substitution]]:
         return self._append_trace
 
     @property
@@ -412,7 +412,11 @@ class Trace(Action):
             else [perform_substitutions(context, field) for field in self._context_fields]
         )
         subbuffersize_ust = perform_typed_substitution(context, self._subbuffer_size_ust, int)
-        subbuffersize_kernel = perform_typed_substitution(context, self._subbuffer_size_kernel, int)
+        subbuffersize_kernel = perform_typed_substitution(
+            context,
+            self._subbuffer_size_kernel,
+            int
+        )
         self._ld_preload_actions = self._get_ld_preload_actions(events_ust)
 
         def setup() -> bool:


### PR DESCRIPTION
## Description

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->
This PR updates the Trace action to make the parameters `append_timestamp`, `append_trace`, `subbuffer_size_ust` and `subbuffer_size_kernel`  to be specified using substitutions in Python launch files.

The related tests have been updated accordingly and are passing.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

Fixes #186 

### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->
Yes.
### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->
No.

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
Support for XML and YAML frontends is not yet implemented.

