### PR TITLE
Add dual session tests

### DIFF
--- a/test_ros2trace/package.xml
+++ b/test_ros2trace/package.xml
@@ -20,6 +20,7 @@
   <test_depend>launch_ros</test_depend>
   <test_depend>lttngpy</test_depend>
   <test_depend>python3-pytest</test_depend>
+  <test_depend>rclpy</test_depend>
   <test_depend>ros2run</test_depend>
   <test_depend>ros2trace</test_depend>
   <test_depend>test_tracetools</test_depend>

--- a/test_ros2trace/test/test_ros2trace/test_trace.py
+++ b/test_ros2trace/test/test_ros2trace/test_trace.py
@@ -18,7 +18,9 @@ import os
 import shutil
 import subprocess
 import tempfile
+import threading
 import time
+from typing import Callable
 from typing import Dict
 from typing import List
 from typing import Optional
@@ -30,6 +32,12 @@ from launch import LaunchService
 from launch_ros.actions import Node
 from lttngpy import impl as lttngpy
 import osrf_pycommon.process_utils
+import rclpy
+from rclpy.clock import Clock, ClockType
+from rclpy.duration import Duration
+from rclpy.executors import SingleThreadedExecutor
+from rclpy.qos import QoSProfile
+from std_msgs.msg import String
 from tracetools_launch.action import Trace
 from tracetools_read import get_event_name
 from tracetools_test.mark_process import get_corresponding_trace_test_events
@@ -272,6 +280,19 @@ class TestROS2TraceCLI(unittest.TestCase):
         process = self.run_command(['ros2', 'trace', *args], env=env)
         return self.wait_and_print_command_output(process)
 
+    def wait_for(
+        condition: Callable[[], bool],
+        timeout: Duration,
+        sleep_time: float = 0.1,
+    ):
+        clock = Clock(clock_type=ClockType.STEADY_TIME)
+        start = clock.now()
+        while not condition():
+            if clock.now() - start > timeout:
+                return False
+            time.sleep(sleep_time)
+        return True
+
     def run_nodes(self, env: Optional[Mapping[str, str]] = None) -> None:
         # Set trace test ID env var for spawned processes
         additional_env: Dict[str, str] = {}
@@ -339,9 +360,6 @@ class TestROS2TraceCLI(unittest.TestCase):
 
         loop = osrf_pycommon.process_utils.get_loop()
         launch_task = loop.create_task(ls.run_async())
-
-        # Give the launch service time to start actions
-        loop.run_until_complete(asyncio.sleep(1.0))
 
         return ls, launch_task
 
@@ -790,10 +808,32 @@ class TestROS2TraceCLI(unittest.TestCase):
     def test_dual_session_start_pause_resume_stop(self) -> None:
         tmpdir = self.create_test_tmpdir('test_dual_session_start_pause_resume_stop')
         session_name = 'test_dual_session_start_pause_resume_stop'
+        snapshot_session_name = session_name + '-snapshot'
+        runtime_session_name = session_name + '-runtime'
 
-        # Pre-configure dual session, start nodes and check that the snapshot session exists
+        # Pre-configure dual session and start nodes
         ls, launch_task = self.pre_configure_dual_session_and_run_nodes(tmpdir, session_name)
