### PR TITLE
Make trace action parameters substitutable for xml and yaml launch files

### DIFF
--- a/test_tracetools_launch/test/test_tracetools_launch/test_trace_action.py
+++ b/test_tracetools_launch/test/test_tracetools_launch/test_trace_action.py
@@ -84,7 +84,7 @@ class TestTraceAction(unittest.TestCase):
             (action for action in ld.entities if isinstance(action, Trace)),
             None
         )
-        assert trace_action is not None, f'expected Trace action, got: {trace_action}'
+        assert trace_action is not None, 'did not find Trace action'
         return trace_action, ls.context
 
     def _check_trace_action(
@@ -336,7 +336,7 @@ class TestTraceAction(unittest.TestCase):
         del os.environ['TestTraceAction__context_field']
 
     def test_action_substitutions_frontend_xml(self) -> None:
-        tmpdir = tempfile.mkdtemp(prefix='TestTraceAction__test_frontend_xml')
+        tmpdir = tempfile.mkdtemp(prefix='TestTraceAction__test_action_substitutions_frontend_xml')
 
         xml_file = textwrap.dedent(
             r"""
@@ -371,7 +371,8 @@ class TestTraceAction(unittest.TestCase):
         shutil.rmtree(tmpdir)
 
     def test_action_substitutions_frontend_yaml(self) -> None:
-        tmpdir = tempfile.mkdtemp(prefix='TestTraceAction__test_frontend_yaml')
+        tmpdir = tempfile.mkdtemp(
+            prefix='TestTraceAction__test_action_substitutions_frontend_yaml')
 
         yaml_file = textwrap.dedent(
             r"""

--- a/test_tracetools_launch/test/test_tracetools_launch/test_trace_action.py
+++ b/test_tracetools_launch/test/test_tracetools_launch/test_trace_action.py
@@ -345,6 +345,8 @@ class TestTraceAction(unittest.TestCase):
                 <arg name="append-timestamp" default="false" />
                 <arg name="base-path" default="{}" />
                 <arg name="append-trace" default="true" />
+                <arg name="events-ust-1" default="ros2:*" />
+                <arg name="events-ust-2" default="*" />
                 <arg name="subbuffer-size-ust" default="524288" />
                 <arg name="subbuffer-size-kernel" default="1048576" />
                 <trace
@@ -354,7 +356,7 @@ class TestTraceAction(unittest.TestCase):
                     append-trace="$(var append-trace)"
                     events-kernel=""
                     syscalls=""
-                    events-ust="ros2:* *"
+                    events-ust="$(var events-ust-1) $(var events-ust-2)"
                     subbuffer-size-ust="$(var subbuffer-size-ust)"
                     subbuffer-size-kernel="$(var subbuffer-size-kernel)"
                 />
@@ -390,6 +392,12 @@ class TestTraceAction(unittest.TestCase):
                 name: append-trace
                 default: "true"
             - arg:
+                name: events-ust-1
+                default: "ros2:*"
+            - arg:
+                name: events-ust-2
+                default: "*"
+            - arg:
                 name: subbuffer-size-ust
                 default: "524288"
             - arg:
@@ -402,7 +410,7 @@ class TestTraceAction(unittest.TestCase):
                 append-trace: "$(var append-trace)"
                 events-kernel: ""
                 syscalls: ""
-                events-ust: ros2:* *
+                events-ust: "$(var events-ust-1) $(var events-ust-2)"
                 subbuffer-size-ust: "$(var subbuffer-size-ust)"
                 subbuffer-size-kernel: "$(var subbuffer-size-kernel)"
             """.format(tmpdir)

--- a/test_tracetools_launch/test/test_tracetools_launch/test_trace_action.py
+++ b/test_tracetools_launch/test/test_tracetools_launch/test_trace_action.py
@@ -80,8 +80,11 @@ class TestTraceAction(unittest.TestCase):
         ls = LaunchService()
         ls.include_launch_description(ld)
         self.assertEqual(0, ls.run(), 'expected no errors')
-        trace_action = ld.describe_sub_entities()[0]
-        assert isinstance(trace_action, Trace), f'expected Trace action, got: {trace_action}'
+        trace_action = next(
+            (action for action in ld.entities if isinstance(action, Trace)),
+            None
+        )
+        assert trace_action is not None, f'expected Trace action, got: {trace_action}'
         return trace_action, ls.context
 
     def _check_trace_action(
@@ -331,6 +334,86 @@ class TestTraceAction(unittest.TestCase):
         shutil.rmtree(tmpdir)
         del os.environ['TestTraceAction__event_ust']
         del os.environ['TestTraceAction__context_field']
+
+    def test_action_substitutions_frontend_xml(self) -> None:
+        tmpdir = tempfile.mkdtemp(prefix='TestTraceAction__test_frontend_xml')
+
+        xml_file = textwrap.dedent(
+            r"""
+            <launch>
+                <arg name="session-name" default="my-session-name" />
+                <arg name="append-timestamp" default="false" />
+                <arg name="base-path" default="{}" />
+                <arg name="append-trace" default="true" />
+                <arg name="subbuffer-size-ust" default="524288" />
+                <arg name="subbuffer-size-kernel" default="1048576" />
+                <trace
+                    session-name="$(var session-name)"
+                    append-timestamp="$(var append-timestamp)"
+                    base-path="$(var base-path)"
+                    append-trace="$(var append-trace)"
+                    events-kernel=""
+                    syscalls=""
+                    events-ust="ros2:* *"
+                    subbuffer-size-ust="$(var subbuffer-size-ust)"
+                    subbuffer-size-kernel="$(var subbuffer-size-kernel)"
+                />
+            </launch>
+            """.format(tmpdir)
+        )
+
+        trace_action = None
+        with io.StringIO(xml_file) as f:
+            trace_action, context = self._assert_launch_frontend_no_errors(f)
+
+        self._check_trace_action(trace_action, context, tmpdir, append_trace=True)
+
+        shutil.rmtree(tmpdir)
+
+    def test_action_substitutions_frontend_yaml(self) -> None:
+        tmpdir = tempfile.mkdtemp(prefix='TestTraceAction__test_frontend_yaml')
+
+        yaml_file = textwrap.dedent(
+            r"""
+            launch:
+            - arg:
+                name: session-name
+                default: my-session-name
+            - arg:
+                name: append-timestamp
+                default: "false"
+            - arg:
+                name: base-path
+                default: "{}"
+            - arg:
+                name: append-trace
+                default: "true"
+            - arg:
+                name: subbuffer-size-ust
+                default: "524288"
+            - arg:
+                name: subbuffer-size-kernel
+                default: "1048576"
+            - trace:
+                session-name: "$(var session-name)"
+                append-timestamp: "$(var append-timestamp)"
+                base-path: "$(var base-path)"
+                append-trace: "$(var append-trace)"
+                events-kernel: ""
+                syscalls: ""
+                events-ust: ros2:* *
+                subbuffer-size-ust: "$(var subbuffer-size-ust)"
+                subbuffer-size-kernel: "$(var subbuffer-size-kernel)"
+            """.format(tmpdir)
+        )
+
+        trace_action = None
+        with io.StringIO(yaml_file) as f:
+            trace_action, context = self._assert_launch_frontend_no_errors(f)
+
+        self._check_trace_action(trace_action, context, tmpdir, append_trace=True)
+
+        shutil.rmtree(tmpdir)
 
     def test_action_ld_preload(self) -> None:
         tmpdir = tempfile.mkdtemp(prefix='TestTraceAction__test_action_ld_preload')

--- a/tracetools_launch/tracetools_launch/action.py
+++ b/tracetools_launch/tracetools_launch/action.py
@@ -307,23 +307,19 @@ class Trace(Action):
         session_name = entity.get_attr('session-name')
         if session_name is not None:
             kwargs['session_name'] = parser.parse_substitution(session_name)
-        append_timestamp = entity.get_attr(
-            'append-timestamp', data_type=bool, optional=True, can_be_str=True)
+        append_timestamp = entity.get_attr('append-timestamp', data_type=bool, optional=True)
         if append_timestamp is not None:
-            kwargs['append_timestamp'] = (
-                append_timestamp if isinstance(append_timestamp, bool)
+            kwargs['append_timestamp'] = append_timestamp \
+                if isinstance(append_timestamp, bool) \
                 else parser.parse_substitution(append_timestamp)
-            )
         base_path = entity.get_attr('base-path', optional=True)
         if base_path:
             kwargs['base_path'] = parser.parse_substitution(base_path)
-        append_trace = entity.get_attr(
-            'append-trace', data_type=bool, optional=True, can_be_str=True)
+        append_trace = entity.get_attr('append-trace', data_type=bool, optional=True)
         if append_trace is not None:
-            kwargs['append_trace'] = (
-                append_trace if isinstance(append_trace, bool)
+            kwargs['append_trace'] = append_trace \
+                if isinstance(append_trace, bool) \
                 else parser.parse_substitution(append_trace)
-            )
         # Make sure to handle empty strings and replace with empty lists,
         # otherwise an empty string enables all events
         events_ust = entity.get_attr('events-ust', optional=True)
@@ -342,21 +338,16 @@ class Trace(Action):
         if context_fields is not None:
             kwargs['context_fields'] = cls._parse_cmdline(context_fields, parser) \
                 if context_fields else []
-        subbuffer_size_ust = entity.get_attr(
-            'subbuffer-size-ust', data_type=int, optional=True, can_be_str=True)
+        subbuffer_size_ust = entity.get_attr('subbuffer-size-ust', data_type=int, optional=True)
         if subbuffer_size_ust is not None:
-            kwargs['subbuffer_size_ust'] = (
-                subbuffer_size_ust if isinstance(subbuffer_size_ust, int)
+            kwargs['subbuffer_size_ust'] = subbuffer_size_ust \
+                if isinstance(subbuffer_size_ust, int) \
                 else parser.parse_substitution(subbuffer_size_ust)
-            )
-        subbuffer_size_kernel = entity.get_attr(
-            'subbuffer-size-kernel', data_type=int, optional=True, can_be_str=True)
+        subbuffer_size_kernel = entity.get_attr('subbuffer-size-kernel', data_type=int, optional=True)
         if subbuffer_size_kernel is not None:
-            kwargs['subbuffer_size_kernel'] = (
-                subbuffer_size_kernel if isinstance(subbuffer_size_kernel, int)
+            kwargs['subbuffer_size_kernel'] = subbuffer_size_kernel \
+                if isinstance(subbuffer_size_kernel, int) \
                 else parser.parse_substitution(subbuffer_size_kernel)
-            )
-
         return cls, kwargs
 
     @staticmethod

--- a/tracetools_launch/tracetools_launch/action.py
+++ b/tracetools_launch/tracetools_launch/action.py
@@ -311,7 +311,7 @@ class Trace(Action):
         if append_timestamp is not None:
             kwargs['append_timestamp'] = append_timestamp \
                 if isinstance(append_timestamp, bool) \
-                else parser.parse_substitution(append_timestamp)
+                else parser.parse_substitution(cast(str, append_timestamp))
         base_path = entity.get_attr('base-path', optional=True)
         if base_path:
             kwargs['base_path'] = parser.parse_substitution(base_path)
@@ -319,7 +319,7 @@ class Trace(Action):
         if append_trace is not None:
             kwargs['append_trace'] = append_trace \
                 if isinstance(append_trace, bool) \
-                else parser.parse_substitution(append_trace)
+                else parser.parse_substitution(cast(str, append_trace))
         # Make sure to handle empty strings and replace with empty lists,
         # otherwise an empty string enables all events
         events_ust = entity.get_attr('events-ust', optional=True)
@@ -342,12 +342,12 @@ class Trace(Action):
         if subbuffer_size_ust is not None:
             kwargs['subbuffer_size_ust'] = subbuffer_size_ust \
                 if isinstance(subbuffer_size_ust, int) \
-                else parser.parse_substitution(subbuffer_size_ust)
+                else parser.parse_substitution(cast(str, subbuffer_size_ust))
         subbuffer_size_kernel = entity.get_attr('subbuffer-size-kernel', data_type=int, optional=True)
         if subbuffer_size_kernel is not None:
             kwargs['subbuffer_size_kernel'] = subbuffer_size_kernel \
                 if isinstance(subbuffer_size_kernel, int) \
-                else parser.parse_substitution(subbuffer_size_kernel)
+                else parser.parse_substitution(cast(str, subbuffer_size_kernel))
         return cls, kwargs
 
     @staticmethod

--- a/tracetools_launch/tracetools_launch/action.py
+++ b/tracetools_launch/tracetools_launch/action.py
@@ -304,18 +304,26 @@ class Trace(Action):
         """Parse."""
         _, kwargs = super().parse(entity, parser)
 
-        kwargs['session_name'] = entity.get_attr('session-name')
+        session_name = entity.get_attr('session-name')
+        if session_name is not None:
+            kwargs['session_name'] = parser.parse_substitution(session_name)
         append_timestamp = entity.get_attr(
-            'append-timestamp', data_type=bool, optional=True, can_be_str=False)
+            'append-timestamp', data_type=bool, optional=True, can_be_str=True)
         if append_timestamp is not None:
-            kwargs['append_timestamp'] = append_timestamp
+            kwargs['append_timestamp'] = (
+                append_timestamp if isinstance(append_timestamp, bool)
+                else parser.parse_substitution(append_timestamp)
+            )
         base_path = entity.get_attr('base-path', optional=True)
         if base_path:
             kwargs['base_path'] = parser.parse_substitution(base_path)
         append_trace = entity.get_attr(
-            'append-trace', data_type=bool, optional=True, can_be_str=False)
+            'append-trace', data_type=bool, optional=True, can_be_str=True)
         if append_trace is not None:
-            kwargs['append_trace'] = append_trace
+            kwargs['append_trace'] = (
+                append_trace if isinstance(append_trace, bool)
+                else parser.parse_substitution(append_trace)
+            )
         # Make sure to handle empty strings and replace with empty lists,
         # otherwise an empty string enables all events
         events_ust = entity.get_attr('events-ust', optional=True)
@@ -335,13 +343,19 @@ class Trace(Action):
             kwargs['context_fields'] = cls._parse_cmdline(context_fields, parser) \
                 if context_fields else []
         subbuffer_size_ust = entity.get_attr(
-            'subbuffer-size-ust', data_type=int, optional=True, can_be_str=False)
+            'subbuffer-size-ust', data_type=int, optional=True, can_be_str=True)
         if subbuffer_size_ust is not None:
-            kwargs['subbuffer_size_ust'] = subbuffer_size_ust
+            kwargs['subbuffer_size_ust'] = (
+                subbuffer_size_ust if isinstance(subbuffer_size_ust, int)
+                else parser.parse_substitution(subbuffer_size_ust)
+            )
         subbuffer_size_kernel = entity.get_attr(
-            'subbuffer-size-kernel', data_type=int, optional=True, can_be_str=False)
+            'subbuffer-size-kernel', data_type=int, optional=True, can_be_str=True)
         if subbuffer_size_kernel is not None:
-            kwargs['subbuffer_size_kernel'] = subbuffer_size_kernel
+            kwargs['subbuffer_size_kernel'] = (
+                subbuffer_size_kernel if isinstance(subbuffer_size_kernel, int)
+                else parser.parse_substitution(subbuffer_size_kernel)
+            )
 
         return cls, kwargs
 

--- a/tracetools_launch/tracetools_launch/action.py
+++ b/tracetools_launch/tracetools_launch/action.py
@@ -343,7 +343,8 @@ class Trace(Action):
             kwargs['subbuffer_size_ust'] = subbuffer_size_ust \
                 if isinstance(subbuffer_size_ust, int) \
                 else parser.parse_substitution(cast(str, subbuffer_size_ust))
-        subbuffer_size_kernel = entity.get_attr('subbuffer-size-kernel', data_type=int, optional=True)
+        subbuffer_size_kernel = entity.get_attr(
+            'subbuffer-size-kernel', data_type=int, optional=True)
         if subbuffer_size_kernel is not None:
             kwargs['subbuffer_size_kernel'] = subbuffer_size_kernel \
                 if isinstance(subbuffer_size_kernel, int) \


### PR DESCRIPTION
This PR if merged will allow users to set the parameters `session_name`, `append_timestamp`, `append_trace`, `subbuffer_size_ust` and `subbuffer_size_kernel`  using substitutions in xml and yaml launch files.

Continues the work from #187 

Related tests have been added and are passing.