### PR TITLE
Allow creating snapshot sessions

### DIFF
--- a/lttngpy/src/lttngpy/_lttngpy_pybind11.cpp
+++ b/lttngpy/src/lttngpy/_lttngpy_pybind11.cpp
@@ -118,11 +118,8 @@ PYBIND11_MODULE(_lttngpy_pybind11, m) {
   m.def(
     "get_session_names",
     &lttngpy::get_session_names,
-    "Get the currently-existing session names.");
-  m.def(
-    "get_snapshot_session_names",
-    &lttngpy::get_snapshot_session_names,
-    "Get the currently-existing snapshot session names.");
+    "Get the currently-existing session names.",
+    py::arg("snapshot_mode") = false);
 
   // Domain
   py::enum_<lttng_domain_type>(m, "lttng_domain_type")

--- a/lttngpy/src/lttngpy/_lttngpy_pybind11.cpp
+++ b/lttngpy/src/lttngpy/_lttngpy_pybind11.cpp
@@ -119,6 +119,10 @@ PYBIND11_MODULE(_lttngpy_pybind11, m) {
     "get_session_names",
     &lttngpy::get_session_names,
     "Get the currently-existing session names.");
+  m.def(
+    "get_snapshot_session_names",
+    &lttngpy::get_snapshot_session_names,
+    "Get the currently-existing snapshot session names.");
 
   // Domain
   py::enum_<lttng_domain_type>(m, "lttng_domain_type")

--- a/lttngpy/src/lttngpy/session.cpp
+++ b/lttngpy/src/lttngpy/session.cpp
@@ -42,6 +42,26 @@ std::variant<int, std::set<std::string>> get_session_names()
   return session_names;
 }
 
