### PR TITLE
Add support for starting tracing at runtime

### DIFF
--- a/lttngpy/CMakeLists.txt
+++ b/lttngpy/CMakeLists.txt
@@ -87,6 +87,7 @@ if(NOT LTTNGPY_DISABLED)
     src/lttngpy/event.cpp
     src/lttngpy/lttng.cpp
     src/lttngpy/session.cpp
+    src/lttngpy/snapshot.cpp
   )
 endif()
 

--- a/lttngpy/src/lttngpy/_lttngpy_pybind11.cpp
+++ b/lttngpy/src/lttngpy/_lttngpy_pybind11.cpp
@@ -67,6 +67,13 @@ PYBIND11_MODULE(_lttngpy_pybind11, m) {
     py::arg("session_name"),
     py::arg("url"));
   m.def(
+    "lttng_create_session_snapshot",
+    &lttng_create_session_snapshot,
+    "Create snapshot session.",
+    py::kw_only(),
+    py::arg("session_name"),
+    py::arg("url"));
+  m.def(
     "lttng_destroy_session",
     &lttng_destroy_session,
     "Destroy session.",

--- a/lttngpy/src/lttngpy/_lttngpy_pybind11.cpp
+++ b/lttngpy/src/lttngpy/_lttngpy_pybind11.cpp
@@ -25,6 +25,7 @@
 #  include "lttngpy/event.hpp"
 #  include "lttngpy/lttng.hpp"
 #  include "lttngpy/session.hpp"
+#  include "lttngpy/snapshot.hpp"
 #endif  // LTTNGPY_DISABLED
 #include "lttngpy/status.hpp"
 
@@ -97,6 +98,17 @@ PYBIND11_MODULE(_lttngpy_pybind11, m) {
     "Stop tracing.",
     py::kw_only(),
     py::arg("session_name"));
+  m.def(
+    "lttng_record_snapshot",
+    &lttngpy::lttng_record_snapshot,
+    "Record a snapshot session.",
+    py::kw_only(),
+    py::arg("session_name"),
+    py::arg("id"),
+    py::arg("max_size"),
+    py::arg("name"),
+    py::arg("url"),
+    py::arg("wait"));
 
   // Session info
   m.def(

--- a/lttngpy/src/lttngpy/_lttngpy_pybind11.cpp
+++ b/lttngpy/src/lttngpy/_lttngpy_pybind11.cpp
@@ -75,6 +75,15 @@ PYBIND11_MODULE(_lttngpy_pybind11, m) {
     py::arg("session_name"),
     py::arg("url"));
   m.def(
+    "lttng_add_snapshot_output",
+    &lttngpy::lttng_add_snapshot_output,
+    "Add an output object to the snapshot session.",
+    py::kw_only(),
+    py::arg("session_name"),
+    py::arg("max_size"),
+    py::arg("name"),
+    py::arg("url"));
+  m.def(
     "lttng_destroy_session",
     &lttng_destroy_session,
     "Destroy session.",
@@ -103,11 +112,7 @@ PYBIND11_MODULE(_lttngpy_pybind11, m) {
     &lttngpy::lttng_record_snapshot,
     "Record a snapshot session.",
     py::kw_only(),
-    py::arg("session_name"),
-    py::arg("id"),
-    py::arg("max_size"),
-    py::arg("name"),
-    py::arg("url"));
+    py::arg("session_name"));
 
   // Session info
   m.def(

--- a/lttngpy/src/lttngpy/_lttngpy_pybind11.cpp
+++ b/lttngpy/src/lttngpy/_lttngpy_pybind11.cpp
@@ -75,8 +75,8 @@ PYBIND11_MODULE(_lttngpy_pybind11, m) {
     py::arg("session_name"),
     py::arg("url"));
   m.def(
-    "lttng_add_snapshot_output",
-    &lttngpy::lttng_add_snapshot_output,
+    "add_snapshot_output",
+    &lttngpy::add_snapshot_output,
     "Add an output object to the snapshot session.",
     py::kw_only(),
     py::arg("session_name"),
@@ -108,8 +108,8 @@ PYBIND11_MODULE(_lttngpy_pybind11, m) {
     py::kw_only(),
     py::arg("session_name"));
   m.def(
-    "lttng_record_snapshot",
-    &lttngpy::lttng_record_snapshot,
+    "record_snapshot",
+    &lttngpy::record_snapshot,
     "Record a snapshot session.",
     py::kw_only(),
     py::arg("session_name"));

--- a/lttngpy/src/lttngpy/_lttngpy_pybind11.cpp
+++ b/lttngpy/src/lttngpy/_lttngpy_pybind11.cpp
@@ -107,8 +107,7 @@ PYBIND11_MODULE(_lttngpy_pybind11, m) {
     py::arg("id"),
     py::arg("max_size"),
     py::arg("name"),
-    py::arg("url"),
-    py::arg("wait"));
+    py::arg("url"));
 
   // Session info
   m.def(

--- a/lttngpy/src/lttngpy/snapshot.cpp
+++ b/lttngpy/src/lttngpy/snapshot.cpp
@@ -1,0 +1,37 @@
+#include <lttng/snapshot.h>
+#include <lttng/lttng-error.h>
+
+#include <string>
+
+#include "lttngpy/snapshot.hpp"
+
+namespace lttngpy
+{
+
+int lttng_record_snapshot(
+  const std::string & session_name,
+  const uint32_t id,
+  const uint64_t max_size,
+  const std::string & name,
+  const std::string & url,
+  const int wait)
+{
+  struct lttng_snapshot_output * output = lttng_snapshot_output_create();
+  if (nullptr == output) {
+    return -LTTNG_ERR_UNK;
+  }
+
+  // Set snapshot output attributes.
+  lttng_snapshot_output_set_id(id, output);
+  lttng_snapshot_output_set_size(max_size, output);
+  lttng_snapshot_output_set_name(name.c_str(), output);  
+  lttng_snapshot_output_set_local_path(url.c_str(), output);
+
+  // Add snapshot output to the session.
+  lttng_snapshot_add_output(session_name.c_str(), output);
+
+  int ret = lttng_snapshot_record(session_name.c_str(), output, wait);
+  return ret;
+}
+
+}  // namespace lttngpy

--- a/lttngpy/src/lttngpy/snapshot.cpp
+++ b/lttngpy/src/lttngpy/snapshot.cpp
@@ -22,9 +22,8 @@
 namespace lttngpy
 {
 
-int lttng_record_snapshot(
+int lttng_add_snapshot_output(
   const std::string & session_name,
-  const uint32_t id,
   const uint64_t max_size,
   const std::string & name,
   const std::string & url)
@@ -45,16 +44,18 @@ int lttng_record_snapshot(
     };
 
   // Set snapshot output attributes.
-  if (!try_or_cleanup(lttng_snapshot_output_set_id(id, output))) {return ret;}
   if (!try_or_cleanup(lttng_snapshot_output_set_size(max_size, output))) {return ret;}
   if (!try_or_cleanup(lttng_snapshot_output_set_name(name.c_str(), output))) {return ret;}
   if (!try_or_cleanup(lttng_snapshot_output_set_local_path(url.c_str(), output))) {return ret;}
 
-  // Add snapshot output to the session.
-  if (!try_or_cleanup(lttng_snapshot_add_output(session_name.c_str(), output))) {return ret;}
+  // Add output object to the session.
+  ret = lttng_snapshot_add_output(session_name.c_str(), output);
+  return ret;
+}
 
-  // Record the snapshot.
-  ret = lttng_snapshot_record(session_name.c_str(), output, 1);
+int lttng_record_snapshot(const std::string & session_name)
+{
+  int ret = lttng_snapshot_record(session_name.c_str(), NULL, 1);
   return ret;
 }
 

--- a/lttngpy/src/lttngpy/snapshot.cpp
+++ b/lttngpy/src/lttngpy/snapshot.cpp
@@ -24,7 +24,7 @@ int lttng_record_snapshot(
   // Set snapshot output attributes.
   lttng_snapshot_output_set_id(id, output);
   lttng_snapshot_output_set_size(max_size, output);
-  lttng_snapshot_output_set_name(name.c_str(), output);  
+  lttng_snapshot_output_set_name(name.c_str(), output);
   lttng_snapshot_output_set_local_path(url.c_str(), output);
 
   // Add snapshot output to the session.

--- a/lttngpy/src/lttngpy/snapshot.cpp
+++ b/lttngpy/src/lttngpy/snapshot.cpp
@@ -36,22 +36,22 @@ int lttng_record_snapshot(
 
   int ret = 0;
   auto try_or_cleanup = [&](int function_call) -> bool {
-    ret = function_call;
-    if (0 != ret) {
-      lttng_snapshot_output_destroy(output);
-      return false;
-    }
-    return true;
-  };
+      ret = function_call;
+      if (0 != ret) {
+        lttng_snapshot_output_destroy(output);
+        return false;
+      }
+      return true;
+    };
 
   // Set snapshot output attributes.
-  if (!try_or_cleanup(lttng_snapshot_output_set_id(id, output))) return ret;
-  if (!try_or_cleanup(lttng_snapshot_output_set_size(max_size, output))) return ret;
-  if (!try_or_cleanup(lttng_snapshot_output_set_name(name.c_str(), output))) return ret;
-  if (!try_or_cleanup(lttng_snapshot_output_set_local_path(url.c_str(), output))) return ret;
+  if (!try_or_cleanup(lttng_snapshot_output_set_id(id, output))) {return ret;}
+  if (!try_or_cleanup(lttng_snapshot_output_set_size(max_size, output))) {return ret;}
+  if (!try_or_cleanup(lttng_snapshot_output_set_name(name.c_str(), output))) {return ret;}
+  if (!try_or_cleanup(lttng_snapshot_output_set_local_path(url.c_str(), output))) {return ret;}
 
   // Add snapshot output to the session.
-  if (!try_or_cleanup(lttng_snapshot_add_output(session_name.c_str(), output))) return ret;
+  if (!try_or_cleanup(lttng_snapshot_add_output(session_name.c_str(), output))) {return ret;}
 
   // Record the snapshot.
   ret = lttng_snapshot_record(session_name.c_str(), output, 1);

--- a/lttngpy/src/lttngpy/snapshot.cpp
+++ b/lttngpy/src/lttngpy/snapshot.cpp
@@ -22,7 +22,7 @@
 namespace lttngpy
 {
 
-int lttng_add_snapshot_output(
+int add_snapshot_output(
   const std::string & session_name,
   const uint64_t max_size,
   const std::string & name,
@@ -34,7 +34,7 @@ int lttng_add_snapshot_output(
   }
 
   int ret = 0;
-  auto try_or_cleanup = [&](int function_call) -> bool {
+  auto try_or_cleanup = [&ret, output](int function_call) -> bool {
       ret = function_call;
       if (0 != ret) {
         lttng_snapshot_output_destroy(output);
@@ -53,10 +53,9 @@ int lttng_add_snapshot_output(
   return ret;
 }
 
-int lttng_record_snapshot(const std::string & session_name)
+int record_snapshot(const std::string & session_name)
 {
-  int ret = lttng_snapshot_record(session_name.c_str(), NULL, 1);
-  return ret;
+  return lttng_snapshot_record(session_name.c_str(), NULL, 1);  // The last parameter is unused
 }
 
 }  // namespace lttngpy

--- a/lttngpy/src/lttngpy/snapshot.cpp
+++ b/lttngpy/src/lttngpy/snapshot.cpp
@@ -34,16 +34,27 @@ int lttng_record_snapshot(
     return -LTTNG_ERR_UNK;
   }
 
+  int ret = 0;
+  auto try_or_cleanup = [&](int function_call) -> bool {
+    ret = function_call;
+    if (0 != ret) {
+      lttng_snapshot_output_destroy(output);
+      return false;
+    }
+    return true;
+  };
+
   // Set snapshot output attributes.
-  lttng_snapshot_output_set_id(id, output);
-  lttng_snapshot_output_set_size(max_size, output);
-  lttng_snapshot_output_set_name(name.c_str(), output);
-  lttng_snapshot_output_set_local_path(url.c_str(), output);
+  if (!try_or_cleanup(lttng_snapshot_output_set_id(id, output))) return ret;
+  if (!try_or_cleanup(lttng_snapshot_output_set_size(max_size, output))) return ret;
+  if (!try_or_cleanup(lttng_snapshot_output_set_name(name.c_str(), output))) return ret;
+  if (!try_or_cleanup(lttng_snapshot_output_set_local_path(url.c_str(), output))) return ret;
 
   // Add snapshot output to the session.
-  lttng_snapshot_add_output(session_name.c_str(), output);
+  if (!try_or_cleanup(lttng_snapshot_add_output(session_name.c_str(), output))) return ret;
 
-  int ret = lttng_snapshot_record(session_name.c_str(), output, 1);
+  // Record the snapshot.
+  ret = lttng_snapshot_record(session_name.c_str(), output, 1);
   return ret;
 }
 

--- a/lttngpy/src/lttngpy/snapshot.cpp
+++ b/lttngpy/src/lttngpy/snapshot.cpp
@@ -27,8 +27,7 @@ int lttng_record_snapshot(
   const uint32_t id,
   const uint64_t max_size,
   const std::string & name,
-  const std::string & url,
-  const int wait)
+  const std::string & url)
 {
   struct lttng_snapshot_output * output = lttng_snapshot_output_create();
   if (nullptr == output) {
@@ -44,7 +43,7 @@ int lttng_record_snapshot(
   // Add snapshot output to the session.
   lttng_snapshot_add_output(session_name.c_str(), output);
 
-  int ret = lttng_snapshot_record(session_name.c_str(), output, wait);
+  int ret = lttng_snapshot_record(session_name.c_str(), output, 1);
   return ret;
 }
 

--- a/lttngpy/src/lttngpy/snapshot.cpp
+++ b/lttngpy/src/lttngpy/snapshot.cpp
@@ -46,7 +46,9 @@ int add_snapshot_output(
   // Set snapshot output attributes.
   if (!try_or_cleanup(lttng_snapshot_output_set_size(max_size, output))) {return ret;}
   if (!try_or_cleanup(lttng_snapshot_output_set_name(name.c_str(), output))) {return ret;}
-  if (!try_or_cleanup(lttng_snapshot_output_set_local_path(url.c_str(), output))) {return ret;}
+  if (!try_or_cleanup(lttng_snapshot_output_set_ctrl_url(("file://" + url).c_str(), output))) {
+    return ret;
+  }
 
   // Add output object to the session.
   ret = lttng_snapshot_add_output(session_name.c_str(), output);

--- a/lttngpy/src/lttngpy/snapshot.cpp
+++ b/lttngpy/src/lttngpy/snapshot.cpp
@@ -1,3 +1,17 @@
+// Copyright 2025 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <lttng/snapshot.h>
 #include <lttng/lttng-error.h>
 

--- a/lttngpy/src/lttngpy/snapshot.hpp
+++ b/lttngpy/src/lttngpy/snapshot.hpp
@@ -22,7 +22,7 @@ namespace lttngpy
 
 /**
  * Record a snapshot session.
- * 
+ *
  * \param session_name the session name
  * \param id the snapshot output ID
  * \param max_size the maximum size of the snapshot output in bytes

--- a/lttngpy/src/lttngpy/snapshot.hpp
+++ b/lttngpy/src/lttngpy/snapshot.hpp
@@ -1,0 +1,28 @@
+#ifndef LTTNGPY__SNAPSHOT_HPP_
+#define LTTNGPY__SNAPSHOT_HPP_
+
+#include <string>
+
+namespace lttngpy
+{
+
+/**
+ * Record a snapshot session.
+ * 
+ * \param session_name the session name
+ * \param id the snapshot output ID
+ * \param max_size the maximum size of the snapshot output in bytes
+ * \param name the name of the snapshot output
+ * \param url the destination URL for the snapshot output
+ */
+int lttng_record_snapshot(
+  const std::string & session_name,
+  const uint32_t id,
+  const uint64_t max_size,
+  const std::string & name,
+  const std::string & url,
+  const int wait);
+
+} // namespace lttngpy
+
+#endif  // LTTNGPY__SNAPSHOT_HPP_

--- a/lttngpy/src/lttngpy/snapshot.hpp
+++ b/lttngpy/src/lttngpy/snapshot.hpp
@@ -23,6 +23,6 @@ int lttng_record_snapshot(
   const std::string & url,
   const int wait);
 
-} // namespace lttngpy
+}  // namespace lttngpy
 
 #endif  // LTTNGPY__SNAPSHOT_HPP_

--- a/lttngpy/src/lttngpy/snapshot.hpp
+++ b/lttngpy/src/lttngpy/snapshot.hpp
@@ -1,3 +1,17 @@
+// Copyright 2025 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #ifndef LTTNGPY__SNAPSHOT_HPP_
 #define LTTNGPY__SNAPSHOT_HPP_
 

--- a/lttngpy/src/lttngpy/snapshot.hpp
+++ b/lttngpy/src/lttngpy/snapshot.hpp
@@ -34,8 +34,7 @@ int lttng_record_snapshot(
   const uint32_t id,
   const uint64_t max_size,
   const std::string & name,
-  const std::string & url,
-  const int wait);
+  const std::string & url);
 
 }  // namespace lttngpy
 

--- a/lttngpy/src/lttngpy/snapshot.hpp
+++ b/lttngpy/src/lttngpy/snapshot.hpp
@@ -21,20 +21,25 @@ namespace lttngpy
 {
 
 /**
- * Record a snapshot session.
+ * Add an output object to the snapshot session.
  *
  * \param session_name the session name
- * \param id the snapshot output ID
  * \param max_size the maximum size of the snapshot output in bytes
  * \param name the name of the snapshot output
  * \param url the destination URL for the snapshot output
  */
-int lttng_record_snapshot(
+int lttng_add_snapshot_output(
   const std::string & session_name,
-  const uint32_t id,
   const uint64_t max_size,
   const std::string & name,
   const std::string & url);
+
+/**
+ * Record a snapshot session.
+ *
+ * \param session_name the session name
+ */
+int lttng_record_snapshot(const std::string & session_name);
 
 }  // namespace lttngpy
 

--- a/lttngpy/src/lttngpy/snapshot.hpp
+++ b/lttngpy/src/lttngpy/snapshot.hpp
@@ -27,8 +27,9 @@ namespace lttngpy
  * \param max_size the maximum size of the snapshot output in bytes
  * \param name the name of the snapshot output
  * \param url the destination URL for the snapshot output
+ * \return 0 on success, else a negative LTTng error code
  */
-int lttng_add_snapshot_output(
+int add_snapshot_output(
   const std::string & session_name,
   const uint64_t max_size,
   const std::string & name,
@@ -38,8 +39,9 @@ int lttng_add_snapshot_output(
  * Record a snapshot session.
  *
  * \param session_name the session name
+ * \return 0 on success, else a negative LTTng error code
  */
-int lttng_record_snapshot(const std::string & session_name);
+int record_snapshot(const std::string & session_name);
 
 }  // namespace lttngpy
 

--- a/ros2trace/ros2trace/verb/pause.py
+++ b/ros2trace/ros2trace/verb/pause.py
@@ -21,7 +21,7 @@ class PauseVerb(VerbExtension):
     """Pause tracing after starting."""
 
     def add_arguments(self, parser, cli_name) -> None:
-        args.add_arguments_session_name(parser)
+        args.add_arguments_noninteractive_control(parser)
 
     def main(self, *, args) -> int:
         return pause(args)

--- a/ros2trace/ros2trace/verb/resume.py
+++ b/ros2trace/ros2trace/verb/resume.py
@@ -21,7 +21,7 @@ class ResumeVerb(VerbExtension):
     """Resume tracing after pausing."""
 
     def add_arguments(self, parser, cli_name) -> None:
-        args.add_arguments_session_name(parser)
+        args.add_arguments_noninteractive_control(parser)
 
     def main(self, *, args) -> int:
         return resume(args)

--- a/ros2trace/ros2trace/verb/start.py
+++ b/ros2trace/ros2trace/verb/start.py
@@ -21,7 +21,7 @@ class StartVerb(VerbExtension):
     """Configure tracing session and start tracing."""
 
     def add_arguments(self, parser, cli_name) -> None:
-        args.add_arguments_noninteractive(parser)
+        args.add_arguments_noninteractive_configure(parser)
 
     def main(self, *, args) -> int:
         return start(args)

--- a/ros2trace/ros2trace/verb/stop.py
+++ b/ros2trace/ros2trace/verb/stop.py
@@ -21,7 +21,7 @@ class StopVerb(VerbExtension):
     """Stop tracing after starting or resuming."""
 
     def add_arguments(self, parser, cli_name) -> None:
-        args.add_arguments_session_name(parser)
+        args.add_arguments_noninteractive_control(parser)
 
     def main(self, *, args) -> int:
         return stop(args)

--- a/tracetools_launch/tracetools_launch/action.py
+++ b/tracetools_launch/tracetools_launch/action.py
@@ -113,7 +113,7 @@ class Trace(Action):
         self,
         *,
         session_name: SomeSubstitutionsType,
-        is_init_session: Union[bool, SomeSubstitutionsType] = False,
+        is_snapshot_session: Union[bool, SomeSubstitutionsType] = False,
         append_timestamp: Union[bool, SomeSubstitutionsType] = False,
         base_path: Optional[SomeSubstitutionsType] = None,
         append_trace: Union[bool, SomeSubstitutionsType] = False,
@@ -140,7 +140,7 @@ class Trace(Action):
         an empty string (through launch frontends).
 
         :param session_name: the name of the tracing session
-        :param is_init_session: whether the session is a init session
+        :param is_snapshot_session: whether the session is a snapshot session
         :param append_timestamp: whether to append timestamp to the session name
         :param base_path: the path to the base directory in which to create the session directory,
             or `None` for default
@@ -172,7 +172,7 @@ class Trace(Action):
                 session_name
             )
         ]
-        self._is_init_session = normalize_typed_substitution(is_init_session, bool)
+        self._is_snapshot_session = normalize_typed_substitution(is_snapshot_session, bool)
         self._base_path: List[Substitution] = [
             IfElseSubstitution(
                 str(base_path is not None),
@@ -183,7 +183,7 @@ class Trace(Action):
         self._append_trace = normalize_typed_substitution(append_trace, bool)
         self._trace_directory: Optional[str] = None
         if events_ust is None:
-            events_ust = names.DEFAULT_EVENTS_ROS if not self._is_init_session \
+            events_ust = names.DEFAULT_EVENTS_ROS if not self._is_snapshot_session \
                 else names.DEFAULT_INIT_EVENTS_ROS
         self._events_ust = [normalize_to_list_of_substitutions(x) for x in events_ust]
         self._events_kernel = [normalize_to_list_of_substitutions(x) for x in events_kernel]
@@ -207,8 +207,8 @@ class Trace(Action):
         return self._session_name
 
     @property
-    def is_init_session(self) -> NormalizedValueType:
-        return self._is_init_session
+    def is_snapshot_session(self) -> NormalizedValueType:
+        return self._is_snapshot_session
 
     @property
     def base_path(self) -> List[Substitution]:
@@ -317,11 +317,11 @@ class Trace(Action):
         session_name = entity.get_attr('session-name')
         if session_name is not None:
             kwargs['session_name'] = parser.parse_substitution(session_name)
-        is_init_session = entity.get_attr('is-init-session', data_type=bool, optional=True)
-        if is_init_session is not None:
-            kwargs['is_init_session'] = is_init_session \
-                if isinstance(is_init_session, bool) \
-                else parser.parse_substitution(cast(str, is_init_session))
+        is_snapshot_session = entity.get_attr('is-snapshot-session', data_type=bool, optional=True)
+        if is_snapshot_session is not None:
+            kwargs['is_snapshot_session'] = is_snapshot_session \
+                if isinstance(is_snapshot_session, bool) \
+                else parser.parse_substitution(cast(str, is_snapshot_session))
         append_timestamp = entity.get_attr('append-timestamp', data_type=bool, optional=True)
         if append_timestamp is not None:
             kwargs['append_timestamp'] = append_timestamp \
@@ -424,7 +424,7 @@ class Trace(Action):
 
     def execute(self, context: LaunchContext) -> List[Action]:
         session_name = perform_substitutions(context, self._session_name)
-        is_init_session = perform_typed_substitution(context, self._is_init_session, bool)
+        is_snapshot_session = perform_typed_substitution(context, self._is_snapshot_session, bool)
         base_path = perform_substitutions(context, self._base_path)
         append_trace = perform_typed_substitution(context, self._append_trace, bool)
         events_ust = [perform_substitutions(context, x) for x in self._events_ust]
@@ -446,15 +446,15 @@ class Trace(Action):
         )
         self._ld_preload_actions = self._get_ld_preload_actions(events_ust)
 
-        # Append '-init' to the session name if it is an init session
-        if is_init_session:
-            session_name += '-init'
+        # Append '-snapshot' to the session name if it is a snapshot session
+        if is_snapshot_session:
+            session_name += '-snapshot'
 
         def setup() -> bool:
             try:
                 self._trace_directory = lttng.lttng_init(
                     session_name=session_name,
-                    is_init_session=is_init_session,
+                    is_snapshot_session=is_snapshot_session,
                     base_path=base_path,
                     append_trace=append_trace,
                     ros_events=events_ust,
@@ -521,7 +521,7 @@ class Trace(Action):
         return (
             'Trace('
             f'session_name={self._session_name}, '
-            f'is_init_session={self._is_init_session}, '
+            f'is_snapshot_session={self._is_snapshot_session}, '
             f'base_path={self._base_path}, '
             f'append_trace={self._append_trace}, '
             f'trace_directory={self._trace_directory}, '

--- a/tracetools_launch/tracetools_launch/action.py
+++ b/tracetools_launch/tracetools_launch/action.py
@@ -113,7 +113,7 @@ class Trace(Action):
         self,
         *,
         session_name: SomeSubstitutionsType,
-        is_snapshot_session: Union[bool, SomeSubstitutionsType] = False,
+        dual_session: Union[bool, SomeSubstitutionsType] = False,
         append_timestamp: Union[bool, SomeSubstitutionsType] = False,
         base_path: Optional[SomeSubstitutionsType] = None,
         append_trace: Union[bool, SomeSubstitutionsType] = False,
@@ -140,7 +140,7 @@ class Trace(Action):
         an empty string (through launch frontends).
 
         :param session_name: the name of the tracing session
-        :param is_snapshot_session: whether the session is a snapshot session
+        :param dual_session: whether to pre-configure a dual session
         :param append_timestamp: whether to append timestamp to the session name
         :param base_path: the path to the base directory in which to create the session directory,
             or `None` for default
@@ -174,7 +174,7 @@ class Trace(Action):
                 session_name
             )
         ]
-        self._is_snapshot_session = normalize_typed_substitution(is_snapshot_session, bool)
+        self._dual_session = normalize_typed_substitution(dual_session, bool)
         self._base_path: List[Substitution] = [
             IfElseSubstitution(
                 str(base_path is not None),
@@ -185,7 +185,7 @@ class Trace(Action):
         self._append_trace = normalize_typed_substitution(append_trace, bool)
         self._trace_directory: Optional[str] = None
         if events_ust is None:
-            events_ust = names.DEFAULT_EVENTS_ROS if not self._is_snapshot_session \
+            events_ust = names.DEFAULT_EVENTS_ROS if not self._dual_session \
                 else names.DEFAULT_INIT_EVENTS_ROS
         self._events_ust = [normalize_to_list_of_substitutions(x) for x in events_ust]
         self._events_kernel = [normalize_to_list_of_substitutions(x) for x in events_kernel]
@@ -209,8 +209,8 @@ class Trace(Action):
         return self._session_name
 
     @property
-    def is_snapshot_session(self) -> NormalizedValueType:
-        return self._is_snapshot_session
+    def dual_session(self) -> NormalizedValueType:
+        return self._dual_session
 
     @property
     def base_path(self) -> List[Substitution]:
@@ -319,11 +319,11 @@ class Trace(Action):
         session_name = entity.get_attr('session-name')
         if session_name is not None:
             kwargs['session_name'] = parser.parse_substitution(session_name)
-        is_snapshot_session = entity.get_attr('is-snapshot-session', data_type=bool, optional=True)
-        if is_snapshot_session is not None:
-            kwargs['is_snapshot_session'] = is_snapshot_session \
-                if isinstance(is_snapshot_session, bool) \
-                else parser.parse_substitution(cast(str, is_snapshot_session))
+        dual_session = entity.get_attr('dual-session', data_type=bool, optional=True)
+        if dual_session is not None:
+            kwargs['dual_session'] = dual_session \
+                if isinstance(dual_session, bool) \
+                else parser.parse_substitution(cast(str, dual_session))
         append_timestamp = entity.get_attr('append-timestamp', data_type=bool, optional=True)
         if append_timestamp is not None:
             kwargs['append_timestamp'] = append_timestamp \
@@ -426,7 +426,7 @@ class Trace(Action):
 
     def execute(self, context: LaunchContext) -> List[Action]:
         session_name = perform_substitutions(context, self._session_name)
-        is_snapshot_session = perform_typed_substitution(context, self._is_snapshot_session, bool)
+        dual_session = perform_typed_substitution(context, self._dual_session, bool)
         base_path = perform_substitutions(context, self._base_path)
         append_trace = perform_typed_substitution(context, self._append_trace, bool)
         events_ust = [perform_substitutions(context, x) for x in self._events_ust]
@@ -448,15 +448,16 @@ class Trace(Action):
         )
         self._ld_preload_actions = self._get_ld_preload_actions(events_ust)
 
-        # Append '-snapshot' to the session name if it is a snapshot session
-        if is_snapshot_session:
+        # Append '-snapshot' to the session name if pre-configuring a dual session
+        if dual_session:
             session_name += '-snapshot'
 
         def setup() -> bool:
             try:
                 self._trace_directory = lttng.lttng_init(
                     session_name=session_name,
-                    is_snapshot_session=is_snapshot_session,
+                    snapshot_session=dual_session,
+                    dual_session=dual_session,
                     base_path=base_path,
                     append_trace=append_trace,
                     ros_events=events_ust,
@@ -468,7 +469,7 @@ class Trace(Action):
                 )
                 if self._trace_directory is None:
                     return False
-                if not is_snapshot_session:
+                if not dual_session:
                     self._logger.info(f'Writing tracing session to: {self._trace_directory}')
                 self._logger.debug(f'UST events: {events_ust}')
                 self._logger.debug(f'Kernel events: {events_kernel}')
@@ -524,7 +525,7 @@ class Trace(Action):
         return (
             'Trace('
             f'session_name={self._session_name}, '
-            f'is_snapshot_session={self._is_snapshot_session}, '
+            f'dual_session={self._dual_session}, '
             f'base_path={self._base_path}, '
             f'append_trace={self._append_trace}, '
             f'trace_directory={self._trace_directory}, '

--- a/tracetools_launch/tracetools_launch/action.py
+++ b/tracetools_launch/tracetools_launch/action.py
@@ -468,7 +468,8 @@ class Trace(Action):
                 )
                 if self._trace_directory is None:
                     return False
-                self._logger.info(f'Writing tracing session to: {self._trace_directory}')
+                if not is_snapshot_session:
+                    self._logger.info(f'Writing tracing session to: {self._trace_directory}')
                 self._logger.debug(f'UST events: {events_ust}')
                 self._logger.debug(f'Kernel events: {events_kernel}')
                 self._logger.debug(f'Syscalls: {syscalls}')

--- a/tracetools_launch/tracetools_launch/action.py
+++ b/tracetools_launch/tracetools_launch/action.py
@@ -146,7 +146,9 @@ class Trace(Action):
             or `None` for default
         :param append_trace: whether to append to the trace directory if it already exists,
             otherwise an error is reported
-        :param events_ust: the list of ROS UST events to enable
+        :param events_ust: the list of ROS UST events to enable; if it's `None`, the default ROS
+            events are used for a normal session, and the default ROS initialization events are
+            used for a snapshot session; if it's an empty list, no UST events are enabled
         :param events_kernel: the list of kernel events to enable
         :param syscalls: the list of syscalls to enable
         :param context_fields: the names of context fields to enable

--- a/tracetools_launch/tracetools_launch/action.py
+++ b/tracetools_launch/tracetools_launch/action.py
@@ -117,7 +117,7 @@ class Trace(Action):
         append_timestamp: Union[bool, SomeSubstitutionsType] = False,
         base_path: Optional[SomeSubstitutionsType] = None,
         append_trace: Union[bool, SomeSubstitutionsType] = False,
-        events_ust: Iterable[SomeSubstitutionsType] = None,
+        events_ust: Optional[Iterable[SomeSubstitutionsType]] = None,
         events_kernel: Iterable[SomeSubstitutionsType] = [],
         syscalls: Iterable[SomeSubstitutionsType] = [],
         context_fields:

--- a/tracetools_launch/tracetools_launch/action.py
+++ b/tracetools_launch/tracetools_launch/action.py
@@ -113,10 +113,11 @@ class Trace(Action):
         self,
         *,
         session_name: SomeSubstitutionsType,
+        is_init_session: Union[bool, SomeSubstitutionsType] = False,
         append_timestamp: Union[bool, SomeSubstitutionsType] = False,
         base_path: Optional[SomeSubstitutionsType] = None,
         append_trace: Union[bool, SomeSubstitutionsType] = False,
-        events_ust: Iterable[SomeSubstitutionsType] = names.DEFAULT_EVENTS_ROS,
+        events_ust: Iterable[SomeSubstitutionsType] = None,
         events_kernel: Iterable[SomeSubstitutionsType] = [],
         syscalls: Iterable[SomeSubstitutionsType] = [],
         context_fields:
@@ -139,6 +140,7 @@ class Trace(Action):
         an empty string (through launch frontends).
 
         :param session_name: the name of the tracing session
+        :param is_init_session: whether the session is a init session
         :param append_timestamp: whether to append timestamp to the session name
         :param base_path: the path to the base directory in which to create the session directory,
             or `None` for default
@@ -170,6 +172,7 @@ class Trace(Action):
                 session_name
             )
         ]
+        self._is_init_session = normalize_typed_substitution(is_init_session, bool)
         self._base_path: List[Substitution] = [
             IfElseSubstitution(
                 str(base_path is not None),
@@ -179,6 +182,9 @@ class Trace(Action):
         ]
         self._append_trace = normalize_typed_substitution(append_trace, bool)
         self._trace_directory: Optional[str] = None
+        if events_ust is None:
+            events_ust = names.DEFAULT_EVENTS_ROS if not self._is_init_session \
+                else names.DEFAULT_INIT_EVENTS_ROS
         self._events_ust = [normalize_to_list_of_substitutions(x) for x in events_ust]
         self._events_kernel = [normalize_to_list_of_substitutions(x) for x in events_kernel]
         self._syscalls = [normalize_to_list_of_substitutions(x) for x in syscalls]
@@ -199,6 +205,10 @@ class Trace(Action):
     @property
     def session_name(self) -> List[Substitution]:
         return self._session_name
+
+    @property
+    def is_init_session(self) -> NormalizedValueType:
+        return self._is_init_session
 
     @property
     def base_path(self) -> List[Substitution]:
@@ -307,6 +317,11 @@ class Trace(Action):
         session_name = entity.get_attr('session-name')
         if session_name is not None:
             kwargs['session_name'] = parser.parse_substitution(session_name)
+        is_init_session = entity.get_attr('is-init-session', data_type=bool, optional=True)
+        if is_init_session is not None:
+            kwargs['is_init_session'] = is_init_session \
+                if isinstance(is_init_session, bool) \
+                else parser.parse_substitution(cast(str, is_init_session))
         append_timestamp = entity.get_attr('append-timestamp', data_type=bool, optional=True)
         if append_timestamp is not None:
             kwargs['append_timestamp'] = append_timestamp \
@@ -409,6 +424,7 @@ class Trace(Action):
 
     def execute(self, context: LaunchContext) -> List[Action]:
         session_name = perform_substitutions(context, self._session_name)
+        is_init_session = perform_typed_substitution(context, self._is_init_session, bool)
         base_path = perform_substitutions(context, self._base_path)
         append_trace = perform_typed_substitution(context, self._append_trace, bool)
         events_ust = [perform_substitutions(context, x) for x in self._events_ust]
@@ -430,10 +446,15 @@ class Trace(Action):
         )
         self._ld_preload_actions = self._get_ld_preload_actions(events_ust)
 
+        # Append '-init' to the session name if it is an init session
+        if is_init_session:
+            session_name += '-init'
+
         def setup() -> bool:
             try:
                 self._trace_directory = lttng.lttng_init(
                     session_name=session_name,
+                    is_init_session=is_init_session,
                     base_path=base_path,
                     append_trace=append_trace,
                     ros_events=events_ust,
@@ -500,6 +521,7 @@ class Trace(Action):
         return (
             'Trace('
             f'session_name={self._session_name}, '
+            f'is_init_session={self._is_init_session}, '
             f'base_path={self._base_path}, '
             f'append_trace={self._append_trace}, '
             f'trace_directory={self._trace_directory}, '

--- a/tracetools_launch/tracetools_launch/action.py
+++ b/tracetools_launch/tracetools_launch/action.py
@@ -473,12 +473,7 @@ class Trace(Action):
                 )
                 if self._trace_directory is None:
                     return False
-                if not dual_session:
-                    self._logger.info(f'Writing tracing session to: {self._trace_directory}')
-                else:
-                    self._logger.info(
-                        'Snapshot tracing session will be written to: '
-                        f'{self._trace_directory}')
+                self._logger.info(f'Writing tracing session to: {self._trace_directory}')
                 self._logger.debug(f'UST events: {events_ust}')
                 self._logger.debug(f'Kernel events: {events_kernel}')
                 self._logger.debug(f'Syscalls: {syscalls}')

--- a/tracetools_launch/tracetools_launch/action.py
+++ b/tracetools_launch/tracetools_launch/action.py
@@ -140,7 +140,10 @@ class Trace(Action):
         an empty string (through launch frontends).
 
         :param session_name: the name of the tracing session
-        :param dual_session: whether to pre-configure a dual session
+        :param dual_session: whether to pre-configure a dual session: a snapshot session
+            is configured here, with a normal tracing session to be configured later, while the
+            application is running, e.g., through `ros2 trace --dual-session` with the same session
+            name
         :param append_timestamp: whether to append timestamp to the session name
         :param base_path: the path to the base directory in which to create the session directory,
             or `None` for default
@@ -148,7 +151,8 @@ class Trace(Action):
             otherwise an error is reported
         :param events_ust: the list of ROS UST events to enable; if it's `None`, the default ROS
             events are used for a normal session, and the default ROS initialization events are
-            used for a snapshot session; if it's an empty list, no UST events are enabled
+            used for the snapshot session in case of a dual session; if it's an empty list, no UST
+            events are enabled
         :param events_kernel: the list of kernel events to enable
         :param syscalls: the list of syscalls to enable
         :param context_fields: the names of context fields to enable
@@ -450,7 +454,7 @@ class Trace(Action):
 
         # Append '-snapshot' to the session name if pre-configuring a dual session
         if dual_session:
-            session_name += '-snapshot'
+            session_name += path.SNAPSHOT_SESSION_SUFFIX
 
         def setup() -> bool:
             try:
@@ -471,6 +475,10 @@ class Trace(Action):
                     return False
                 if not dual_session:
                     self._logger.info(f'Writing tracing session to: {self._trace_directory}')
+                else:
+                    self._logger.info(
+                        'Snapshot tracing session will be written to: '
+                        f'{self._trace_directory}')
                 self._logger.debug(f'UST events: {events_ust}')
                 self._logger.debug(f'Kernel events: {events_kernel}')
                 self._logger.debug(f'Syscalls: {syscalls}')

--- a/tracetools_trace/tracetools_trace/tools/args.py
+++ b/tracetools_trace/tracetools_trace/tools/args.py
@@ -93,8 +93,11 @@ def _add_arguments_session_type(parser: argparse.ArgumentParser) -> None:
     """Add session type argument to parser."""
     parser.add_argument(
         '-d', '--dual-session', dest='dual_session', action='store_true',
-        help='record snapshot of the pre-configured snapshot session '
-             'with the same name and start normal tracing session (default: %(default)s)')
+        help='use this in non-interactive mode to record snapshot of the pre-configured snapshot '
+             'session with the same name and start normal runtime tracing session; use this in '
+             'interactive mode along with: start/resume to record snapshot of pre-configured '
+             'snapshot session and start/resume normal runtime tracing session, stop/pause to '
+             'stop/pause normal runtime tracing session (default: %(default)s)')
 
 
 def add_arguments(parser: argparse.ArgumentParser) -> None:

--- a/tracetools_trace/tracetools_trace/tools/args.py
+++ b/tracetools_trace/tracetools_trace/tools/args.py
@@ -92,7 +92,7 @@ def _add_arguments_default_session_name(parser: argparse.ArgumentParser) -> None
 def _add_arguments_session_type(parser: argparse.ArgumentParser) -> None:
     """Add session type argument to parser."""
     parser.add_argument(
-        '-r', '--runtime', dest='is_runtime_session', action='store_true',
+        '-d', '--dual-session', dest='dual_session', action='store_true',
         help='record snapshot of the pre-configured snapshot session '
              'with the same name and start normal tracing session (default: %(default)s)')
 
@@ -106,8 +106,8 @@ def add_arguments(parser: argparse.ArgumentParser) -> None:
 
 def add_arguments_noninteractive_configure(parser: argparse.ArgumentParser) -> None:
     """Add arguments to parser for non-interactive tracing session configuration."""
-    add_arguments_noninteractive_control(parser)
     _add_arguments_configure(parser)
+    add_arguments_noninteractive_control(parser)
 
 
 def add_arguments_noninteractive_control(parser: argparse.ArgumentParser) -> None:

--- a/tracetools_trace/tracetools_trace/tools/args.py
+++ b/tracetools_trace/tracetools_trace/tools/args.py
@@ -80,9 +80,6 @@ def _add_arguments_configure(parser: argparse.ArgumentParser) -> None:
     parser.add_argument(
         '-a', '--append-trace', dest='append_trace', action='store_true',
         help='append to trace if it already exists, otherwise error out (default: %(default)s)')
-    parser.add_argument(
-        '-r', '--runtime', dest='is_runtime_session', action='store_true',
-        help='enable runtime tracing (default: %(default)s)')
 
 
 def _add_arguments_default_session_name(parser: argparse.ArgumentParser) -> None:
@@ -92,18 +89,28 @@ def _add_arguments_default_session_name(parser: argparse.ArgumentParser) -> None
         help='the name of the tracing session (default: session-YYYYMMDDHHMMSS)')
 
 
+def _add_arguments_session_type(parser: argparse.ArgumentParser) -> None:
+    """Add session type argument to parser."""
+    parser.add_argument(
+        '-r', '--runtime', dest='is_runtime_session', action='store_true',
+        help='record snapshot of the pre-configured snapshot session '
+             'with the same name and start normal tracing session (default: %(default)s)')
+
+
 def add_arguments(parser: argparse.ArgumentParser) -> None:
     """Add arguments to parser for interactive tracing session configuration."""
     _add_arguments_default_session_name(parser)
+    _add_arguments_session_type(parser)
     _add_arguments_configure(parser)
 
 
-def add_arguments_noninteractive(parser: argparse.ArgumentParser) -> None:
+def add_arguments_noninteractive_configure(parser: argparse.ArgumentParser) -> None:
     """Add arguments to parser for non-interactive tracing session configuration."""
-    add_arguments_session_name(parser)
+    add_arguments_noninteractive_control(parser)
     _add_arguments_configure(parser)
 
 
-def add_arguments_session_name(parser: argparse.ArgumentParser) -> None:
-    """Add mandatory session name argument to parser."""
+def add_arguments_noninteractive_control(parser: argparse.ArgumentParser) -> None:
+    """Add arguments to parser for non-interactive tracing session control."""
     parser.add_argument('session_name', help='the name of the tracing session')
+    _add_arguments_session_type(parser)

--- a/tracetools_trace/tracetools_trace/tools/args.py
+++ b/tracetools_trace/tracetools_trace/tools/args.py
@@ -80,6 +80,9 @@ def _add_arguments_configure(parser: argparse.ArgumentParser) -> None:
     parser.add_argument(
         '-a', '--append-trace', dest='append_trace', action='store_true',
         help='append to trace if it already exists, otherwise error out (default: %(default)s)')
+    parser.add_argument(
+        '-r', '--runtime', dest='is_runtime_session', action='store_true',
+        help='enable runtime tracing (default: %(default)s)')
 
 
 def _add_arguments_default_session_name(parser: argparse.ArgumentParser) -> None:

--- a/tracetools_trace/tracetools_trace/tools/lttng.py
+++ b/tracetools_trace/tracetools_trace/tools/lttng.py
@@ -94,6 +94,17 @@ def lttng_stop(**kwargs) -> None:
     _lttng.stop(**kwargs)
 
 
+def lttng_record_snapshot(**kwargs) -> None:
+    """
+    Record a snapshot.
+
+    Raises RuntimeError on failure.
+
+    :param session_name: the name of the session
+    """
+    _lttng.record_snapshot(**kwargs)
+
+
 def is_lttng_installed(
     *,
     minimum_version: Optional[str] = None,

--- a/tracetools_trace/tracetools_trace/tools/lttng_impl.py
+++ b/tracetools_trace/tracetools_trace/tools/lttng_impl.py
@@ -522,7 +522,7 @@ def _create_session_snapshot(
 
     :param session_name: the name of the session
     :param full_path: the full path to the main directory to write trace data to;
-        if `None`, the snapshot output object will not be created 
+        if `None`, the snapshot output object will not be created
         (output object must be created before taking snapshots)
     """
     result = lttngpy.lttng_create_session_snapshot(

--- a/tracetools_trace/tracetools_trace/tools/lttng_impl.py
+++ b/tracetools_trace/tracetools_trace/tools/lttng_impl.py
@@ -457,7 +457,7 @@ def record_snapshot(
 
     :param session_name: the name of the session
     """
-    result = lttngpy.lttng_record_snapshot(session_name=session_name)
+    result = lttngpy.record_snapshot(session_name=session_name)
     if result < 0:
         error = lttngpy.lttng_strerror(result)
         raise RuntimeError(
@@ -549,8 +549,8 @@ def _create_session_snapshot(
         )
     if result < 0:
         error = lttngpy.lttng_strerror(result)
-        raise RuntimeError(f"failed to create tracing session '{session_name}': {error}")
-    result = lttngpy.lttng_add_snapshot_output(
+        raise RuntimeError(f"failed to create snapshot session '{session_name}': {error}")
+    result = lttngpy.add_snapshot_output(
         session_name=session_name,
         max_size=max_size,
         name=name,
@@ -558,7 +558,7 @@ def _create_session_snapshot(
     )
     if result < 0:
         error = lttngpy.lttng_strerror(result)
-        raise RuntimeError(f"failed to setup the tracing session '{session_name}': {error}")
+        raise RuntimeError(f"failed to add output for snapshot session '{session_name}': {error}")
 
 
 def _enable_channel(**kwargs) -> None:

--- a/tracetools_trace/tracetools_trace/tools/lttng_impl.py
+++ b/tracetools_trace/tracetools_trace/tools/lttng_impl.py
@@ -194,8 +194,8 @@ def spawn_session_daemon() -> None:
 def setup(
     *,
     session_name: str,
-    is_snapshot_session: bool = False,
-    is_runtime_session: bool = False,
+    snapshot_session: bool = False,
+    dual_session: bool = False,
     base_path: str,
     append_trace: bool = False,
     ros_events: Union[List[str], Set[str]] = DEFAULT_EVENTS_ROS,
@@ -219,8 +219,8 @@ def setup(
     Raises RuntimeError on failure, in which case the tracing session might still exist.
 
     :param session_name: the name of the session
-    :param is_snapshot_session: whether to create a snapshot session
-    :param is_runtime_session: whether this is a runtime session
+    :param snapshot_session: whether this is a snapshot session
+    :param dual_session: whether this is part of a dual session
     :param base_path: the path to the directory in which to create the tracing session directory,
         which will be created if needed
     :param append_trace: whether to append to the trace directory if it already exists, otherwise
@@ -246,13 +246,13 @@ def setup(
     if not session_name:
         raise RuntimeError('empty session name')
     # Resolve full tracing directory path
-    if is_runtime_session:
-        full_path = os.path.join(base_path, session_name.removesuffix('-runtime'), 'runtime')
-    elif is_snapshot_session:
+    if snapshot_session and dual_session:
         full_path = os.path.join(base_path, session_name.removesuffix('-snapshot'), 'snapshot')
+    elif dual_session:
+        full_path = os.path.join(base_path, session_name.removesuffix('-runtime'), 'runtime')
     else:
         full_path = os.path.join(base_path, session_name)
-    if os.path.isdir(full_path) and not append_trace and not is_snapshot_session:
+    if os.path.isdir(full_path) and not append_trace:
         raise RuntimeError(
             f'trace directory already exists, use the append option to append to it: {full_path}')
 
@@ -307,7 +307,7 @@ def setup(
 
     # Create session
     # LTTng will create the parent directories if needed
-    if not is_snapshot_session:
+    if not snapshot_session:
         _create_session(
             session_name=session_name,
             full_path=full_path,

--- a/tracetools_trace/tracetools_trace/tools/lttng_impl.py
+++ b/tracetools_trace/tracetools_trace/tools/lttng_impl.py
@@ -195,6 +195,7 @@ def setup(
     *,
     session_name: str,
     is_snapshot_session: bool = False,
+    is_runtime_session: bool = False,
     base_path: str,
     append_trace: bool = False,
     ros_events: Union[List[str], Set[str]] = DEFAULT_EVENTS_ROS,
@@ -219,6 +220,7 @@ def setup(
 
     :param session_name: the name of the session
     :param is_snapshot_session: whether to create a snapshot session
+    :param is_runtime_session: whether this is a runtime session
     :param base_path: the path to the directory in which to create the tracing session directory,
         which will be created if needed
     :param append_trace: whether to append to the trace directory if it already exists, otherwise
@@ -244,7 +246,10 @@ def setup(
     if not session_name:
         raise RuntimeError('empty session name')
     # Resolve full tracing directory path
-    full_path = os.path.join(base_path, session_name)
+    if is_runtime_session:
+        full_path = os.path.join(base_path, session_name.removesuffix('-runtime'), 'runtime')
+    else:
+        full_path = os.path.join(base_path, session_name)
     if os.path.isdir(full_path) and not append_trace:
         raise RuntimeError(
             f'trace directory already exists, use the append option to append to it: {full_path}')
@@ -432,6 +437,24 @@ def stop(
     if result < 0 and not ignore_error:
         error = lttngpy.lttng_strerror(result)
         raise RuntimeError(f"failed to stop tracing session '{session_name}': {error}")
+
+
+def record_snapshot(**kwargs) -> None:
+    """
+    Record a snapshot, and check for errors.
+
+    This must not be called if `lttngpy.is_available()` is `False`.
+    Raises RuntimeError on failure.
+
+    See `lttngpy.lttng_record_snapshot` for kwargs.
+    """
+    result = lttngpy.lttng_record_snapshot(**kwargs)
+    if result < 0:
+        session_name = kwargs['session_name']
+        error = lttngpy.lttng_strerror(result)
+        raise RuntimeError(
+            f"failed to record snapshot of the tracing session '{session_name}': {error}"
+        )
 
 
 def destroy(

--- a/tracetools_trace/tracetools_trace/tools/lttng_impl.py
+++ b/tracetools_trace/tracetools_trace/tools/lttng_impl.py
@@ -510,9 +510,9 @@ def _create_session(
 
 
 def _create_session_snapshot(
-        *,
-        session_name: str,
-        full_path: Optional[str] = None,
+    *,
+    session_name: str,
+    full_path: Optional[str] = None,
 ) -> None:
     """
     Create snapshot session from name and full directory path, and check for errors.

--- a/tracetools_trace/tracetools_trace/tools/lttng_impl.py
+++ b/tracetools_trace/tracetools_trace/tools/lttng_impl.py
@@ -244,11 +244,7 @@ def setup(
     if not session_name:
         raise RuntimeError('empty session name')
     # Resolve full tracing directory path
-    # For snapshot sessions, remove the suffixes in the full path
-    if is_snapshot_session:
-        full_path = os.path.join(base_path, session_name.removesuffix('-snapshot'), 'snapshot')
-    else:
-        full_path = os.path.join(base_path, session_name)
+    full_path = os.path.join(base_path, session_name)
     if os.path.isdir(full_path) and not append_trace:
         raise RuntimeError(
             f'trace directory already exists, use the append option to append to it: {full_path}')
@@ -312,7 +308,6 @@ def setup(
     else:
         _create_session_snapshot(
             session_name=session_name,
-            full_path=full_path,
         )
 
     # Enable channel, events, and contexts for each domain
@@ -494,7 +489,7 @@ def _create_session(
 def _create_session_snapshot(
         *,
         session_name: str,
-        full_path: str,
+        full_path: Optional[str] = None,
 ) -> None:
     """
     Create snapshot session from name and full directory path, and check for errors.

--- a/tracetools_trace/tracetools_trace/tools/lttng_impl.py
+++ b/tracetools_trace/tracetools_trace/tools/lttng_impl.py
@@ -194,7 +194,7 @@ def spawn_session_daemon() -> None:
 def setup(
     *,
     session_name: str,
-    is_init_session: bool = False,
+    is_snapshot_session: bool = False,
     base_path: str,
     append_trace: bool = False,
     ros_events: Union[List[str], Set[str]] = DEFAULT_EVENTS_ROS,
@@ -218,6 +218,7 @@ def setup(
     Raises RuntimeError on failure, in which case the tracing session might still exist.
 
     :param session_name: the name of the session
+    :param is_snapshot_session: whether to create a snapshot session
     :param base_path: the path to the directory in which to create the tracing session directory,
         which will be created if needed
     :param append_trace: whether to append to the trace directory if it already exists, otherwise
@@ -243,9 +244,9 @@ def setup(
     if not session_name:
         raise RuntimeError('empty session name')
     # Resolve full tracing directory path
-    # For init and runtime sessions, remove the suffixes in the full path
-    if is_init_session:
-        full_path = os.path.join(base_path, session_name.removesuffix('-init'))
+    # For snapshot sessions, remove the suffixes in the full path
+    if is_snapshot_session:
+        full_path = os.path.join(base_path, session_name.removesuffix('-snapshot'), 'snapshot')
     else:
         full_path = os.path.join(base_path, session_name)
     if os.path.isdir(full_path) and not append_trace:
@@ -303,7 +304,7 @@ def setup(
 
     # Create session
     # LTTng will create the parent directories if needed
-    if not is_init_session:
+    if not is_snapshot_session:
         _create_session(
             session_name=session_name,
             full_path=full_path,

--- a/tracetools_trace/tracetools_trace/tools/lttng_impl.py
+++ b/tracetools_trace/tracetools_trace/tools/lttng_impl.py
@@ -498,7 +498,9 @@ def _create_session_snapshot(
     Raises RuntimeError on failure.
 
     :param session_name: the name of the session
-    :param full_path: the full path to the main directory to write trace data to
+    :param full_path: the full path to the main directory to write trace data to;
+        if `None`, the snapshot output object will not be created 
+        (output object must be created before taking snapshots)
     """
     result = lttngpy.lttng_create_session_snapshot(
         session_name=session_name,

--- a/tracetools_trace/tracetools_trace/tools/lttng_impl.py
+++ b/tracetools_trace/tracetools_trace/tools/lttng_impl.py
@@ -248,11 +248,11 @@ def setup(
     # Resolve full tracing directory path
     if is_runtime_session:
         full_path = os.path.join(base_path, session_name.removesuffix('-runtime'), 'runtime')
-    if is_snapshot_session:
+    elif is_snapshot_session:
         full_path = os.path.join(base_path, session_name.removesuffix('-snapshot'), 'snapshot')
     else:
         full_path = os.path.join(base_path, session_name)
-    if os.path.isdir(full_path) and not append_trace:
+    if os.path.isdir(full_path) and not append_trace and not is_snapshot_session:
         raise RuntimeError(
             f'trace directory already exists, use the append option to append to it: {full_path}')
 
@@ -444,18 +444,21 @@ def stop(
         raise RuntimeError(f"failed to stop tracing session '{session_name}': {error}")
 
 
-def record_snapshot(**kwargs) -> None:
+def record_snapshot(
+    *,
+    session_name: str,
+    **kwargs
+) -> None:
     """
     Record a snapshot, and check for errors.
 
     This must not be called if `lttngpy.is_available()` is `False`.
     Raises RuntimeError on failure.
 
-    See `lttngpy.lttng_record_snapshot` for kwargs.
+    :param session_name: the name of the session
     """
-    result = lttngpy.lttng_record_snapshot(**kwargs)
+    result = lttngpy.lttng_record_snapshot(session_name=session_name)
     if result < 0:
-        session_name = kwargs['session_name']
         error = lttngpy.lttng_strerror(result)
         raise RuntimeError(
             f"failed to record snapshot of the tracing session '{session_name}': {error}"

--- a/tracetools_trace/tracetools_trace/tools/lttng_impl.py
+++ b/tracetools_trace/tracetools_trace/tools/lttng_impl.py
@@ -194,6 +194,7 @@ def spawn_session_daemon() -> None:
 def setup(
     *,
     session_name: str,
+    is_init_session: bool = False,
     base_path: str,
     append_trace: bool = False,
     ros_events: Union[List[str], Set[str]] = DEFAULT_EVENTS_ROS,
@@ -242,7 +243,11 @@ def setup(
     if not session_name:
         raise RuntimeError('empty session name')
     # Resolve full tracing directory path
-    full_path = os.path.join(base_path, session_name)
+    # For init and runtime sessions, remove the suffixes in the full path
+    if is_init_session:
+        full_path = os.path.join(base_path, session_name.removesuffix('-init'))
+    else:
+        full_path = os.path.join(base_path, session_name)
     if os.path.isdir(full_path) and not append_trace:
         raise RuntimeError(
             f'trace directory already exists, use the append option to append to it: {full_path}')
@@ -298,10 +303,16 @@ def setup(
 
     # Create session
     # LTTng will create the parent directories if needed
-    _create_session(
-        session_name=session_name,
-        full_path=full_path,
-    )
+    if not is_init_session:
+        _create_session(
+            session_name=session_name,
+            full_path=full_path,
+        )
+    else:
+        _create_session_snapshot(
+            session_name=session_name,
+            full_path=full_path,
+        )
 
     # Enable channel, events, and contexts for each domain
     if ust_enabled:
@@ -471,6 +482,37 @@ def _create_session(
         # destroy it and try again
         destroy(session_name=session_name)
         result = lttngpy.lttng_create_session(
+            session_name=session_name,
+            url=full_path,
+        )
+    if result < 0:
+        error = lttngpy.lttng_strerror(result)
+        raise RuntimeError(f"failed to create tracing session '{session_name}': {error}")
+
+
+def _create_session_snapshot(
+        *,
+        session_name: str,
+        full_path: str,
+) -> None:
+    """
+    Create snapshot session from name and full directory path, and check for errors.
+
+    This must not be called if `lttngpy.is_available()` is `False`.
+    Raises RuntimeError on failure.
+
+    :param session_name: the name of the session
+    :param full_path: the full path to the main directory to write trace data to
+    """
+    result = lttngpy.lttng_create_session_snapshot(
+        session_name=session_name,
+        url=full_path,
+    )
+    if -lttngpy.LTTNG_ERR_EXIST_SESS.value == result:
+        # Sessions may persist if there was an error previously, so if it already exists, just
+        # destroy it and try again
+        destroy(session_name=session_name)
+        result = lttngpy.lttng_create_session_snapshot(
             session_name=session_name,
             url=full_path,
         )

--- a/tracetools_trace/tracetools_trace/tools/lttng_impl.py
+++ b/tracetools_trace/tracetools_trace/tools/lttng_impl.py
@@ -248,6 +248,8 @@ def setup(
     # Resolve full tracing directory path
     if is_runtime_session:
         full_path = os.path.join(base_path, session_name.removesuffix('-runtime'), 'runtime')
+    if is_snapshot_session:
+        full_path = os.path.join(base_path, session_name.removesuffix('-snapshot'), 'snapshot')
     else:
         full_path = os.path.join(base_path, session_name)
     if os.path.isdir(full_path) and not append_trace:
@@ -313,6 +315,9 @@ def setup(
     else:
         _create_session_snapshot(
             session_name=session_name,
+            max_size=10 * subbuffer_size_ust,
+            name='snapshot',
+            full_path=full_path,
         )
 
     # Enable channel, events, and contexts for each domain
@@ -512,7 +517,9 @@ def _create_session(
 def _create_session_snapshot(
     *,
     session_name: str,
-    full_path: Optional[str] = None,
+    max_size: int,
+    name: str,
+    full_path: str,
 ) -> None:
     """
     Create snapshot session from name and full directory path, and check for errors.
@@ -521,13 +528,13 @@ def _create_session_snapshot(
     Raises RuntimeError on failure.
 
     :param session_name: the name of the session
-    :param full_path: the full path to the main directory to write trace data to;
-        if `None`, the snapshot output object will not be created
-        (output object must be created before taking snapshots)
+    :param max_size: the maximum size of the snapshot output in bytes
+    :param name: the name of the snapshot output
+    :param full_path: the full path to the main directory to write trace data to
     """
     result = lttngpy.lttng_create_session_snapshot(
         session_name=session_name,
-        url=full_path,
+        url=None,
     )
     if -lttngpy.LTTNG_ERR_EXIST_SESS.value == result:
         # Sessions may persist if there was an error previously, so if it already exists, just
@@ -535,11 +542,20 @@ def _create_session_snapshot(
         destroy(session_name=session_name)
         result = lttngpy.lttng_create_session_snapshot(
             session_name=session_name,
-            url=full_path,
+            url=None,
         )
     if result < 0:
         error = lttngpy.lttng_strerror(result)
         raise RuntimeError(f"failed to create tracing session '{session_name}': {error}")
+    result = lttngpy.lttng_add_snapshot_output(
+        session_name=session_name,
+        max_size=max_size,
+        name=name,
+        url=full_path,
+    )
+    if result < 0:
+        error = lttngpy.lttng_strerror(result)
+        raise RuntimeError(f"failed to setup the tracing session '{session_name}': {error}")
 
 
 def _enable_channel(**kwargs) -> None:

--- a/tracetools_trace/tracetools_trace/tools/lttng_impl.py
+++ b/tracetools_trace/tracetools_trace/tools/lttng_impl.py
@@ -30,6 +30,9 @@ from typing import Union
 from lttngpy import impl as lttngpy
 from packaging.version import Version
 
+from tracetools_trace.tools.path import RUNTIME_SESSION_SUFFIX
+from tracetools_trace.tools.path import SNAPSHOT_SESSION_SUFFIX
+
 from .names import DEFAULT_CONTEXT
 from .names import DEFAULT_EVENTS_ROS
 from .names import DOMAIN_TYPE_KERNEL
@@ -247,9 +250,17 @@ def setup(
         raise RuntimeError('empty session name')
     # Resolve full tracing directory path
     if snapshot_session and dual_session:
-        full_path = os.path.join(base_path, session_name.removesuffix('-snapshot'), 'snapshot')
+        full_path = os.path.join(
+            base_path,
+            session_name.removesuffix(SNAPSHOT_SESSION_SUFFIX),
+            'snapshot',
+        )
     elif dual_session:
-        full_path = os.path.join(base_path, session_name.removesuffix('-runtime'), 'runtime')
+        full_path = os.path.join(
+            base_path,
+            session_name.removesuffix(RUNTIME_SESSION_SUFFIX),
+            'runtime',
+        )
     else:
         full_path = os.path.join(base_path, session_name)
     if os.path.isdir(full_path) and not append_trace:
@@ -447,7 +458,7 @@ def stop(
 def record_snapshot(
     *,
     session_name: str,
-    **kwargs
+    **kwargs,
 ) -> None:
     """
     Record a snapshot, and check for errors.

--- a/tracetools_trace/tracetools_trace/tools/names.py
+++ b/tracetools_trace/tracetools_trace/tools/names.py
@@ -104,6 +104,26 @@ DEFAULT_EVENTS_ROS = [
     tracepoints.rclcpp_ring_buffer_clear
 ]
 
+DEFAULT_INIT_EVENTS_ROS = [
+    tracepoints.rcl_init,
+    tracepoints.rcl_node_init,
+    tracepoints.rmw_publisher_init,
+    tracepoints.rcl_publisher_init,
+    tracepoints.rmw_subscription_init,
+    tracepoints.rcl_subscription_init,
+    tracepoints.rclcpp_subscription_init,
+    tracepoints.rclcpp_subscription_callback_added,
+    tracepoints.rcl_service_init,
+    tracepoints.rmw_client_init,
+    tracepoints.rcl_client_init,
+    tracepoints.rcl_timer_init,
+    tracepoints.rclcpp_callback_register,
+    tracepoints.rcl_lifecycle_state_machine_init,
+    tracepoints.rclcpp_ipb_to_subscription,
+    tracepoints.rclcpp_buffer_to_ipb,
+    tracepoints.rclcpp_construct_ring_buffer,
+]
+
 DEFAULT_EVENTS_UST = DEFAULT_EVENTS_ROS
 
 DOMAIN_TYPE_KERNEL = 'kernel'

--- a/tracetools_trace/tracetools_trace/tools/names.py
+++ b/tracetools_trace/tracetools_trace/tools/names.py
@@ -114,14 +114,17 @@ DEFAULT_INIT_EVENTS_ROS = [
     tracepoints.rclcpp_subscription_init,
     tracepoints.rclcpp_subscription_callback_added,
     tracepoints.rcl_service_init,
+    tracepoints.rclcpp_service_callback_added,
     tracepoints.rmw_client_init,
     tracepoints.rcl_client_init,
     tracepoints.rcl_timer_init,
+    tracepoints.rclcpp_timer_callback_added,
+    tracepoints.rclcpp_timer_link_node,
     tracepoints.rclcpp_callback_register,
     tracepoints.rcl_lifecycle_state_machine_init,
     tracepoints.rclcpp_ipb_to_subscription,
     tracepoints.rclcpp_buffer_to_ipb,
-    tracepoints.rclcpp_construct_ring_buffer,
+    tracepoints.rclcpp_construct_ring_buffer
 ]
 
 DEFAULT_EVENTS_UST = DEFAULT_EVENTS_ROS

--- a/tracetools_trace/tracetools_trace/tools/path.py
+++ b/tracetools_trace/tracetools_trace/tools/path.py
@@ -16,6 +16,9 @@
 import os
 import time
 
+RUNTIME_SESSION_SUFFIX = '-runtime'
+SNAPSHOT_SESSION_SUFFIX = '-snapshot'
+
 
 def append_timestamp(
     session_name_base: str,

--- a/tracetools_trace/tracetools_trace/trace.py
+++ b/tracetools_trace/tracetools_trace/trace.py
@@ -76,24 +76,35 @@ def _resolve_session_path(
     *,
     session_name: str,
     base_path: Optional[str],
-    is_runtime_session: bool,
 ) -> Tuple[str, str]:
     if not base_path:
         base_path = path.get_tracing_directory()
-    if is_runtime_session:
-        full_session_path = os.path.join(
-            base_path,
-            session_name.removesuffix('-runtime'),
-            'runtime',
-        )
-    else:
-        full_session_path = os.path.join(base_path, session_name)
-
-    session_path = full_session_path if not is_runtime_session \
-        else full_session_path.removesuffix('/runtime')
-    print(f'writing tracing session to: {session_path}')
-
+    full_session_path = os.path.join(base_path, session_name)
+    print(f'writing tracing session to: {full_session_path}')
     return base_path, full_session_path
+
+
+def _resolve_runtime_session_path(
+    *,
+    session_name: str,
+    base_path: Optional[str],
+) -> Tuple[str, str]:
+    if not base_path:
+        base_path = path.get_tracing_directory()
+    full_session_path = os.path.join(base_path, session_name, 'runtime')
+    print(f'writing runtime tracing session to: {full_session_path}')
+    return base_path, full_session_path
+
+
+def _display_snapshot_session_path(
+    *,
+    session_name: str,
+    base_path: Optional[str],
+) -> None:
+    if not base_path:
+        base_path = path.get_tracing_directory()
+    full_session_path = os.path.join(base_path, session_name, 'snapshot')
+    print(f'writing snapshot tracing session to: {full_session_path}')
 
 
 def init(
@@ -140,16 +151,31 @@ def init(
     )
 
     if is_runtime_session:
-        session_name = session_name + '-runtime'
+        _display_snapshot_session_path(session_name=session_name, base_path=base_path)
+        base_path, full_runtime_session_path = _resolve_runtime_session_path(
+            session_name=session_name,
+            base_path=base_path,
+        )
 
-    base_path, full_session_path = _resolve_session_path(
-        session_name=session_name,
-        base_path=base_path,
-        is_runtime_session=is_runtime_session,
-    )
+        snapshot_session_name = session_name + '-snapshot'
+        runtime_session_name = session_name + '-runtime'
 
-    if interactive:
-        input('press enter to start...')
+        if interactive:
+            input('press enter to start tracing...')
+        lttng.lttng_record_snapshot(session_name=snapshot_session_name)
+
+        # For runtime sessions, use the runtime session name 
+        # and path so lttng_init() can be called uniformly
+        full_session_path = full_runtime_session_path
+        session_name = runtime_session_name
+    else:
+        base_path, full_session_path = _resolve_session_path(
+            session_name=session_name,
+            base_path=base_path,
+        )
+        if interactive:
+            input('press enter to start...')
+    
     trace_directory = lttng.lttng_init(
         session_name=session_name,
         is_runtime_session=is_runtime_session,
@@ -170,6 +196,7 @@ def init(
 def fini(
     *,
     session_name: str,
+    is_runtime_session: bool = False,
 ) -> None:
     """
     Stop and finalize tracing.
@@ -183,6 +210,8 @@ def fini(
 
     def _fini() -> None:
         print('stopping & destroying tracing session')
+        if is_runtime_session:
+            session_name += '-runtime'
         lttng.lttng_fini(session_name=session_name)
 
     signals.execute_and_handle_sigint(_run, _fini)
@@ -191,18 +220,22 @@ def fini(
 def cleanup(
     *,
     session_name: str,
+    is_runtime_session: bool = False,
 ) -> None:
     """
     Clean up and remove tracing session if it exists.
 
     :param session_name: the name of the session
     """
+    if is_runtime_session:
+        session_name += '-runtime'
     lttng.lttng_fini(session_name=session_name, ignore_error=True)
 
 
 def _do_work_and_report_error(
     work: Callable[[], int],
     session_name: str,
+    is_runtime_session: bool = False,
     *,
     do_cleanup: bool,
 ) -> int:
@@ -223,7 +256,7 @@ def _do_work_and_report_error(
     except RuntimeError as e:
         print(f'error: {str(e)}', file=sys.stderr)
         if do_cleanup:
-            cleanup(session_name=session_name)
+            cleanup(session_name=session_name, is_runtime_session=is_runtime_session)
         return 1
 
 
@@ -241,6 +274,7 @@ def trace(args: argparse.Namespace) -> int:
     def work() -> int:
         if not init(
             session_name=args.session_name,
+            is_runtime_session=args.is_runtime_session,
             base_path=args.path,
             append_trace=args.append_trace,
             ros_events=args.events_ust,
@@ -249,16 +283,15 @@ def trace(args: argparse.Namespace) -> int:
             context_fields=args.context_fields,
             display_list=args.list,
             interactive=True,
-            is_runtime_session=args.is_runtime_session,
         ):
             return 1
-        fini(session_name=args.session_name if not args.is_runtime_session
-             else args.session_name + '-runtime')
+        fini(session_name=args.session_name, is_runtime_session=args.is_runtime_session)
         return 0
     return _do_work_and_report_error(
         work,
-        args.session_name if not args.is_runtime_session else args.session_name + '-runtime',
-        do_cleanup=True
+        args.session_name,
+        args.is_runtime_session,
+        do_cleanup=True,
     )
 
 
@@ -276,6 +309,7 @@ def start(args: argparse.Namespace) -> int:
         return int(
             not init(
                 session_name=args.session_name,
+                is_runtime_session=args.is_runtime_session,
                 base_path=args.path,
                 append_trace=args.append_trace,
                 ros_events=args.events_ust,
@@ -286,7 +320,12 @@ def start(args: argparse.Namespace) -> int:
                 interactive=False,
             )
         )
-    return _do_work_and_report_error(work, args.session_name, do_cleanup=True)
+    return _do_work_and_report_error(
+        work,
+        args.session_name,
+        args.is_runtime_session,
+        do_cleanup=True
+    )
 
 
 def stop(args: argparse.Namespace) -> int:
@@ -300,7 +339,10 @@ def stop(args: argparse.Namespace) -> int:
     :return: the return code (0 if successful, 1 otherwise)
     """
     def work() -> int:
-        lttng.lttng_fini(session_name=args.session_name)
+        session_name = args.session_name
+        if args.is_runtime_session:
+            session_name += '-runtime'
+        lttng.lttng_fini(session_name=session_name)
         return 0
     return _do_work_and_report_error(work, args.session_name, do_cleanup=False)
 
@@ -316,7 +358,10 @@ def pause(args: argparse.Namespace) -> int:
     :return: the return code (0 if successful, 1 otherwise)
     """
     def work() -> int:
-        lttng.lttng_stop(session_name=args.session_name)
+        session_name = args.session_name
+        if args.is_runtime_session:
+            session_name += '-runtime'
+        lttng.lttng_stop(session_name=session_name)
         return 0
     return _do_work_and_report_error(work, args.session_name, do_cleanup=False)
 
@@ -332,7 +377,12 @@ def resume(args: argparse.Namespace) -> int:
     :return: the return code (0 if successful, 1 otherwise)
     """
     def work() -> int:
-        lttng.lttng_start(session_name=args.session_name)
+        session_name = args.session_name
+        if args.is_runtime_session:
+            snapshot_session_name = session_name + '-snapshot'
+            lttng.lttng_record_snapshot(session_name=snapshot_session_name)
+            session_name += '-runtime'
+        lttng.lttng_start(session_name=session_name)
         return 0
     return _do_work_and_report_error(work, args.session_name, do_cleanup=False)
 

--- a/tracetools_trace/tracetools_trace/trace.py
+++ b/tracetools_trace/tracetools_trace/trace.py
@@ -110,7 +110,7 @@ def _display_snapshot_session_path(
 def init(
     *,
     session_name: str,
-    is_runtime_session: bool,
+    dual_session: bool,
     base_path: Optional[str],
     append_trace: bool,
     ros_events: List[str],
@@ -129,7 +129,7 @@ def init(
     Raises RuntimeError on failure, in which case the tracing session might still exist.
 
     :param session_name: the name of the session
-    :param is_runtime_session: whether this is a runtime session
+    :param dual_session: whether this is part of a dual session
     :param base_path: the path to the directory in which to create the tracing session directory,
         or `None` for default
     :param append_trace: whether to append to the trace directory if it already exists, otherwise
@@ -150,7 +150,7 @@ def init(
         display_list=display_list,
     )
 
-    if is_runtime_session:
+    if dual_session:
         _display_snapshot_session_path(session_name=session_name, base_path=base_path)
         base_path, full_runtime_session_path = _resolve_runtime_session_path(
             session_name=session_name,
@@ -178,7 +178,7 @@ def init(
 
     trace_directory = lttng.lttng_init(
         session_name=session_name,
-        is_runtime_session=is_runtime_session,
+        dual_session=dual_session,
         base_path=base_path,
         append_trace=append_trace,
         ros_events=ros_events,
@@ -196,7 +196,7 @@ def init(
 def fini(
     *,
     session_name: str,
-    is_runtime_session: bool = False,
+    dual_session: bool = False,
 ) -> None:
     """
     Stop and finalize tracing.
@@ -211,7 +211,7 @@ def fini(
     def _fini() -> None:
         print('stopping & destroying tracing session')
         lttng.lttng_fini(
-            session_name=session_name + (path.RUNTIME_SESSION_SUFFIX if is_runtime_session else '')
+            session_name=session_name + (path.RUNTIME_SESSION_SUFFIX if dual_session else '')
         )
 
     signals.execute_and_handle_sigint(_run, _fini)
@@ -220,14 +220,14 @@ def fini(
 def cleanup(
     *,
     session_name: str,
-    is_runtime_session: bool = False,
+    dual_session: bool = False,
 ) -> None:
     """
     Clean up and remove tracing session if it exists.
 
     :param session_name: the name of the session
     """
-    if is_runtime_session:
+    if dual_session:
         session_name += path.RUNTIME_SESSION_SUFFIX
     lttng.lttng_fini(session_name=session_name, ignore_error=True)
 
@@ -235,7 +235,7 @@ def cleanup(
 def _do_work_and_report_error(
     work: Callable[[], int],
     session_name: str,
-    is_runtime_session: bool = False,
+    dual_session: bool = False,
     *,
     do_cleanup: bool,
 ) -> int:
@@ -256,7 +256,7 @@ def _do_work_and_report_error(
     except RuntimeError as e:
         print(f'error: {str(e)}', file=sys.stderr)
         if do_cleanup:
-            cleanup(session_name=session_name, is_runtime_session=is_runtime_session)
+            cleanup(session_name=session_name, dual_session=dual_session)
         return 1
 
 
@@ -274,7 +274,7 @@ def trace(args: argparse.Namespace) -> int:
     def work() -> int:
         if not init(
             session_name=args.session_name,
-            is_runtime_session=args.is_runtime_session,
+            dual_session=args.dual_session,
             base_path=args.path,
             append_trace=args.append_trace,
             ros_events=args.events_ust,
@@ -285,12 +285,12 @@ def trace(args: argparse.Namespace) -> int:
             interactive=True,
         ):
             return 1
-        fini(session_name=args.session_name, is_runtime_session=args.is_runtime_session)
+        fini(session_name=args.session_name, dual_session=args.dual_session)
         return 0
     return _do_work_and_report_error(
         work,
         args.session_name,
-        args.is_runtime_session,
+        args.dual_session,
         do_cleanup=True,
     )
 
@@ -309,7 +309,7 @@ def start(args: argparse.Namespace) -> int:
         return int(
             not init(
                 session_name=args.session_name,
-                is_runtime_session=args.is_runtime_session,
+                dual_session=args.dual_session,
                 base_path=args.path,
                 append_trace=args.append_trace,
                 ros_events=args.events_ust,
@@ -323,7 +323,7 @@ def start(args: argparse.Namespace) -> int:
     return _do_work_and_report_error(
         work,
         args.session_name,
-        args.is_runtime_session,
+        args.dual_session,
         do_cleanup=True
     )
 
@@ -340,7 +340,7 @@ def stop(args: argparse.Namespace) -> int:
     """
     def work() -> int:
         session_name = args.session_name
-        if args.is_runtime_session:
+        if args.dual_session:
             session_name += path.RUNTIME_SESSION_SUFFIX
         lttng.lttng_fini(session_name=session_name)
         return 0
@@ -359,7 +359,7 @@ def pause(args: argparse.Namespace) -> int:
     """
     def work() -> int:
         session_name = args.session_name
-        if args.is_runtime_session:
+        if args.dual_session:
             session_name += path.RUNTIME_SESSION_SUFFIX
         lttng.lttng_stop(session_name=session_name)
         return 0
@@ -378,7 +378,7 @@ def resume(args: argparse.Namespace) -> int:
     """
     def work() -> int:
         session_name = args.session_name
-        if args.is_runtime_session:
+        if args.dual_session:
             snapshot_session_name = session_name + path.SNAPSHOT_SESSION_SUFFIX
             lttng.lttng_record_snapshot(session_name=snapshot_session_name)
             session_name += path.RUNTIME_SESSION_SUFFIX

--- a/tracetools_trace/tracetools_trace/trace.py
+++ b/tracetools_trace/tracetools_trace/trace.py
@@ -76,17 +76,25 @@ def _resolve_session_path(
     *,
     session_name: str,
     base_path: Optional[str],
+    is_runtime_session: bool,
 ) -> Tuple[str, str]:
     if not base_path:
         base_path = path.get_tracing_directory()
-    full_session_path = os.path.join(base_path, session_name)
-    print(f'writing tracing session to: {full_session_path}')
+    if is_runtime_session:
+        full_session_path = os.path.join(base_path, session_name.removesuffix('-runtime'), 'runtime')
+    else:
+        full_session_path = os.path.join(base_path, session_name)
+
+    session_path = full_session_path if not is_runtime_session else full_session_path.removesuffix("/runtime")
+    print(f'writing tracing session to: {session_path}')
+
     return base_path, full_session_path
 
 
 def init(
     *,
     session_name: str,
+    is_runtime_session: bool,
     base_path: Optional[str],
     append_trace: bool,
     ros_events: List[str],
@@ -105,6 +113,7 @@ def init(
     Raises RuntimeError on failure, in which case the tracing session might still exist.
 
     :param session_name: the name of the session
+    :param is_runtime_session: whether this is a runtime session
     :param base_path: the path to the directory in which to create the tracing session directory,
         or `None` for default
     :param append_trace: whether to append to the trace directory if it already exists, otherwise
@@ -125,15 +134,20 @@ def init(
         display_list=display_list,
     )
 
+    if is_runtime_session:
+        session_name = session_name + '-runtime'
+
     base_path, full_session_path = _resolve_session_path(
         session_name=session_name,
         base_path=base_path,
+        is_runtime_session=is_runtime_session,
     )
 
     if interactive:
         input('press enter to start...')
     trace_directory = lttng.lttng_init(
         session_name=session_name,
+        is_runtime_session=is_runtime_session,
         base_path=base_path,
         append_trace=append_trace,
         ros_events=ros_events,
@@ -230,11 +244,17 @@ def trace(args: argparse.Namespace) -> int:
             context_fields=args.context_fields,
             display_list=args.list,
             interactive=True,
+            is_runtime_session=args.is_runtime_session,
         ):
             return 1
-        fini(session_name=args.session_name)
+        fini(session_name=args.session_name if not args.is_runtime_session
+                   else args.session_name + '-runtime')
         return 0
-    return _do_work_and_report_error(work, args.session_name, do_cleanup=True)
+    return _do_work_and_report_error(
+        work,
+        args.session_name if not args.is_runtime_session else args.session_name + '-runtime',
+        do_cleanup=True
+    )
 
 
 def start(args: argparse.Namespace) -> int:

--- a/tracetools_trace/tracetools_trace/trace.py
+++ b/tracetools_trace/tracetools_trace/trace.py
@@ -164,7 +164,7 @@ def init(
             input('press enter to start tracing...')
         lttng.lttng_record_snapshot(session_name=snapshot_session_name)
 
-        # For runtime sessions, use the runtime session name 
+        # For runtime sessions, use the runtime session name
         # and path so lttng_init() can be called uniformly
         full_session_path = full_runtime_session_path
         session_name = runtime_session_name
@@ -175,7 +175,7 @@ def init(
         )
         if interactive:
             input('press enter to start...')
-    
+
     trace_directory = lttng.lttng_init(
         session_name=session_name,
         is_runtime_session=is_runtime_session,
@@ -210,9 +210,9 @@ def fini(
 
     def _fini() -> None:
         print('stopping & destroying tracing session')
-        if is_runtime_session:
-            session_name += '-runtime'
-        lttng.lttng_fini(session_name=session_name)
+        lttng.lttng_fini(
+            session_name=session_name + ('-runtime' if is_runtime_session else '')
+        )
 
     signals.execute_and_handle_sigint(_run, _fini)
 

--- a/tracetools_trace/tracetools_trace/trace.py
+++ b/tracetools_trace/tracetools_trace/trace.py
@@ -157,8 +157,8 @@ def init(
             base_path=base_path,
         )
 
-        snapshot_session_name = session_name + '-snapshot'
-        runtime_session_name = session_name + '-runtime'
+        snapshot_session_name = session_name + path.SNAPSHOT_SESSION_SUFFIX
+        runtime_session_name = session_name + path.RUNTIME_SESSION_SUFFIX
 
         if interactive:
             input('press enter to start tracing...')
@@ -211,7 +211,7 @@ def fini(
     def _fini() -> None:
         print('stopping & destroying tracing session')
         lttng.lttng_fini(
-            session_name=session_name + ('-runtime' if is_runtime_session else '')
+            session_name=session_name + (path.RUNTIME_SESSION_SUFFIX if is_runtime_session else '')
         )
 
     signals.execute_and_handle_sigint(_run, _fini)
@@ -228,7 +228,7 @@ def cleanup(
     :param session_name: the name of the session
     """
     if is_runtime_session:
-        session_name += '-runtime'
+        session_name += path.RUNTIME_SESSION_SUFFIX
     lttng.lttng_fini(session_name=session_name, ignore_error=True)
 
 
@@ -341,7 +341,7 @@ def stop(args: argparse.Namespace) -> int:
     def work() -> int:
         session_name = args.session_name
         if args.is_runtime_session:
-            session_name += '-runtime'
+            session_name += path.RUNTIME_SESSION_SUFFIX
         lttng.lttng_fini(session_name=session_name)
         return 0
     return _do_work_and_report_error(work, args.session_name, do_cleanup=False)
@@ -360,7 +360,7 @@ def pause(args: argparse.Namespace) -> int:
     def work() -> int:
         session_name = args.session_name
         if args.is_runtime_session:
-            session_name += '-runtime'
+            session_name += path.RUNTIME_SESSION_SUFFIX
         lttng.lttng_stop(session_name=session_name)
         return 0
     return _do_work_and_report_error(work, args.session_name, do_cleanup=False)
@@ -379,9 +379,9 @@ def resume(args: argparse.Namespace) -> int:
     def work() -> int:
         session_name = args.session_name
         if args.is_runtime_session:
-            snapshot_session_name = session_name + '-snapshot'
+            snapshot_session_name = session_name + path.SNAPSHOT_SESSION_SUFFIX
             lttng.lttng_record_snapshot(session_name=snapshot_session_name)
-            session_name += '-runtime'
+            session_name += path.RUNTIME_SESSION_SUFFIX
         lttng.lttng_start(session_name=session_name)
         return 0
     return _do_work_and_report_error(work, args.session_name, do_cleanup=False)

--- a/tracetools_trace/tracetools_trace/trace.py
+++ b/tracetools_trace/tracetools_trace/trace.py
@@ -324,7 +324,7 @@ def start(args: argparse.Namespace) -> int:
         work,
         args.session_name,
         args.dual_session,
-        do_cleanup=True
+        do_cleanup=True,
     )
 
 
@@ -379,6 +379,7 @@ def resume(args: argparse.Namespace) -> int:
     def work() -> int:
         session_name = args.session_name
         if args.dual_session:
+            # Trigger snapshot to record any init events missed while paused
             snapshot_session_name = session_name + path.SNAPSHOT_SESSION_SUFFIX
             lttng.lttng_record_snapshot(session_name=snapshot_session_name)
             session_name += path.RUNTIME_SESSION_SUFFIX

--- a/tracetools_trace/tracetools_trace/trace.py
+++ b/tracetools_trace/tracetools_trace/trace.py
@@ -81,11 +81,16 @@ def _resolve_session_path(
     if not base_path:
         base_path = path.get_tracing_directory()
     if is_runtime_session:
-        full_session_path = os.path.join(base_path, session_name.removesuffix('-runtime'), 'runtime')
+        full_session_path = os.path.join(
+            base_path,
+            session_name.removesuffix('-runtime'),
+            'runtime',
+        )
     else:
         full_session_path = os.path.join(base_path, session_name)
 
-    session_path = full_session_path if not is_runtime_session else full_session_path.removesuffix("/runtime")
+    session_path = full_session_path if not is_runtime_session \
+        else full_session_path.removesuffix('/runtime')
     print(f'writing tracing session to: {session_path}')
 
     return base_path, full_session_path
@@ -248,7 +253,7 @@ def trace(args: argparse.Namespace) -> int:
         ):
             return 1
         fini(session_name=args.session_name if not args.is_runtime_session
-                   else args.session_name + '-runtime')
+             else args.session_name + '-runtime')
         return 0
     return _do_work_and_report_error(
         work,


### PR DESCRIPTION
## Description

At present, users must start tracing before launching their application in order to collect meaningful trace data, due to the way the ROS 2 source code is instrumented (See #190). 

This PR adds the ability to start tracing at runtime, provided some pre-configuration is done. Specifically, the `dual_session` argument of the `Trace` action must be set to `True`:

Setting the `dual_session` argument of Trace Action to `True`
```python
Trace(
    session_name='my-tracing-session',
    dual_session=True,
),
```
This starts an [LTTng session in snapshot mode](https://lttng.org/docs/v2.13/#doc-tracing-session-mode), which captures initialization trace data and makes it available for writing to disk on demand.

Once pre-configured, tracing can be started at runtime using the `ros2 trace` command with the `--dual-session` option, which records a snapshot from the pre-configured session and starts a runtime tracing session to record the runtime trace data.

Example:
```bash
ros2 trace --session-name my-tracing-session --dual-session
```
⚠️ The session name used here must match the one specified in the Trace action.

When tracing is started, data will be written under:
```
~/.ros/tracing/my-session-name/
├── runtime # trace data of runtime events
└── snapshot # trace data of initialization events
```
If tracing is never started, no data will be written to disk.

Fixes #190 
Fixes #44 