### PR TITLE
Use overwrite mode for snapshot sessions

### DIFF
--- a/tracetools_trace/tracetools_trace/tools/lttng_impl.py
+++ b/tracetools_trace/tracetools_trace/tools/lttng_impl.py
@@ -342,12 +342,14 @@ def setup(
             # Per-user buffer
             buffer_type=lttngpy.LTTNG_BUFFER_PER_UID,
             channel_name=channel_name,
-            # Discard, do not overwrite
-            overwrite=0,
-            # We use 2 sub-buffers because the number of sub-buffers is pointless in discard mode,
-            # and switching between sub-buffers introduces noticeable CPU overhead
+            # Overwrite if snapshot mode, otherwise discard
+            overwrite=snapshot_mode,
+            # We use 2 sub-buffers in normal mode because the number of sub-buffers is pointless in
+            # discard mode, and switching between sub-buffers introduces noticeable CPU overhead.
+            # In snapshot mode, we use 4 sub-buffers to lose less data when sub-buffers are over-
+            # written, because when all sub-buffers are full the oldest one is discarded entirely.
             subbuf_size=subbuffer_size_ust,
-            num_subbuf=2,
+            num_subbuf=4 if snapshot_mode else 2,
             # Ignore switch timer interval and use read timer instead
             switch_timer_interval=0,
             read_timer_interval=200,
@@ -377,12 +379,14 @@ def setup(
             # Global buffer (only option for kernel domain)
             buffer_type=lttngpy.LTTNG_BUFFER_GLOBAL,
             channel_name=channel_name,
-            # Discard, do not overwrite
-            overwrite=0,
-            # We use 2 sub-buffers because the number of sub-buffers is pointless in discard mode,
-            # and switching between sub-buffers introduces noticeable CPU overhead
+            # Overwrite if snapshot mode, otherwise discard
+            overwrite=snapshot_mode,
+            # We use 2 sub-buffers in normal mode because the number of sub-buffers is pointless in
+            # discard mode, and switching between sub-buffers introduces noticeable CPU overhead.
+            # In snapshot mode, we use 4 sub-buffers to lose less data when sub-buffers are over-
+            # written, because when all sub-buffers are full the oldest one is discarded entirely.
             subbuf_size=subbuffer_size_kernel,
-            num_subbuf=2,
+            num_subbuf=4 if snapshot_mode else 2,
             # Ignore switch timer interval and use read timer instead
             switch_timer_interval=0,
             read_timer_interval=200,

--- a/tracetools_trace/tracetools_trace/tools/lttng_impl.py
+++ b/tracetools_trace/tracetools_trace/tools/lttng_impl.py
@@ -343,11 +343,12 @@ def setup(
             buffer_type=lttngpy.LTTNG_BUFFER_PER_UID,
             channel_name=channel_name,
             # Overwrite if snapshot mode, otherwise discard
-            overwrite=snapshot_mode,
+            overwrite=int(snapshot_mode),
             # We use 2 sub-buffers in normal mode because the number of sub-buffers is pointless in
             # discard mode, and switching between sub-buffers introduces noticeable CPU overhead.
             # In snapshot mode, we use 4 sub-buffers to lose less data when sub-buffers are over-
             # written, because when all sub-buffers are full the oldest one is discarded entirely.
+            # See: https://lttng.org/docs/v2.13/#doc-channel-subbuf-size-vs-subbuf-count
             subbuf_size=subbuffer_size_ust,
             num_subbuf=4 if snapshot_mode else 2,
             # Ignore switch timer interval and use read timer instead
@@ -380,11 +381,12 @@ def setup(
             buffer_type=lttngpy.LTTNG_BUFFER_GLOBAL,
             channel_name=channel_name,
             # Overwrite if snapshot mode, otherwise discard
-            overwrite=snapshot_mode,
+            overwrite=int(snapshot_mode),
             # We use 2 sub-buffers in normal mode because the number of sub-buffers is pointless in
             # discard mode, and switching between sub-buffers introduces noticeable CPU overhead.
             # In snapshot mode, we use 4 sub-buffers to lose less data when sub-buffers are over-
             # written, because when all sub-buffers are full the oldest one is discarded entirely.
+            # See: https://lttng.org/docs/v2.13/#doc-channel-subbuf-size-vs-subbuf-count
             subbuf_size=subbuffer_size_kernel,
             num_subbuf=4 if snapshot_mode else 2,
             # Ignore switch timer interval and use read timer instead


### PR DESCRIPTION
## Description

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

Fixes #208 

The changes worked fine locally

```
shravan@deva:~$ lttng list snapshot-session 
Recording session snapshot-session: [active snapshot]
=== Domain: User space ===

Buffering scheme: per-user

Tracked process attributes
  Virtual process IDs:  all
  Virtual user IDs:     all
  Virtual group IDs:    all

Channels:
-------------
- ros2: [enabled]

    Attributes:
      Event-loss mode:  overwrite   <------
      Sub-buffer size:  32768 bytes
      Sub-buffer count: 4
      Switch timer:     inactive
      Read timer:       200 us
      Monitor timer:    1000000 us
      Trace file count: 1 per stream
      Trace file size:  unlimited
      Output mode:      mmap

    Statistics:
      None

    Recording event rules:
      ros2:callback_end (type: tracepoint) [enabled]
      ....
```

### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