+std::variant<int, std::set<std::string>> get_snapshot_session_names()
+{
+  struct lttng_session * sessions = nullptr;
+  int ret = lttng_list_sessions(&sessions);
+  if (0 > ret) {
+    std::free(sessions);
+    return ret;
+  }
+
+  std::set<std::string> snapshot_session_names = {};
+  const int num_sessions = ret;
+  for (int i = 0; i < num_sessions; i++) {
+    if (sessions[i].snapshot_mode) {
+      snapshot_session_names.insert(sessions[i].name);
+    }
+  }
+  std::free(sessions);
+  return snapshot_session_names;
+}
+
 int destroy_all_sessions()
 {
   const auto & session_names_opt = lttngpy::get_session_names();

--- a/lttngpy/src/lttngpy/session.cpp
+++ b/lttngpy/src/lttngpy/session.cpp
@@ -24,7 +24,7 @@
 namespace lttngpy
 {
 
-std::variant<int, std::set<std::string>> get_session_names()
+std::variant<int, std::set<std::string>> get_session_names(bool snapshot_mode)
 {
   struct lttng_session * sessions = nullptr;
   int ret = lttng_list_sessions(&sessions);
@@ -36,30 +36,13 @@ std::variant<int, std::set<std::string>> get_session_names()
   std::set<std::string> session_names = {};
   const int num_sessions = ret;
   for (int i = 0; i < num_sessions; i++) {
+    if (snapshot_mode && !sessions[i].snapshot_mode) {
+      continue;
+    }
     session_names.insert(sessions[i].name);
   }
   std::free(sessions);
   return session_names;
-}
-
-std::variant<int, std::set<std::string>> get_snapshot_session_names()
-{
-  struct lttng_session * sessions = nullptr;
-  int ret = lttng_list_sessions(&sessions);
-  if (0 > ret) {
-    std::free(sessions);
-    return ret;
-  }
-
-  std::set<std::string> snapshot_session_names = {};
-  const int num_sessions = ret;
-  for (int i = 0; i < num_sessions; i++) {
-    if (sessions[i].snapshot_mode) {
-      snapshot_session_names.insert(sessions[i].name);
-    }
-  }
-  std::free(sessions);
-  return snapshot_session_names;
 }
 
 int destroy_all_sessions()

--- a/lttngpy/src/lttngpy/session.hpp
+++ b/lttngpy/src/lttngpy/session.hpp
@@ -25,16 +25,10 @@ namespace lttngpy
 /**
  * Get the currently-existing session names.
  *
+ * \param snapshot_mode If true, only snapshot session names are returned
  * \return the set of session names, else a negative LTTng error code
  */
-std::variant<int, std::set<std::string>> get_session_names();
-
-/**
- * Get the currently-existing snapshot session names.
- *
- * \return the set of snapshot session names, else a negative LTTng error code
- */
-std::variant<int, std::set<std::string>> get_snapshot_session_names();
+std::variant<int, std::set<std::string>> get_session_names(bool snapshot_mode = false);
 
 /**
  * Destroy all sessions.

--- a/lttngpy/src/lttngpy/session.hpp
+++ b/lttngpy/src/lttngpy/session.hpp
@@ -30,6 +30,13 @@ namespace lttngpy
 std::variant<int, std::set<std::string>> get_session_names();
 
 /**
+ * Get the currently-existing snapshot session names.
+ *
+ * \return the set of snapshot session names, else a negative LTTng error code
+ */
+std::variant<int, std::set<std::string>> get_snapshot_session_names();
+
+/**
  * Destroy all sessions.
  *
  * Tries to destroy all sessions, and reports an error if any session destruction was unsuccessful.

--- a/lttngpy/src/lttngpy/snapshot.cpp
+++ b/lttngpy/src/lttngpy/snapshot.cpp
@@ -78,8 +78,10 @@ int record_snapshot(const std::string & session_name)
     return ret;
   }
 
+  lttng_error_code result;
+  ret = lttng_clear_handle_get_result(handle, &result);
   lttng_clear_handle_destroy(handle);
-  return 0;
+  return ret;
 }
 
 }  // namespace lttngpy

--- a/lttngpy/src/lttngpy/snapshot.cpp
+++ b/lttngpy/src/lttngpy/snapshot.cpp
@@ -12,8 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <lttng/snapshot.h>
+#include <lttng/clear.h>
+#include <lttng/clear-handle.h>
 #include <lttng/lttng-error.h>
+#include <lttng/snapshot.h>
 
 #include <string>
 
@@ -57,7 +59,27 @@ int add_snapshot_output(
 
 int record_snapshot(const std::string & session_name)
 {
-  return lttng_snapshot_record(session_name.c_str(), NULL, 1);  // The last parameter is unused
+  int ret = lttng_snapshot_record(session_name.c_str(), NULL, 1);  // The last parameter is unused
+  if (0 != ret) {
+    return ret;
+  }
+
+  // Clear the session after recording the snapshot
+  lttng_clear_handle *handle;
+  ret = lttng_clear_session(session_name.c_str(), &handle);
+  if (0 > ret) {
+    lttng_clear_handle_destroy(handle);
+    return ret;
+  }
+
+  ret = lttng_clear_handle_wait_for_completion(handle, -1);  // Wait indefinitely
+  if (LTTNG_CLEAR_HANDLE_STATUS_COMPLETED != ret) {
+    lttng_clear_handle_destroy(handle);
+    return ret;
+  }
+
+  lttng_clear_handle_destroy(handle);
+  return 0;
 }
 
 }  // namespace lttngpy

--- a/lttngpy/test/test_session.py
+++ b/lttngpy/test/test_session.py
@@ -59,6 +59,42 @@ class TestSession(unittest.TestCase):
 
         shutil.rmtree(tmpdir)
 
+    def test_snapshot_session_list_create_start_stop_destroy(self):
+        session_name = 'test_snapshot_session_list_create_start_stop_destroy'
+        tmpdir = self.create_test_tmpdir(session_name)
+
+        self.assertSetEqual(set(), lttngpy.get_session_names(snapshot_mode=True))
+        self.assertEqual(
+            0,
+            lttngpy.lttng_create_session_snapshot(session_name=session_name, url=tmpdir),
+        )
+        self.assertSetEqual({session_name}, lttngpy.get_session_names(snapshot_mode=True))
+        self.assertEqual(
+            0,
+            lttngpy.enable_channel(
+                session_name=session_name,
+                domain_type=lttngpy.LTTNG_DOMAIN_UST,
+                buffer_type=lttngpy.LTTNG_BUFFER_PER_UID,
+                channel_name='dummy_channel',
+                overwrite=None,
+                subbuf_size=None,
+                num_subbuf=None,
+                switch_timer_interval=None,
+                read_timer_interval=None,
+                output=None,
+            ),
+        )
+        self.assertEqual(0, lttngpy.lttng_start_tracing(session_name=session_name))
+        self.assertEqual(0, lttngpy.lttng_stop_tracing(session_name=session_name))
+        self.assertEqual(0, lttngpy.lttng_destroy_session(session_name=session_name))
+        self.assertSetEqual(set(), lttngpy.get_session_names(snapshot_mode=True))
+
+        self.assertEqual(0, lttngpy.lttng_create_session(session_name=session_name, url=tmpdir))
+        self.assertEqual(0, lttngpy.destroy_all_sessions())
+        self.assertSetEqual(set(), lttngpy.get_session_names(snapshot_mode=True))
+
+        shutil.rmtree(tmpdir)
+
     def test_error(self):
         session_name = 'test_error'
         self.assertSetEqual(set(), lttngpy.get_session_names())

--- a/lttngpy/test/test_session.py
+++ b/lttngpy/test/test_session.py
@@ -89,7 +89,10 @@ class TestSession(unittest.TestCase):
         self.assertEqual(0, lttngpy.lttng_destroy_session(session_name=session_name))
         self.assertSetEqual(set(), lttngpy.get_session_names(snapshot_mode=True))
 
-        self.assertEqual(0, lttngpy.lttng_create_session(session_name=session_name, url=tmpdir))
+        self.assertEqual(
+            0,
+            lttngpy.lttng_create_session_snapshot(session_name=session_name, url=tmpdir),
+        )
         self.assertEqual(0, lttngpy.destroy_all_sessions())
         self.assertSetEqual(set(), lttngpy.get_session_names(snapshot_mode=True))
 

--- a/ros2trace/ros2trace/verb/record_snapshot.py
+++ b/ros2trace/ros2trace/verb/record_snapshot.py
@@ -18,10 +18,10 @@ from tracetools_trace.trace import record_snapshot
 
 
 class RecordSnapshotVerb(VerbExtension):
-    """Record a snapshot of the current tracing session."""
+    """Take a snapshot of a snapshot session."""
 
-    def add_arguments(self, parser, cli_name):
+    def add_arguments(self, parser, cli_name) -> None:
         args.add_arguments_noninteractive_control(parser)
 
-    def main(self, *, args):
+    def main(self, *, args) -> int:
         return record_snapshot(args)

--- a/ros2trace/ros2trace/verb/record_snapshot.py
+++ b/ros2trace/ros2trace/verb/record_snapshot.py
@@ -1,0 +1,27 @@
+# Copyright 2025 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ros2trace.verb import VerbExtension
+from tracetools_trace.tools import args
+from tracetools_trace.trace import record_snapshot
+
+
+class RecordSnapshotVerb(VerbExtension):
+    """Record a snapshot of the current tracing session."""
+
+    def add_arguments(self, parser, cli_name):
+        args.add_arguments_noninteractive_control(parser)
+
+    def main(self, *, args):
+        return record_snapshot(args)

--- a/ros2trace/setup.py
+++ b/ros2trace/setup.py
@@ -47,6 +47,7 @@ setup(
         ],
         f'{package_name}.verb': [
             f'pause = {package_name}.verb.pause:PauseVerb',
+            f'record_snapshot = {package_name}.verb.record_snapshot:RecordSnapshotVerb',
             f'resume = {package_name}.verb.resume:ResumeVerb',
             f'start = {package_name}.verb.start:StartVerb',
             f'stop = {package_name}.verb.stop:StopVerb',

--- a/test_ros2trace/test/test_ros2trace/test_trace.py
+++ b/test_ros2trace/test/test_ros2trace/test_trace.py
@@ -99,11 +99,30 @@ class TestROS2TraceCLI(unittest.TestCase):
             f"tracing session '{session_name}' does not exist",
         )
 
+    def assertSnapshotTracingSessionExist(self, session_name: str) -> None:
+        self.assertTrue(
+            lttngpy.is_lttng_session_daemon_alive(),
+            f"tracing session '{session_name}' does not exist because there is no daemon",
+        )
+        session_names = lttngpy.get_snapshot_session_names()
+        self.assertIn(
+            session_name,
+            session_names,
+            f"tracing session '{session_name}' does not exist",
+        )
+
     def assertTracingSessionNotExist(self, session_name: str) -> None:
         # If there is no session daemon, then there are no tracing sessions
         if not lttngpy.is_lttng_session_daemon_alive():
             return
         session_names = lttngpy.get_session_names()
+        self.assertNotIn(session_name, session_names, f"tracing session '{session_name}' exists")
+
+    def assertSnapshotTracingSessionNotExist(self, session_name: str) -> None:
+        # If there is no session daemon, then there are no tracing sessions
+        if not lttngpy.is_lttng_session_daemon_alive():
+            return
+        session_names = lttngpy.get_snapshot_session_names()
         self.assertNotIn(session_name, session_names, f"tracing session '{session_name}' exists")
 
     def assertTraceExist(self, trace_dir: str) -> None:
@@ -659,6 +678,76 @@ class TestROS2TraceCLI(unittest.TestCase):
         ret = self.run_trace_subcommand(['stop', session_name])
         self.assertEqual(1, ret)
         self.assertTracingSessionNotExist(session_name)
+
+        shutil.rmtree(tmpdir)
+
+    @unittest.skipIf(not are_tracepoints_included(), 'tracepoints are required')
+    def test_snapshot_start_pause_resume_stop(self) -> None:
+        tmpdir = self.create_test_tmpdir('test_snapshot_start_pause_resume_stop')
+        session_name = 'test_snapshot_start_pause_resume_stop'
+
+        # Start tracing and run nodes
+        ret = self.run_trace_subcommand(
+            [
+                'start', session_name,
+                '--ust', tracepoints.rcl_subscription_init, TRACE_TEST_ID_TP_NAME,
+                '--path', tmpdir,
+                '--snapshot-mode',
+            ]
+        )
+        self.assertEqual(0, ret)
+        self.assertSnapshotTracingSessionExist(session_name)
+        self.run_nodes()
+
+        # Pause tracing, record snapshot and check trace
+        ret = self.run_trace_subcommand(['pause', session_name])
+        self.assertEqual(0, ret)
+        ret = self.run_trace_subcommand(['record_snapshot', session_name])
+        self.assertEqual(0, ret)
+        trace_dir = os.path.join(tmpdir, session_name)
+        self.assertTraceExist(trace_dir)
+        self.assertSnapshotTracingSessionExist(session_name)
+        expected_trace_data = [
+            ('topic_name', '/ping'),
+            ('topic_name', '/pong'),
+        ]
+        num_events = self.assertTraceContains(trace_dir, expected_field_value=expected_trace_data)
+
+        # Pausing again should give an error
+        ret = self.run_trace_subcommand(['pause', session_name])
+        self.assertEqual(1, ret)
+
+        # Subbuffers should be cleared after the last record_snapshot
+        ret = self.run_trace_subcommand(['record_snapshot', session_name])
+        self.assertEqual(0, ret)
+        self.assertSnapshotTracingSessionExist(session_name)
+        expected_trace_data = []
+        new_num_events = self.assertTraceContains(
+            trace_dir,
+            expected_field_value=expected_trace_data
+            )
+        self.assertEqual(num_events, new_num_events, 'subbuffers were not cleared')
+
+        # Resume tracing and run nodes again
+        ret = self.run_trace_subcommand(['resume', session_name])
+        self.assertEqual(0, ret)
+        self.assertSnapshotTracingSessionExist(session_name)
+        self.run_nodes()
+
+        # Resuming tracing again should give an error
+        ret = self.run_trace_subcommand(['resume', session_name])
+        self.assertEqual(1, ret)
+        self.assertSnapshotTracingSessionExist(session_name)
+
+        # Stop tracing and check that session does not exist
+        ret = self.run_trace_subcommand(['stop', session_name])
+        self.assertEqual(0, ret)
+        self.assertSnapshotTracingSessionNotExist(session_name)
+
+        # Stopping tracing again should give an error
+        ret = self.run_trace_subcommand(['stop', session_name])
+        self.assertEqual(1, ret)
+        self.assertSnapshotTracingSessionNotExist(session_name)
 
         shutil.rmtree(tmpdir)
 

--- a/test_ros2trace/test/test_ros2trace/test_trace.py
+++ b/test_ros2trace/test/test_ros2trace/test_trace.py
@@ -87,42 +87,23 @@ class TestROS2TraceCLI(unittest.TestCase):
     def tearDown(self) -> None:
         del self.trace_test_id
 
-    def assertTracingSessionExist(self, session_name: str) -> None:
+    def assertTracingSessionExist(self, session_name: str, snapshot_mode: bool = False) -> None:
         self.assertTrue(
             lttngpy.is_lttng_session_daemon_alive(),
             f"tracing session '{session_name}' does not exist because there is no daemon",
         )
-        session_names = lttngpy.get_session_names()
+        session_names = lttngpy.get_session_names(snapshot_mode=snapshot_mode)
         self.assertIn(
             session_name,
             session_names,
             f"tracing session '{session_name}' does not exist",
         )
 
-    def assertSnapshotTracingSessionExist(self, session_name: str) -> None:
-        self.assertTrue(
-            lttngpy.is_lttng_session_daemon_alive(),
-            f"tracing session '{session_name}' does not exist because there is no daemon",
-        )
-        session_names = lttngpy.get_snapshot_session_names()
-        self.assertIn(
-            session_name,
-            session_names,
-            f"tracing session '{session_name}' does not exist",
-        )
-
-    def assertTracingSessionNotExist(self, session_name: str) -> None:
+    def assertTracingSessionNotExist(self, session_name: str, snapshot_mode: bool = False) -> None:
         # If there is no session daemon, then there are no tracing sessions
         if not lttngpy.is_lttng_session_daemon_alive():
             return
-        session_names = lttngpy.get_session_names()
-        self.assertNotIn(session_name, session_names, f"tracing session '{session_name}' exists")
-
-    def assertSnapshotTracingSessionNotExist(self, session_name: str) -> None:
-        # If there is no session daemon, then there are no tracing sessions
-        if not lttngpy.is_lttng_session_daemon_alive():
-            return
-        session_names = lttngpy.get_snapshot_session_names()
+        session_names = lttngpy.get_session_names(snapshot_mode=snapshot_mode)
         self.assertNotIn(session_name, session_names, f"tracing session '{session_name}' exists")
 
     def assertTraceExist(self, trace_dir: str) -> None:
@@ -696,7 +677,7 @@ class TestROS2TraceCLI(unittest.TestCase):
             ]
         )
         self.assertEqual(0, ret)
-        self.assertSnapshotTracingSessionExist(session_name)
+        self.assertTracingSessionExist(session_name, snapshot_mode=True)
         self.run_nodes()
 
         # Pause tracing, record snapshot and check trace
@@ -706,7 +687,7 @@ class TestROS2TraceCLI(unittest.TestCase):
         self.assertEqual(0, ret)
         trace_dir = os.path.join(tmpdir, session_name)
         self.assertTraceExist(trace_dir)
-        self.assertSnapshotTracingSessionExist(session_name)
+        self.assertTracingSessionExist(session_name, snapshot_mode=True)
         expected_trace_data = [
             ('topic_name', '/ping'),
             ('topic_name', '/pong'),
@@ -720,34 +701,38 @@ class TestROS2TraceCLI(unittest.TestCase):
         # Subbuffers should be cleared after the last record_snapshot
         ret = self.run_trace_subcommand(['record_snapshot', session_name])
         self.assertEqual(0, ret)
-        self.assertSnapshotTracingSessionExist(session_name)
+        self.assertTracingSessionExist(session_name, snapshot_mode=True)
         expected_trace_data = []
         new_num_events = self.assertTraceContains(
             trace_dir,
             expected_field_value=expected_trace_data
-            )
+        )
         self.assertEqual(num_events, new_num_events, 'subbuffers were not cleared')
 
         # Resume tracing and run nodes again
         ret = self.run_trace_subcommand(['resume', session_name])
         self.assertEqual(0, ret)
-        self.assertSnapshotTracingSessionExist(session_name)
+        self.assertTracingSessionExist(session_name, snapshot_mode=True)
         self.run_nodes()
 
         # Resuming tracing again should give an error
         ret = self.run_trace_subcommand(['resume', session_name])
         self.assertEqual(1, ret)
-        self.assertSnapshotTracingSessionExist(session_name)
+        self.assertTracingSessionExist(session_name, snapshot_mode=True)
 
         # Stop tracing and check that session does not exist
         ret = self.run_trace_subcommand(['stop', session_name])
         self.assertEqual(0, ret)
-        self.assertSnapshotTracingSessionNotExist(session_name)
+        self.assertTracingSessionNotExist(session_name, snapshot_mode=True)
+
+        # Taking a snapshot after stopping should give an error
+        ret = self.run_trace_subcommand(['record_snapshot', session_name])
+        self.assertEqual(1, ret)
 
         # Stopping tracing again should give an error
         ret = self.run_trace_subcommand(['stop', session_name])
         self.assertEqual(1, ret)
-        self.assertSnapshotTracingSessionNotExist(session_name)
+        self.assertTracingSessionNotExist(session_name, snapshot_mode=True)
 
         shutil.rmtree(tmpdir)
 

--- a/tracetools_launch/tracetools_launch/action.py
+++ b/tracetools_launch/tracetools_launch/action.py
@@ -113,6 +113,7 @@ class Trace(Action):
         self,
         *,
         session_name: SomeSubstitutionsType,
+        snapshot_session: Union[bool, SomeSubstitutionsType] = False,
         dual_session: Union[bool, SomeSubstitutionsType] = False,
         append_timestamp: Union[bool, SomeSubstitutionsType] = False,
         base_path: Optional[SomeSubstitutionsType] = None,
@@ -140,6 +141,7 @@ class Trace(Action):
         an empty string (through launch frontends).
 
         :param session_name: the name of the tracing session
+        :param snapshot_session: whether it is a snapshot session
         :param dual_session: whether to pre-configure a dual session: a snapshot session
             is configured here, with a normal tracing session to be configured later, while the
             application is running, e.g., through `ros2 trace --dual-session` with the same session
@@ -178,6 +180,7 @@ class Trace(Action):
                 session_name
             )
         ]
+        self._snapshot_session = normalize_typed_substitution(snapshot_session, bool)
         self._dual_session = normalize_typed_substitution(dual_session, bool)
         self._base_path: List[Substitution] = [
             IfElseSubstitution(
@@ -211,6 +214,10 @@ class Trace(Action):
     @property
     def session_name(self) -> List[Substitution]:
         return self._session_name
+
+    @property
+    def snapshot_session(self) -> NormalizedValueType:
+        return self._snapshot_session
 
     @property
     def dual_session(self) -> NormalizedValueType:
@@ -323,6 +330,11 @@ class Trace(Action):
         session_name = entity.get_attr('session-name')
         if session_name is not None:
             kwargs['session_name'] = parser.parse_substitution(session_name)
+        snapshot_session = entity.get_attr('snapshot-session', data_type=bool, optional=True)
+        if snapshot_session is not None:
+            kwargs['snapshot_session'] = snapshot_session \
+                if isinstance(snapshot_session, bool) \
+                else parser.parse_substitution(cast(str, snapshot_session))
         dual_session = entity.get_attr('dual-session', data_type=bool, optional=True)
         if dual_session is not None:
             kwargs['dual_session'] = dual_session \
@@ -430,6 +442,7 @@ class Trace(Action):
 
     def execute(self, context: LaunchContext) -> List[Action]:
         session_name = perform_substitutions(context, self._session_name)
+        snapshot_session = perform_typed_substitution(context, self._snapshot_session, bool)
         dual_session = perform_typed_substitution(context, self._dual_session, bool)
         base_path = perform_substitutions(context, self._base_path)
         append_trace = perform_typed_substitution(context, self._append_trace, bool)
@@ -460,7 +473,7 @@ class Trace(Action):
             try:
                 self._trace_directory = lttng.lttng_init(
                     session_name=session_name,
-                    snapshot_session=dual_session,
+                    snapshot_session=dual_session or snapshot_session,
                     dual_session=dual_session,
                     base_path=base_path,
                     append_trace=append_trace,
@@ -528,6 +541,7 @@ class Trace(Action):
         return (
             'Trace('
             f'session_name={self._session_name}, '
+            f'snapshot_session={self._snapshot_session}, '
             f'dual_session={self._dual_session}, '
             f'base_path={self._base_path}, '
             f'append_trace={self._append_trace}, '

--- a/tracetools_launch/tracetools_launch/action.py
+++ b/tracetools_launch/tracetools_launch/action.py
@@ -113,7 +113,7 @@ class Trace(Action):
         self,
         *,
         session_name: SomeSubstitutionsType,
-        snapshot_session: Union[bool, SomeSubstitutionsType] = False,
+        snapshot_mode: Union[bool, SomeSubstitutionsType] = False,
         dual_session: Union[bool, SomeSubstitutionsType] = False,
         append_timestamp: Union[bool, SomeSubstitutionsType] = False,
         base_path: Optional[SomeSubstitutionsType] = None,
@@ -141,7 +141,7 @@ class Trace(Action):
         an empty string (through launch frontends).
 
         :param session_name: the name of the tracing session
-        :param snapshot_session: whether it is a snapshot session
+        :param snapshot_mode: whether it is a snapshot session
         :param dual_session: whether to pre-configure a dual session: a snapshot session
             is configured here, with a normal tracing session to be configured later, while the
             application is running, e.g., through `ros2 trace --dual-session` with the same session
@@ -180,7 +180,7 @@ class Trace(Action):
                 session_name
             )
         ]
-        self._snapshot_session = normalize_typed_substitution(snapshot_session, bool)
+        self._snapshot_mode = normalize_typed_substitution(snapshot_mode, bool)
         self._dual_session = normalize_typed_substitution(dual_session, bool)
         self._base_path: List[Substitution] = [
             IfElseSubstitution(
@@ -216,8 +216,8 @@ class Trace(Action):
         return self._session_name
 
     @property
-    def snapshot_session(self) -> NormalizedValueType:
-        return self._snapshot_session
+    def snapshot_mode(self) -> NormalizedValueType:
+        return self._snapshot_mode
 
     @property
     def dual_session(self) -> NormalizedValueType:
@@ -330,11 +330,11 @@ class Trace(Action):
         session_name = entity.get_attr('session-name')
         if session_name is not None:
             kwargs['session_name'] = parser.parse_substitution(session_name)
-        snapshot_session = entity.get_attr('snapshot-session', data_type=bool, optional=True)
-        if snapshot_session is not None:
-            kwargs['snapshot_session'] = snapshot_session \
-                if isinstance(snapshot_session, bool) \
-                else parser.parse_substitution(cast(str, snapshot_session))
+        snapshot_mode = entity.get_attr('snapshot-mode', data_type=bool, optional=True)
+        if snapshot_mode is not None:
+            kwargs['snapshot_mode'] = snapshot_mode \
+                if isinstance(snapshot_mode, bool) \
+                else parser.parse_substitution(cast(str, snapshot_mode))
         dual_session = entity.get_attr('dual-session', data_type=bool, optional=True)
         if dual_session is not None:
             kwargs['dual_session'] = dual_session \
@@ -442,7 +442,7 @@ class Trace(Action):
 
     def execute(self, context: LaunchContext) -> List[Action]:
         session_name = perform_substitutions(context, self._session_name)
-        snapshot_session = perform_typed_substitution(context, self._snapshot_session, bool)
+        snapshot_mode = perform_typed_substitution(context, self._snapshot_mode, bool)
         dual_session = perform_typed_substitution(context, self._dual_session, bool)
         base_path = perform_substitutions(context, self._base_path)
         append_trace = perform_typed_substitution(context, self._append_trace, bool)
@@ -473,7 +473,7 @@ class Trace(Action):
             try:
                 self._trace_directory = lttng.lttng_init(
                     session_name=session_name,
-                    snapshot_session=dual_session or snapshot_session,
+                    snapshot_mode=dual_session or snapshot_mode,
                     dual_session=dual_session,
                     base_path=base_path,
                     append_trace=append_trace,
@@ -541,7 +541,7 @@ class Trace(Action):
         return (
             'Trace('
             f'session_name={self._session_name}, '
-            f'snapshot_session={self._snapshot_session}, '
+            f'snapshot_mode={self._snapshot_mode}, '
             f'dual_session={self._dual_session}, '
             f'base_path={self._base_path}, '
             f'append_trace={self._append_trace}, '

--- a/tracetools_trace/tracetools_trace/tools/args.py
+++ b/tracetools_trace/tracetools_trace/tools/args.py
@@ -89,12 +89,7 @@ def _add_arguments_default_session_name(parser: argparse.ArgumentParser) -> None
         help='the name of the tracing session (default: session-YYYYMMDDHHMMSS)')
 
 
-def _add_arguments_session_type(parser: argparse.ArgumentParser) -> None:
-    """Add session type argument to parser."""
-    parser.add_argument(
-        '--snapshot-session', dest='snapshot_session', action='store_true',
-        help='use this to create tracing session in snapshot mode in interactive mode or with '
-             'the start verb in non-interactive mode (default: %(default)s)')
+def _add_arguments_dual_session(parser: argparse.ArgumentParser) -> None:
     parser.add_argument(
         '-d', '--dual-session', dest='dual_session', action='store_true',
         help='use this in interactive mode to record snapshot of the pre-configured snapshot '
@@ -104,20 +99,28 @@ def _add_arguments_session_type(parser: argparse.ArgumentParser) -> None:
              'stop/pause normal runtime tracing session (default: %(default)s)')
 
 
+def _add_arguments_session_mode(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        '--snapshot-mode', dest='snapshot_mode', action='store_true',
+        help='use this to create tracing session in snapshot mode in interactive mode or with '
+             'the start verb in non-interactive mode (default: %(default)s)')
+
+
 def add_arguments(parser: argparse.ArgumentParser) -> None:
     """Add arguments to parser for interactive tracing session configuration."""
     _add_arguments_default_session_name(parser)
-    _add_arguments_session_type(parser)
+    _add_arguments_session_mode(parser)
     _add_arguments_configure(parser)
 
 
 def add_arguments_noninteractive_configure(parser: argparse.ArgumentParser) -> None:
     """Add arguments to parser for non-interactive tracing session configuration."""
     _add_arguments_configure(parser)
+    _add_arguments_session_mode(parser)
     add_arguments_noninteractive_control(parser)
 
 
 def add_arguments_noninteractive_control(parser: argparse.ArgumentParser) -> None:
     """Add arguments to parser for non-interactive tracing session control."""
     parser.add_argument('session_name', help='the name of the tracing session')
-    _add_arguments_session_type(parser)
+    _add_arguments_dual_session(parser)

--- a/tracetools_trace/tracetools_trace/tools/args.py
+++ b/tracetools_trace/tracetools_trace/tools/args.py
@@ -92,6 +92,10 @@ def _add_arguments_default_session_name(parser: argparse.ArgumentParser) -> None
 def _add_arguments_session_type(parser: argparse.ArgumentParser) -> None:
     """Add session type argument to parser."""
     parser.add_argument(
+        '--snapshot-session', dest='snapshot_session', action='store_true',
+        help='use this to create tracing session in snapshot mode in interactive mode or with '
+             'the start verb in non-interactive mode (default: %(default)s)')
+    parser.add_argument(
         '-d', '--dual-session', dest='dual_session', action='store_true',
         help='use this in non-interactive mode to record snapshot of the pre-configured snapshot '
              'session with the same name and start normal runtime tracing session; use this in '

--- a/tracetools_trace/tracetools_trace/tools/args.py
+++ b/tracetools_trace/tracetools_trace/tools/args.py
@@ -97,9 +97,9 @@ def _add_arguments_session_type(parser: argparse.ArgumentParser) -> None:
              'the start verb in non-interactive mode (default: %(default)s)')
     parser.add_argument(
         '-d', '--dual-session', dest='dual_session', action='store_true',
-        help='use this in non-interactive mode to record snapshot of the pre-configured snapshot '
+        help='use this in interactive mode to record snapshot of the pre-configured snapshot '
              'session with the same name and start normal runtime tracing session; use this in '
-             'interactive mode along with: start/resume to record snapshot of pre-configured '
+             'non-interactive mode along with: start/resume to record snapshot of pre-configured '
              'snapshot session and start/resume normal runtime tracing session, stop/pause to '
              'stop/pause normal runtime tracing session (default: %(default)s)')
 

--- a/tracetools_trace/tracetools_trace/tools/args.py
+++ b/tracetools_trace/tracetools_trace/tools/args.py
@@ -110,6 +110,7 @@ def add_arguments(parser: argparse.ArgumentParser) -> None:
     """Add arguments to parser for interactive tracing session configuration."""
     _add_arguments_default_session_name(parser)
     _add_arguments_session_mode(parser)
+    _add_arguments_dual_session(parser)
     _add_arguments_configure(parser)
 
 

--- a/tracetools_trace/tracetools_trace/tools/lttng_impl.py
+++ b/tracetools_trace/tracetools_trace/tools/lttng_impl.py
@@ -197,7 +197,7 @@ def spawn_session_daemon() -> None:
 def setup(
     *,
     session_name: str,
-    snapshot_session: bool = False,
+    snapshot_mode: bool = False,
     dual_session: bool = False,
     base_path: str,
     append_trace: bool = False,
@@ -222,7 +222,7 @@ def setup(
     Raises RuntimeError on failure, in which case the tracing session might still exist.
 
     :param session_name: the name of the session
-    :param snapshot_session: whether this is a snapshot session
+    :param snapshot_mode: whether this is a snapshot session
     :param dual_session: whether this is part of a dual session
     :param base_path: the path to the directory in which to create the tracing session directory,
         which will be created if needed
@@ -249,7 +249,7 @@ def setup(
     if not session_name:
         raise RuntimeError('empty session name')
     # Resolve full tracing directory path
-    if snapshot_session and dual_session:
+    if snapshot_mode and dual_session:
         full_path = os.path.join(
             base_path,
             session_name.removesuffix(SNAPSHOT_SESSION_SUFFIX),
@@ -318,7 +318,7 @@ def setup(
 
     # Create session
     # LTTng will create the parent directories if needed
-    if not snapshot_session:
+    if not snapshot_mode:
         _create_session(
             session_name=session_name,
             full_path=full_path,

--- a/tracetools_trace/tracetools_trace/trace.py
+++ b/tracetools_trace/tracetools_trace/trace.py
@@ -406,7 +406,7 @@ def record_snapshot(args: argparse.Namespace) -> int:
     def work() -> int:
         session_name = args.session_name
         if args.dual_session:
-            session_name += path.RUNTIME_SESSION_SUFFIX
+            session_name += path.SNAPSHOT_SESSION_SUFFIX
         lttng.lttng_record_snapshot(session_name=session_name)
         return 0
     return _do_work_and_report_error(work, args.session_name, do_cleanup=False)

--- a/tracetools_trace/tracetools_trace/trace.py
+++ b/tracetools_trace/tracetools_trace/trace.py
@@ -110,6 +110,7 @@ def _display_snapshot_session_path(
 def init(
     *,
     session_name: str,
+    snapshot_session: bool,
     dual_session: bool,
     base_path: Optional[str],
     append_trace: bool,
@@ -129,6 +130,7 @@ def init(
     Raises RuntimeError on failure, in which case the tracing session might still exist.
 
     :param session_name: the name of the session
+    :param snapshot_session: whether this is a snapshot session
     :param dual_session: whether this is part of a dual session
     :param base_path: the path to the directory in which to create the tracing session directory,
         or `None` for default
@@ -178,6 +180,7 @@ def init(
 
     trace_directory = lttng.lttng_init(
         session_name=session_name,
+        snapshot_session=snapshot_session,
         dual_session=dual_session,
         base_path=base_path,
         append_trace=append_trace,
@@ -274,6 +277,7 @@ def trace(args: argparse.Namespace) -> int:
     def work() -> int:
         if not init(
             session_name=args.session_name,
+            snapshot_session=args.snapshot_session,
             dual_session=args.dual_session,
             base_path=args.path,
             append_trace=args.append_trace,
@@ -309,6 +313,7 @@ def start(args: argparse.Namespace) -> int:
         return int(
             not init(
                 session_name=args.session_name,
+                snapshot_session=args.snapshot_session,
                 dual_session=args.dual_session,
                 base_path=args.path,
                 append_trace=args.append_trace,

--- a/tracetools_trace/tracetools_trace/trace.py
+++ b/tracetools_trace/tracetools_trace/trace.py
@@ -110,7 +110,7 @@ def _display_snapshot_session_path(
 def init(
     *,
     session_name: str,
-    snapshot_session: bool,
+    snapshot_mode: bool,
     dual_session: bool,
     base_path: Optional[str],
     append_trace: bool,
@@ -130,7 +130,7 @@ def init(
     Raises RuntimeError on failure, in which case the tracing session might still exist.
 
     :param session_name: the name of the session
-    :param snapshot_session: whether this is a snapshot session
+    :param snapshot_mode: whether this is a snapshot session
     :param dual_session: whether this is part of a dual session
     :param base_path: the path to the directory in which to create the tracing session directory,
         or `None` for default
@@ -180,7 +180,7 @@ def init(
 
     trace_directory = lttng.lttng_init(
         session_name=session_name,
-        snapshot_session=snapshot_session,
+        snapshot_mode=snapshot_mode,
         dual_session=dual_session,
         base_path=base_path,
         append_trace=append_trace,
@@ -277,7 +277,7 @@ def trace(args: argparse.Namespace) -> int:
     def work() -> int:
         if not init(
             session_name=args.session_name,
-            snapshot_session=args.snapshot_session,
+            snapshot_mode=args.snapshot_mode,
             dual_session=args.dual_session,
             base_path=args.path,
             append_trace=args.append_trace,
@@ -313,7 +313,7 @@ def start(args: argparse.Namespace) -> int:
         return int(
             not init(
                 session_name=args.session_name,
-                snapshot_session=args.snapshot_session,
+                snapshot_mode=args.snapshot_mode,
                 dual_session=args.dual_session,
                 base_path=args.path,
                 append_trace=args.append_trace,

--- a/tracetools_trace/tracetools_trace/trace.py
+++ b/tracetools_trace/tracetools_trace/trace.py
@@ -306,7 +306,7 @@ def start(args: argparse.Namespace) -> int:
     On failure, the tracing session will not exist.
 
     :param args: the arguments parsed using
-        `tracetools_trace.tools.args.add_arguments_noninteractive`
+        `tracetools_trace.tools.args.add_arguments_noninteractive_configure`
     :return: the return code (0 if successful, 1 otherwise)
     """
     def work() -> int:
@@ -340,7 +340,7 @@ def stop(args: argparse.Namespace) -> int:
     On failure, the tracing session might still exist.
 
     :param args: the arguments parsed using
-        `tracetools_trace.tools.args.add_arguments_session_name`
+        `tracetools_trace.tools.args.add_arguments_noninteractive_control`
     :return: the return code (0 if successful, 1 otherwise)
     """
     def work() -> int:
@@ -359,7 +359,7 @@ def pause(args: argparse.Namespace) -> int:
     On failure, the tracing session might still exist.
 
     :param args: the arguments parsed using
-        `tracetools_trace.tools.args.add_arguments_session_name`
+        `tracetools_trace.tools.args.add_arguments_noninteractive_control`
     :return: the return code (0 if successful, 1 otherwise)
     """
     def work() -> int:
@@ -378,7 +378,7 @@ def resume(args: argparse.Namespace) -> int:
     On failure, the tracing session might still exist.
 
     :param args: the arguments parsed using
-        `tracetools_trace.tools.args.add_arguments_session_name`
+        `tracetools_trace.tools.args.add_arguments_noninteractive_control`
     :return: the return code (0 if successful, 1 otherwise)
     """
     def work() -> int:

--- a/tracetools_trace/tracetools_trace/trace.py
+++ b/tracetools_trace/tracetools_trace/trace.py
@@ -393,5 +393,24 @@ def resume(args: argparse.Namespace) -> int:
     return _do_work_and_report_error(work, args.session_name, do_cleanup=False)
 
 
+def record_snapshot(args: argparse.Namespace) -> int:
+    """
+    Record snapshot of a tracing session (created in snapshot mode).
+
+    On failure, the tracing session might still exist.
+
+    :param args: the arguments parsed using
+        `tracetools_trace.tools.args.add_arguments_noninteractive_control`
+    :return: the return code (0 if successful, 1 otherwise)
+    """
+    def work() -> int:
+        session_name = args.session_name
+        if args.dual_session:
+            session_name += path.RUNTIME_SESSION_SUFFIX
+        lttng.lttng_record_snapshot(session_name=session_name)
+        return 0
+    return _do_work_and_report_error(work, args.session_name, do_cleanup=False)
+
+
 def main() -> int:
     return trace(args.parse_args())


### PR DESCRIPTION
## Description

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->
These changes will allow users to start tracing sessions in [snapshot mode](https://lttng.org/docs/v2.13/#doc-taking-a-snapshot) using both `Trace` action and the `ros2 trace` commands and to stop/pause/resume/record snapshot of the tracing session using `ros2 trace` command.

### Configuring/starting the tracing session
```python
Trace(
    session_name='my-snapshot-session',
    snapshot_mode=True,
),
```
or
```bash
# interactive tracing
ros2 trace -s my-snapshot-session --snapshot-mode
```
or
```bash
# non-interactive tracing
ros2 trace start my-snapshot-session --snapshot-mode
```

### Controlling the tracing session
```bash
ros2 trace pause my-snapshot-session
ros2 trace resume my-snapshot-session
ros2 trace stop my-snapshot-session 

ros2 trace record_snapshot my-snapshot-session
```

Note: The `--snapshot-mode` option is not required. Using `record_snapshot` with a non-snapshot session will result in an error.
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->
Yes.
### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