-        self.assertTracingSessionExist(session_name+'-snapshot', snapshot_mode=True)
+
+        # Wait until the nodes are running
+        ctx = rclpy.Context()
+        ctx.init()
+        node = rclpy.create_node('test_dual_session_sub', context=ctx)
+        ping_sub = node.create_subscription(
+            String, '/ping', lambda msg: None, QoSProfile(depth=15))
+        pong_sub = node.create_subscription(
+            String, '/pong', lambda msg: None, QoSProfile(depth=15))
+        executor = SingleThreadedExecutor(context=ctx)
+        executor.add_node(node)
+        executor_thread = threading.Thread(target=executor.spin, daemon=True)
+        executor_thread.start()
+
+        assert self.wait_for(
+            lambda: ping_sub.get_publisher_count() >= 1 and pong_sub.get_publisher_count() >= 1,
+            Duration(seconds=10),
+        ), 'timed out waiting for nodes to be running'
+
+        # Check that the snapshot session exists
+        self.assertTracingSessionExist(snapshot_session_name, snapshot_mode=True)
 
         # Start tracing
         ret = self.run_trace_subcommand(
@@ -810,14 +850,14 @@ class TestROS2TraceCLI(unittest.TestCase):
         runtime_trace_dir = os.path.join(tmpdir, session_name, 'runtime')
         self.assertTraceExist(snapshot_trace_dir)
         self.assertTraceExist(runtime_trace_dir)
-        self.assertTracingSessionExist(session_name+'-snapshot', snapshot_mode=True)
-        self.assertTracingSessionExist(session_name+'-runtime')
+        self.assertTracingSessionExist(snapshot_session_name, snapshot_mode=True)
+        self.assertTracingSessionExist(runtime_session_name)
 
         # Pause tracing and check trace
         ret = self.run_trace_subcommand(['pause', session_name, '--dual-session'])
         self.assertEqual(0, ret)
-        self.assertTracingSessionExist(session_name+'-snapshot', snapshot_mode=True)
-        self.assertTracingSessionExist(session_name+'-runtime')
+        self.assertTracingSessionExist(snapshot_session_name, snapshot_mode=True)
+        self.assertTracingSessionExist(runtime_session_name)
         expected_trace_data = [
             ('topic_name', '/ping'),
             ('topic_name', '/pong'),
@@ -827,8 +867,8 @@ class TestROS2TraceCLI(unittest.TestCase):
         # Pausing again should give an error but not affect anything
         ret = self.run_trace_subcommand(['pause', session_name, '--dual-session'])
         self.assertEqual(1, ret)
-        self.assertTracingSessionExist(session_name+'-snapshot', snapshot_mode=True)
-        self.assertTracingSessionExist(session_name+'-runtime')
+        self.assertTracingSessionExist(snapshot_session_name, snapshot_mode=True)
+        self.assertTracingSessionExist(runtime_session_name)
         new_num_events = self.assertTraceContains(
             trace_dir=tmpdir,
             expected_field_value=expected_trace_data,
@@ -838,21 +878,21 @@ class TestROS2TraceCLI(unittest.TestCase):
         # Resume tracing
         ret = self.run_trace_subcommand(['resume', session_name, '--dual-session'])
         self.assertEqual(0, ret)
-        self.assertTracingSessionExist(session_name+'-snapshot', snapshot_mode=True)
-        self.assertTracingSessionExist(session_name+'-runtime')
+        self.assertTracingSessionExist(snapshot_session_name, snapshot_mode=True)
+        self.assertTracingSessionExist(runtime_session_name)
 
         # Resuming tracing again should give an error but not affect anything
         ret = self.run_trace_subcommand(['resume', session_name, '--dual-session'])
         self.assertEqual(1, ret)
-        self.assertTracingSessionExist(session_name+'-snapshot', snapshot_mode=True)
-        self.assertTracingSessionExist(session_name+'-runtime')
+        self.assertTracingSessionExist(snapshot_session_name, snapshot_mode=True)
+        self.assertTracingSessionExist(runtime_session_name)
 
         # Stop tracing and check that trace changed
         ret = self.run_trace_subcommand(['stop', session_name, '--dual-session'])
         self.assertEqual(0, ret)
         # Snapshot session should still exist
-        self.assertTracingSessionExist(session_name+'-snapshot', snapshot_mode=True)
-        self.assertTracingSessionNotExist(session_name+'-runtime')
+        self.assertTracingSessionExist(snapshot_session_name, snapshot_mode=True)
+        self.assertTracingSessionNotExist(runtime_session_name)
         new_num_events = self.assertTraceContains(
             trace_dir,
             expected_field_value=expected_trace_data,
@@ -862,8 +902,8 @@ class TestROS2TraceCLI(unittest.TestCase):
         # Stopping tracing again should give an error but not affect anything
         ret = self.run_trace_subcommand(['stop', session_name, '--dual-session'])
         self.assertEqual(1, ret)
-        self.assertTracingSessionExist(session_name+'-snapshot', snapshot_mode=True)
-        self.assertTracingSessionNotExist(session_name+'-runtime')
+        self.assertTracingSessionExist(snapshot_session_name, snapshot_mode=True)
+        self.assertTracingSessionNotExist(runtime_session_name)
 
         # Shutdown launch service
         loop = osrf_pycommon.process_utils.get_loop()
@@ -873,8 +913,15 @@ class TestROS2TraceCLI(unittest.TestCase):
         assert 0 == launch_task.result()
 
         # Shutting down the launch service should destroy the snapshot session
-        self.assertTracingSessionNotExist(session_name+'-snapshot', snapshot_mode=True)
+        self.assertTracingSessionNotExist(snapshot_session_name, snapshot_mode=True)
 
+        executor.shutdown()
+        executor_thread.join(3)
+        assert not executor_thread.is_alive()
+        ping_sub.destroy()
+        pong_sub.destroy()
+        node.destroy_node()
+        ctx.shutdown()
         shutil.rmtree(tmpdir)
 
     @unittest.skipIf(not are_tracepoints_included(), 'tracepoints are required')

--- a/test_ros2trace/test/test_ros2trace/test_trace.py
+++ b/test_ros2trace/test/test_ros2trace/test_trace.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import asyncio
 from collections.abc import Mapping
 import os
 import shutil
@@ -28,6 +29,8 @@ from launch import LaunchDescription
 from launch import LaunchService
 from launch_ros.actions import Node
 from lttngpy import impl as lttngpy
+import osrf_pycommon.process_utils
+from tracetools_launch.action import Trace
 from tracetools_read import get_event_name
 from tracetools_test.mark_process import get_corresponding_trace_test_events
 from tracetools_test.mark_process import get_trace_test_id
@@ -36,6 +39,7 @@ from tracetools_test.mark_process import TRACE_TEST_ID_TP_NAME
 from tracetools_trace.tools import tracepoints
 from tracetools_trace.tools.lttng import is_lttng_installed
 from tracetools_trace.tools.names import DEFAULT_EVENTS_ROS
+from tracetools_trace.tools.names import DEFAULT_INIT_EVENTS_ROS
 
 
 def are_tracepoints_included() -> bool:
@@ -294,6 +298,52 @@ class TestROS2TraceCLI(unittest.TestCase):
         ls.include_launch_description(ld)
         exit_code = ls.run()
         self.assertEqual(0, exit_code)
+
+    def pre_configure_dual_session_and_run_nodes(
+        self,
+        base_path: str,
+        session_name: str,
+        env: Optional[Mapping[str, str]] = None,
+    ) -> Tuple[LaunchService, asyncio.Task]:
+        # Set trace test ID env var for spawned processes
+        additional_env: Dict[str, str] = {}
+        if env is not None:
+            additional_env.update(env)
+        assert self.trace_test_id
+        additional_env[TRACE_TEST_ID_ENV_VAR] = self.trace_test_id
+        actions = [
+            Trace(
+                session_name=session_name,
+                dual_session=True,
+                base_path=base_path,
+                events_ust=DEFAULT_INIT_EVENTS_ROS + [TRACE_TEST_ID_TP_NAME],
+            ),
+            Node(
+                package='test_tracetools',
+                executable='test_ping',
+                output='screen',
+                arguments=['do_more'],  # run indefinitely
+                additional_env=additional_env,
+            ),
+            Node(
+                package='test_tracetools',
+                executable='test_pong',
+                output='screen',
+                arguments=['do_more'],  # run indefinitely
+                additional_env=additional_env,
+            ),
+        ]
+        ld = LaunchDescription(actions)
+        ls = LaunchService()
+        ls.include_launch_description(ld)
+
+        loop = osrf_pycommon.process_utils.get_loop()
+        launch_task = loop.create_task(ls.run_async())
+
+        # Give the launch service time to start actions
+        loop.run_until_complete(asyncio.sleep(1.0))
+
+        return ls, launch_task
 
     def test_default(self) -> None:
         tmpdir = self.create_test_tmpdir('test_default')
@@ -671,7 +721,7 @@ class TestROS2TraceCLI(unittest.TestCase):
         ret = self.run_trace_subcommand(
             [
                 'start', session_name,
-                '--ust', tracepoints.rcl_subscription_init, TRACE_TEST_ID_TP_NAME,
+                '--ust', 'ros2:*', TRACE_TEST_ID_TP_NAME,
                 '--path', tmpdir,
                 '--snapshot-mode',
             ]
@@ -733,6 +783,97 @@ class TestROS2TraceCLI(unittest.TestCase):
         ret = self.run_trace_subcommand(['stop', session_name])
         self.assertEqual(1, ret)
         self.assertTracingSessionNotExist(session_name, snapshot_mode=True)
+
+        shutil.rmtree(tmpdir)
+
+    @unittest.skipIf(not are_tracepoints_included(), 'tracepoints are required')
+    def test_dual_session_start_pause_resume_stop(self) -> None:
+        tmpdir = self.create_test_tmpdir('test_dual_session_start_pause_resume_stop')
+        session_name = 'test_dual_session_start_pause_resume_stop'
+
+        # Pre-configure dual session, start nodes and check that the snapshot session exists
+        ls, launch_task = self.pre_configure_dual_session_and_run_nodes(tmpdir, session_name)
+        self.assertTracingSessionExist(session_name+'-snapshot', snapshot_mode=True)
+
+        # Start tracing
+        ret = self.run_trace_subcommand(
+            [
+                'start', session_name,
+                '--ust', 'ros2:*',
+                '--path', tmpdir,
+                '--dual-session',
+            ]
+        )
+        self.assertEqual(0, ret)
+        trace_dir = os.path.join(tmpdir, session_name)
+        snapshot_trace_dir = os.path.join(tmpdir, session_name, 'snapshot')
+        runtime_trace_dir = os.path.join(tmpdir, session_name, 'runtime')
+        self.assertTraceExist(snapshot_trace_dir)
+        self.assertTraceExist(runtime_trace_dir)
+        self.assertTracingSessionExist(session_name+'-snapshot', snapshot_mode=True)
+        self.assertTracingSessionExist(session_name+'-runtime')
+
+        # Pause tracing and check trace
+        ret = self.run_trace_subcommand(['pause', session_name, '--dual-session'])
+        self.assertEqual(0, ret)
+        self.assertTracingSessionExist(session_name+'-snapshot', snapshot_mode=True)
+        self.assertTracingSessionExist(session_name+'-runtime')
+        expected_trace_data = [
+            ('topic_name', '/ping'),
+            ('topic_name', '/pong'),
+        ]
+        num_events = self.assertTraceContains(trace_dir, expected_field_value=expected_trace_data)
+
+        # Pausing again should give an error but not affect anything
+        ret = self.run_trace_subcommand(['pause', session_name, '--dual-session'])
+        self.assertEqual(1, ret)
+        self.assertTracingSessionExist(session_name+'-snapshot', snapshot_mode=True)
+        self.assertTracingSessionExist(session_name+'-runtime')
+        new_num_events = self.assertTraceContains(
+            trace_dir=tmpdir,
+            expected_field_value=expected_trace_data,
+        )
+        self.assertEqual(num_events, new_num_events, 'unexpected new events in trace')
+
+        # Resume tracing
+        ret = self.run_trace_subcommand(['resume', session_name, '--dual-session'])
+        self.assertEqual(0, ret)
+        self.assertTracingSessionExist(session_name+'-snapshot', snapshot_mode=True)
+        self.assertTracingSessionExist(session_name+'-runtime')
+
+        # Resuming tracing again should give an error but not affect anything
+        ret = self.run_trace_subcommand(['resume', session_name, '--dual-session'])
+        self.assertEqual(1, ret)
+        self.assertTracingSessionExist(session_name+'-snapshot', snapshot_mode=True)
+        self.assertTracingSessionExist(session_name+'-runtime')
+
+        # Stop tracing and check that trace changed
+        ret = self.run_trace_subcommand(['stop', session_name, '--dual-session'])
+        self.assertEqual(0, ret)
+        # Snapshot session should still exist
+        self.assertTracingSessionExist(session_name+'-snapshot', snapshot_mode=True)
+        self.assertTracingSessionNotExist(session_name+'-runtime')
+        new_num_events = self.assertTraceContains(
+            trace_dir,
+            expected_field_value=expected_trace_data,
+        )
+        self.assertGreater(new_num_events, num_events, 'no new events in trace')
+
+        # Stopping tracing again should give an error but not affect anything
+        ret = self.run_trace_subcommand(['stop', session_name, '--dual-session'])
+        self.assertEqual(1, ret)
+        self.assertTracingSessionExist(session_name+'-snapshot', snapshot_mode=True)
+        self.assertTracingSessionNotExist(session_name+'-runtime')
+
+        # Shutdown launch service
+        loop = osrf_pycommon.process_utils.get_loop()
+        if not launch_task.done():
+            loop.create_task(ls.shutdown())
+            loop.run_until_complete(launch_task)
+        assert 0 == launch_task.result()
+
+        # Shutting down the launch service should destroy the snapshot session
+        self.assertTracingSessionNotExist(session_name+'-snapshot', snapshot_mode=True)
 
         shutil.rmtree(tmpdir)
 

--- a/test_tracetools_launch/test/test_tracetools_launch/test_trace_action.py
+++ b/test_tracetools_launch/test/test_tracetools_launch/test_trace_action.py
@@ -423,6 +423,8 @@ class TestTraceAction(unittest.TestCase):
                 <arg name="subbuffer-size-kernel" default="1048576" />
                 <trace
                     session-name="$(var session-name)"
+                    snapshot-mode="$(var snapshot-mode)"
+                    dual-session="$(var dual-session)"
                     append-timestamp="$(var append-timestamp)"
                     base-path="$(var base-path)"
                     append-trace="$(var append-trace)"
@@ -483,6 +485,8 @@ class TestTraceAction(unittest.TestCase):
                 default: "1048576"
             - trace:
                 session-name: "$(var session-name)"
+                snapshot-mode: "$(var snapshot-mode)"
+                dual-session: "$(var dual-session)"
                 append-timestamp: "$(var append-timestamp)"
                 base-path: "$(var base-path)"
                 append-trace: "$(var append-trace)"

--- a/test_tracetools_launch/test/test_tracetools_launch/test_trace_action.py
+++ b/test_tracetools_launch/test/test_tracetools_launch/test_trace_action.py
@@ -95,6 +95,7 @@ class TestTraceAction(unittest.TestCase):
         *,
         session_name: Optional[str] = 'my-session-name',
         snapshot_mode: bool = False,
+        dual_session: bool = False,
         append_trace: bool = False,
         events_ust: List[str] = ['ros2:*', '*'],
         subbuffer_size_ust: int = 524288,
@@ -110,6 +111,10 @@ class TestTraceAction(unittest.TestCase):
         self.assertEqual(
             snapshot_mode,
             perform_typed_substitution(context, action.snapshot_mode, bool)
+        )
+        self.assertEqual(
+            dual_session,
+            perform_typed_substitution(context, action.dual_session, bool)
         )
         self.assertEqual(
             append_trace,
@@ -169,6 +174,27 @@ class TestTraceAction(unittest.TestCase):
 
         shutil.rmtree(tmpdir)
 
+    def test_action_dual_session(self) -> None:
+        tmpdir = tempfile.mkdtemp(prefix='TestTraceAction__test_action_dual_session')
+
+        action = Trace(
+            session_name='my-session-name',
+            dual_session=True,
+            base_path=tmpdir,
+            events_kernel=[],
+            syscalls=[],
+            events_ust=[
+                'ros2:*',
+                '*',
+            ],
+            subbuffer_size_ust=524288,
+            subbuffer_size_kernel=1048576,
+        )
+        context = self._assert_launch_no_errors([action])
+        self._check_trace_action(action, context, tmpdir, dual_session=True)
+
+        shutil.rmtree(tmpdir)
+
     def test_action_frontend_xml(self) -> None:
         tmpdir = tempfile.mkdtemp(prefix='TestTraceAction__test_frontend_xml')
 
@@ -178,6 +204,7 @@ class TestTraceAction(unittest.TestCase):
                 <trace
                     session-name="my-session-name"
                     snapshot-mode="false"
+                    dual-session="false"
                     append-timestamp="false"
                     base-path="{}"
                     append-trace="true"
@@ -208,6 +235,7 @@ class TestTraceAction(unittest.TestCase):
             - trace:
                 session-name: my-session-name
                 snapshot-mode: false
+                dual-session: false
                 append-timestamp: false
                 base-path: {}
                 append-trace: true
@@ -300,6 +328,11 @@ class TestTraceAction(unittest.TestCase):
             default_value='False',
             description='whether to take a snapshot of the session',
         )
+        dual_session_arg = DeclareLaunchArgument(
+            'dual-session',
+            default_value='False',
+            description='whether to pre-configure a dual session',
+        )
         append_timestamp_arg = DeclareLaunchArgument(
             'append-timestamp',
             default_value='False',
@@ -323,6 +356,7 @@ class TestTraceAction(unittest.TestCase):
         action = Trace(
             session_name=LaunchConfiguration(session_name_arg.name),
             snapshot_mode=LaunchConfiguration(snapshot_mode_arg.name),
+            dual_session=LaunchConfiguration(dual_session_arg.name),
             append_timestamp=LaunchConfiguration(append_timestamp_arg.name),
             base_path=TextSubstitution(text=tmpdir),
             append_trace=LaunchConfiguration(append_trace_arg.name),
@@ -345,6 +379,7 @@ class TestTraceAction(unittest.TestCase):
         context = self._assert_launch_no_errors([
             session_name_arg,
             snapshot_mode_arg,
+            dual_session_arg,
             append_timestamp_arg,
             append_trace_arg,
             subbuffer_size_ust_arg,
@@ -378,6 +413,7 @@ class TestTraceAction(unittest.TestCase):
             <launch>
                 <arg name="session-name" default="my-session-name" />
                 <arg name="snapshot-mode" default="false" />
+                <arg name="dual-session" default="false" />
                 <arg name="append-timestamp" default="false" />
                 <arg name="base-path" default="{}" />
                 <arg name="append-trace" default="true" />
@@ -420,6 +456,9 @@ class TestTraceAction(unittest.TestCase):
                 default: my-session-name
             - arg:
                 name: snapshot-mode
+                default: "false"
+            - arg:
+                name: dual-session
                 default: "false"
             - arg:
                 name: append-timestamp


### PR DESCRIPTION
Continuation of #191 

Tests for both `Trace` launch action and `ros2 trace` command are added with `dual_session` enabled