### PR TITLE
[Fix] compile fail

### DIFF
--- a/lttngpy/src/lttngpy/channel.cpp
+++ b/lttngpy/src/lttngpy/channel.cpp
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 // Include lttng-error.h before channel.h, otherwise lttng_error_code isn't known
-// TODO: order it alphabetically once liblttng-ctl 2.14+ is fixed:
+// TODO(mosfet80): order it alphabetically once liblttng-ctl 2.14+ is fixed:
 // https://review.lttng.org/c/lttng-tools/+/15165
 #include <lttng/lttng-error.h>
 #include <lttng/channel.h>

--- a/lttngpy/src/lttngpy/channel.cpp
+++ b/lttngpy/src/lttngpy/channel.cpp
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Include lttng-error.h before channel.h, otherwise lttng_error_code isn't known
+// TODO: order it alphabetically once liblttng-ctl 2.14+ is fixed:
+// https://review.lttng.org/c/lttng-tools/+/15165
 #include <lttng/lttng-error.h>
 #include <lttng/channel.h>
 #include <lttng/constant.h>

--- a/lttngpy/src/lttngpy/channel.cpp
+++ b/lttngpy/src/lttngpy/channel.cpp
@@ -12,12 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <lttng/lttng-error.h>
 #include <lttng/channel.h>
 #include <lttng/constant.h>
 #include <lttng/domain.h>
 #include <lttng/event.h>
 #include <lttng/handle.h>
-#include <lttng/lttng-error.h>
 
 #include <optional>
 #include <string>


### PR DESCRIPTION

## Description

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

Fix compile fail on debian trixie.

Error:
ros2/ros2_tracing/lttngpy/src/lttngpy/channel.cpp:15: /usr/include/lttng/channel.h:766:26: error: use of enum ‘lttng_error_code’ without previous declaration
  766 | LTTNG_EXPORT extern enum lttng_error_code
      |                          ^~~~~~~~~~~~~~~~

### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
