### PR TITLE
Only check test process events in test_runtime_disable

### DIFF
--- a/test_ros2trace/test/test_ros2trace/test_trace.py
+++ b/test_ros2trace/test/test_ros2trace/test_trace.py
@@ -113,19 +113,23 @@ class TestROS2TraceCLI(unittest.TestCase):
         self.assertFalse(os.path.isdir(trace_dir), f'trace directory exists: {trace_dir}')
 
     def assertTraceNotContains(self, trace_dir: str, unexpected_event_names: List[str]) -> None:
+        self.assertNotIn(
+            TRACE_TEST_ID_TP_NAME, unexpected_event_names, 'process marker event is required')
         self.assertTraceExist(trace_dir)
         from tracetools_read.trace import get_trace_events
         events = get_trace_events(trace_dir)
         trace_test_events = get_corresponding_trace_test_events(events, self.trace_test_id)
+        # The events from the marked processes should contain process marker event(s)
         self.assertGreater(
             len(trace_test_events),
             0,
             f'no matching trace test events found: {events}')
-        for event in events:
+        # but not the unexpected events
+        for event in trace_test_events:
             event_name = get_event_name(event)
             self.assertNotIn(
                 event_name, unexpected_event_names,
-                f'{event_name} found in events: {events}'
+                f'{event_name} found in events: {trace_test_events}'
             )
 
     def assertTraceContains(

--- a/tracetools_test/tracetools_test/mark_process.py
+++ b/tracetools_test/tracetools_test/mark_process.py
@@ -65,7 +65,7 @@ def get_corresponding_trace_test_events(
 
     :param events: all of the trace events
     :param trace_test_id: the trace test ID
-    :return: the relevant trace events corresponding to the given test
+    :return: the relevant trace events corresponding to the given test, including the marker event
     """
     expected_event_msg = _get_trace_test_id_event_value(trace_test_id)
     events_id = get_events_with_name(TRACE_TEST_ID_TP_NAME, events)


### PR DESCRIPTION
## Description

Follow-up to #185
Fixes #192

The process marking mechanism exists so that we can filter out trace events from unrelated processes, e.g., from other tests running in parallel.

In `test_runtime_disable`, we disable tracing at runtime by setting the `TRACETOOLS_RUNTIME_DISABLE` env var to `1` and then want to make sure the test nodes we launch do not generate any (ROS 2) events. However, we were checking *all* recorded events in `assertTraceNotContains()`, not just the events from this test's nodes/processes, which could include events generated by other tests in parallel.

### Is this user-facing behavior change?

No.

### Did you use Generative AI?

No.

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
