### PR TITLE
Allow creating multiple channels

### DIFF
--- a/test_tracetools_launch/test/test_tracetools_launch/test_trace_action.py
+++ b/test_tracetools_launch/test/test_tracetools_launch/test_trace_action.py
@@ -23,6 +23,7 @@ from typing import List
 from typing import Optional
 from typing import TextIO
 from typing import Tuple
+from typing import Union
 import unittest
 
 from launch import Action
@@ -96,10 +97,12 @@ class TestTraceAction(unittest.TestCase):
         session_name: Optional[str] = 'my-session-name',
         snapshot_mode: bool = False,
         append_trace: bool = False,
-        events_ust: List[str] = ['ros2:*', '*'],
+        events_ust: Union[List[str], dict[str, List[str]]] = ['ros2:*', '*'],
         subbuffer_size_ust: int = 524288,
         subbuffer_size_kernel: int = 1048576,
     ) -> None:
+        if not isinstance(events_ust, dict):
+            events_ust = {'': events_ust} if bool(events_ust) else {}
         if session_name is not None:
             self.assertEqual(session_name, perform_substitutions(context, action.session_name))
         if tmpdir is not None:
@@ -117,7 +120,10 @@ class TestTraceAction(unittest.TestCase):
         )
         self.assertEqual(0, len(action.events_kernel))
         self.assertEqual(
-            events_ust, [perform_substitutions(context, x) for x in action.events_ust])
+            events_ust,
+            {channel_name: [perform_substitutions(context, x) for x in channel_events]
+             for channel_name, channel_events in action.events_ust.items()}
+        )
         self.assertEqual(
             subbuffer_size_ust,
             perform_typed_substitution(context, action.subbuffer_size_ust, int)
@@ -166,6 +172,34 @@ class TestTraceAction(unittest.TestCase):
         )
         context = self._assert_launch_no_errors([action])
         self._check_trace_action(action, context, tmpdir, snapshot_mode=True)
+
+        shutil.rmtree(tmpdir)
+
+    def test_action_multiple_channels(self) -> None:
+        tmpdir = tempfile.mkdtemp(prefix='TestTraceAction__test_action_multiple_channels')
+
+        action = Trace(
+            session_name='my-session-name',
+            base_path=tmpdir,
+            events_kernel=[],
+            syscalls=[],
+            events_ust={
+                'channel1': ['ros2:*'],
+                'channel2': ['*'],
+            },
+            subbuffer_size_ust=524288,
+            subbuffer_size_kernel=1048576,
+        )
+        context = self._assert_launch_no_errors([action])
+        self._check_trace_action(
+            action,
+            context,
+            tmpdir,
+            events_ust={
+                'channel1': ['ros2:*'],
+                'channel2': ['*'],
+            },
+        )
 
         shutil.rmtree(tmpdir)
 

--- a/tracetools_launch/tracetools_launch/action.py
+++ b/tracetools_launch/tracetools_launch/action.py
@@ -24,6 +24,7 @@ from typing import List
 from typing import Mapping
 from typing import Optional
 from typing import Text
+from typing import TypedDict
 from typing import Union
 
 from launch import logging
@@ -118,8 +119,15 @@ class Trace(Action):
         append_timestamp: Union[bool, SomeSubstitutionsType] = False,
         base_path: Optional[SomeSubstitutionsType] = None,
         append_trace: Union[bool, SomeSubstitutionsType] = False,
-        events_ust: Optional[Iterable[SomeSubstitutionsType]] = None,
-        events_kernel: Iterable[SomeSubstitutionsType] = [],
+        events_ust: Union[
+            Iterable[SomeSubstitutionsType],
+            dict[str, Iterable[SomeSubstitutionsType]],
+            None
+        ] = None,
+        events_kernel: Union[
+            Iterable[SomeSubstitutionsType],
+            dict[str, Iterable[SomeSubstitutionsType]]
+        ] = [],
         syscalls: Iterable[SomeSubstitutionsType] = [],
         context_fields:
             Union[Iterable[SomeSubstitutionsType], Mapping[str, Iterable[SomeSubstitutionsType]]]
@@ -151,11 +159,11 @@ class Trace(Action):
             or `None` for default
         :param append_trace: whether to append to the trace directory if it already exists,
             otherwise an error is reported
-        :param events_ust: the list of ROS UST events to enable; if it's `None`, the default ROS
+        :param events_ust: [TODO: change this accordingly] the list of ROS UST events to enable; if it's `None`, the default ROS
             events are used for a normal session, and the default ROS initialization events are
             used for the snapshot session in case of a dual session; if it's an empty list, no UST
             events are enabled
-        :param events_kernel: the list of kernel events to enable
+        :param events_kernel: [TODO: change this accordingly] the list of kernel events to enable
         :param syscalls: the list of syscalls to enable
         :param context_fields: the names of context fields to enable
             if it's a list or a set, the context fields are enabled for both kernel and userspace;
@@ -192,10 +200,22 @@ class Trace(Action):
         self._append_trace = normalize_typed_substitution(append_trace, bool)
         self._trace_directory: Optional[str] = None
         if events_ust is None:
-            events_ust = names.DEFAULT_EVENTS_ROS if not self._dual_session \
-                else names.DEFAULT_INIT_EVENTS_ROS
-        self._events_ust = [normalize_to_list_of_substitutions(x) for x in events_ust]
-        self._events_kernel = [normalize_to_list_of_substitutions(x) for x in events_kernel]
+            events_ust = {'': names.DEFAULT_EVENTS_ROS} if not self._dual_session \
+                else {'': names.DEFAULT_INIT_EVENTS_ROS}
+        # convert to dictionary if a single list is provided
+        if not isinstance(events_ust, dict):
+            events_ust = {'': events_ust} if bool(events_ust) else {}
+        self._events_ust = {
+            channel_name: [normalize_to_list_of_substitutions(x) for x in channel_events]
+            for channel_name, channel_events in events_ust.items()
+        }
+        # convert to dictionary if a single list is provided
+        if not isinstance(events_kernel, dict):
+            events_kernel = {'': events_kernel} if bool(events_kernel) else {}
+        self._events_kernel = {
+            channel_name: [normalize_to_list_of_substitutions(x) for x in channel_events]
+            for channel_name, channel_events in events_kernel.items()
+        }
         self._syscalls = [normalize_to_list_of_substitutions(x) for x in syscalls]
         self._context_fields: Union[
             Mapping[str, List[List[Substitution]]], List[List[Substitution]]
@@ -236,11 +256,11 @@ class Trace(Action):
         return self._trace_directory
 
     @property
-    def events_ust(self) -> List[List[Substitution]]:
+    def events_ust(self) -> dict[str, List[List[Substitution]]]:
         return self._events_ust
 
     @property
-    def events_kernel(self) -> List[List[Substitution]]:
+    def events_kernel(self) -> dict[str, List[List[Substitution]]]:
         return self._events_kernel
 
     @property
@@ -446,8 +466,14 @@ class Trace(Action):
         dual_session = perform_typed_substitution(context, self._dual_session, bool)
         base_path = perform_substitutions(context, self._base_path)
         append_trace = perform_typed_substitution(context, self._append_trace, bool)
-        events_ust = [perform_substitutions(context, x) for x in self._events_ust]
-        events_kernel = [perform_substitutions(context, x) for x in self._events_kernel]
+        events_ust = {
+            channel_name: [perform_substitutions(context, x) for x in channel_events]
+            for channel_name, channel_events in self._events_ust.items()
+        }
+        events_kernel = {
+            channel_name: [perform_substitutions(context, x) for x in channel_events]
+            for channel_name, channel_events in self._events_kernel.items()
+        }
         syscalls = [perform_substitutions(context, x) for x in self._syscalls]
         context_fields = (
             {
@@ -516,18 +542,22 @@ class Trace(Action):
         context.register_event_handler(OnShutdown(on_shutdown=destroy))
         return self._ld_preload_actions
 
-    def _get_ld_preload_actions(self, events_ust: List[str]) -> List[Action]:
+    def _get_ld_preload_actions(self, events_ust: dict[str, List[str]]) -> List[Action]:
         ld_preload_actions: List[Action] = []
+        # Flatten the events from all channels
+        all_events_ust = [
+            event for channel_events in events_ust.values() for event in channel_events
+        ]
         # Add LD_PRELOAD actions if corresponding events are enabled
-        if self.has_libc_wrapper_events(events_ust):
+        if self.has_libc_wrapper_events(all_events_ust):
             ld_preload_actions.append(LdPreload(self.LIB_LIBC_WRAPPER))
-        if self.has_pthread_wrapper_events(events_ust):
+        if self.has_pthread_wrapper_events(all_events_ust):
             ld_preload_actions.append(LdPreload(self.LIB_PTHREAD_WRAPPER))
-        if self.has_dl_events(events_ust):
+        if self.has_dl_events(all_events_ust):
             ld_preload_actions.append(LdPreload(self.LIB_DL))
         # Warn if events match both normal AND fast profiling libs
-        has_fast_profiling_events = self.has_profiling_events(events_ust, True)
-        has_normal_profiling_events = self.has_profiling_events(events_ust, False)
+        has_fast_profiling_events = self.has_profiling_events(all_events_ust, True)
+        has_normal_profiling_events = self.has_profiling_events(all_events_ust, False)
         # In practice, the first lib in the LD_PRELOAD list will be used, so the fast one here
         if has_fast_profiling_events:
             ld_preload_actions.append(LdPreload(self.LIB_PROFILE_FAST))

--- a/tracetools_launch/tracetools_launch/action.py
+++ b/tracetools_launch/tracetools_launch/action.py
@@ -24,7 +24,6 @@ from typing import List
 from typing import Mapping
 from typing import Optional
 from typing import Text
-from typing import TypedDict
 from typing import Union
 
 from launch import logging
@@ -159,11 +158,16 @@ class Trace(Action):
             or `None` for default
         :param append_trace: whether to append to the trace directory if it already exists,
             otherwise an error is reported
-        :param events_ust: [TODO: change this accordingly] the list of ROS UST events to enable; if it's `None`, the default ROS
-            events are used for a normal session, and the default ROS initialization events are
-            used for the snapshot session in case of a dual session; if it's an empty list, no UST
-            events are enabled
-        :param events_kernel: [TODO: change this accordingly] the list of kernel events to enable
+        :param events_ust: the ROS UST events to enable; if a single list of events is provided,
+            then a single channel will be configured; if a dict is provided, then multiple channels
+            are created with '(ros2){key}' as channel names and the corresponding list of events in
+            values enabled for each channel; if it's `None`, the default ROS events are used for a
+            normal session, and the default ROS initialization events are used for the snapshot
+            session in case of a dual session; if it's an empty list, no UST events are enabled
+        :param events_kernel: the kernel events to enable; if a single list of events is provided,
+            then a single channel will be configured; if a dict is provided, then multiple channels
+            are created with '(kchan){key}' as channel names and the corresponding list of events
+            in values enabled for each channel
         :param syscalls: the list of syscalls to enable
         :param context_fields: the names of context fields to enable
             if it's a list or a set, the context fields are enabled for both kernel and userspace;

--- a/tracetools_trace/tracetools_trace/tools/lttng_impl.py
+++ b/tracetools_trace/tracetools_trace/tools/lttng_impl.py
@@ -348,7 +348,7 @@ def setup(
         domain = DOMAIN_TYPE_USERSPACE
         domain_type = lttngpy.LTTNG_DOMAIN_UST
         for channel_name, channel_events in ros_events.items():
-            if len(ros_events) == 1:
+            if channel_name == '':
                 channel_name = default_channel_name_ust
             else:
                 channel_name = f'({default_channel_name_ust}){channel_name}'
@@ -390,7 +390,7 @@ def setup(
         domain = DOMAIN_TYPE_KERNEL
         domain_type = lttngpy.LTTNG_DOMAIN_KERNEL
         for channel_name, channel_events in kernel_events.items():
-            if len(kernel_events) == 1:
+            if channel_name == '':
                 channel_name = default_channel_name_kernel
             else:
                 channel_name = f'({default_channel_name_kernel}){channel_name}'

--- a/tracetools_trace/tracetools_trace/tools/lttng_impl.py
+++ b/tracetools_trace/tracetools_trace/tools/lttng_impl.py
@@ -201,12 +201,12 @@ def setup(
     dual_session: bool = False,
     base_path: str,
     append_trace: bool = False,
-    ros_events: Union[List[str], Set[str]] = DEFAULT_EVENTS_ROS,
-    kernel_events: Union[List[str], Set[str]] = [],
+    ros_events: dict[str, Union[List[str], Set[str]]] = {'': DEFAULT_EVENTS_ROS},
+    kernel_events: dict[str, Union[List[str], Set[str]]] = {},
     syscalls: Union[List[str], Set[str]] = [],
     context_fields: Union[List[str], Set[str], Dict[str, List[str]]] = DEFAULT_CONTEXT,
-    channel_name_ust: str = 'ros2',
-    channel_name_kernel: str = 'kchan',
+    default_channel_name_ust: str = 'ros2',
+    default_channel_name_kernel: str = 'kchan',
     subbuffer_size_ust: int = 8 * 4096,
     subbuffer_size_kernel: int = 32 * 4096,
 ) -> Optional[str]:
@@ -228,17 +228,17 @@ def setup(
         which will be created if needed
     :param append_trace: whether to append to the trace directory if it already exists, otherwise
         an error is reported
-    :param ros_events: list of ROS events to enable
+    :param ros_events: [TODO: change this accordingly] list of ROS events to enable
     :param kernel_events: list of kernel events to enable
-    :param syscalls: list of syscalls to enable
+    :param syscalls: [TODO: change this accordingly] list of syscalls to enable
         these will be part of the kernel channel
     :param context_fields: the names of context fields to enable
         if it's a list or a set, the context fields are enabled for both kernel and userspace;
         if it's a dictionary: { domain type string -> context fields list }
             with the domain type string being either `names.DOMAIN_TYPE_KERNEL` or
             `names.DOMAIN_TYPE_USERSPACE`
-    :param channel_name_ust: the UST channel name
-    :param channel_name_kernel: the kernel channel name
+    :param channel_name_ust_prefix:[TODO: change this accordingly] the UST channel name
+    :param channel_name_kernel_prefix:[TODO: change this accordingly] the kernel channel name
     :param subbuffer_size_ust: the size of the subbuffers for userspace events (defaults to 8 times
         the usual page size)
     :param subbuffer_size_kernel: the size of the subbuffers for kernel events (defaults to 32
@@ -295,10 +295,22 @@ def setup(
         )
 
     # Convert lists to sets
-    if not isinstance(ros_events, set):
-        ros_events = set(ros_events)
-    if not isinstance(kernel_events, set):
-        kernel_events = set(kernel_events)
+    ros_events = {
+        channel_name: (
+            channel_events
+            if isinstance(channel_events, set)
+            else set(channel_events)
+        )
+        for channel_name, channel_events in ros_events.items()
+    }
+    kernel_events = {
+        channel_name: (
+            channel_events
+            if isinstance(channel_events, set)
+            else set(channel_events)
+        )
+        for channel_name, channel_events in kernel_events.items()
+    }
     if not isinstance(syscalls, set):
         syscalls = set(syscalls)
     if isinstance(context_fields, list):
@@ -335,88 +347,96 @@ def setup(
     if ust_enabled:
         domain = DOMAIN_TYPE_USERSPACE
         domain_type = lttngpy.LTTNG_DOMAIN_UST
-        channel_name = channel_name_ust
-        _enable_channel(
-            session_name=session_name,
-            domain_type=domain_type,
-            # Per-user buffer
-            buffer_type=lttngpy.LTTNG_BUFFER_PER_UID,
-            channel_name=channel_name,
-            # Overwrite if snapshot mode, otherwise discard
-            overwrite=int(snapshot_mode),
-            # We use 2 sub-buffers in normal mode because the number of sub-buffers is pointless in
-            # discard mode, and switching between sub-buffers introduces noticeable CPU overhead.
-            # In snapshot mode, we use 4 sub-buffers to lose less data when sub-buffers are over-
-            # written, because when all sub-buffers are full the oldest one is discarded entirely.
-            # See: https://lttng.org/docs/v2.13/#doc-channel-subbuf-size-vs-subbuf-count
-            subbuf_size=subbuffer_size_ust,
-            num_subbuf=4 if snapshot_mode else 2,
-            # Ignore switch timer interval and use read timer instead
-            switch_timer_interval=0,
-            read_timer_interval=200,
-            # mmap channel output (only option for UST)
-            output=lttngpy.LTTNG_EVENT_MMAP,
-        )
-        _enable_events(
-            session_name=session_name,
-            domain_type=domain_type,
-            event_type=lttngpy.LTTNG_EVENT_TRACEPOINT,
-            channel_name=channel_name,
-            events=ros_events,
-        )
-        _add_contexts(
-            session_name=session_name,
-            domain_type=domain_type,
-            channel_name=channel_name,
-            context_fields=contexts_dict.get(domain),
-        )
-    if kernel_enabled:
-        domain = DOMAIN_TYPE_KERNEL
-        domain_type = lttngpy.LTTNG_DOMAIN_KERNEL
-        channel_name = channel_name_kernel
-        _enable_channel(
-            session_name=session_name,
-            domain_type=domain_type,
-            # Global buffer (only option for kernel domain)
-            buffer_type=lttngpy.LTTNG_BUFFER_GLOBAL,
-            channel_name=channel_name,
-            # Overwrite if snapshot mode, otherwise discard
-            overwrite=int(snapshot_mode),
-            # We use 2 sub-buffers in normal mode because the number of sub-buffers is pointless in
-            # discard mode, and switching between sub-buffers introduces noticeable CPU overhead.
-            # In snapshot mode, we use 4 sub-buffers to lose less data when sub-buffers are over-
-            # written, because when all sub-buffers are full the oldest one is discarded entirely.
-            # See: https://lttng.org/docs/v2.13/#doc-channel-subbuf-size-vs-subbuf-count
-            subbuf_size=subbuffer_size_kernel,
-            num_subbuf=4 if snapshot_mode else 2,
-            # Ignore switch timer interval and use read timer instead
-            switch_timer_interval=0,
-            read_timer_interval=200,
-            # mmap channel output instead of splice
-            output=lttngpy.LTTNG_EVENT_MMAP,
-        )
-        if kernel_events:
+        for channel_name, channel_events in ros_events.items():
+            if len(ros_events) == 1:
+                channel_name = default_channel_name_ust
+            else:
+                channel_name = f'({default_channel_name_ust}){channel_name}'
+            _enable_channel(
+                session_name=session_name,
+                domain_type=domain_type,
+                # Per-user buffer
+                buffer_type=lttngpy.LTTNG_BUFFER_PER_UID,
+                channel_name=channel_name,
+                # Overwrite if snapshot mode, otherwise discard
+                overwrite=int(snapshot_mode),
+                # We use 2 sub-buffers in normal mode because the number of sub-buffers is pointless in
+                # discard mode, and switching between sub-buffers introduces noticeable CPU overhead.
+                # In snapshot mode, we use 4 sub-buffers to lose less data when sub-buffers are over-
+                # written, because when all sub-buffers are full the oldest one is discarded entirely.
+                # See: https://lttng.org/docs/v2.13/#doc-channel-subbuf-size-vs-subbuf-count
+                subbuf_size=subbuffer_size_ust,
+                num_subbuf=4 if snapshot_mode else 2,
+                # Ignore switch timer interval and use read timer instead
+                switch_timer_interval=0,
+                read_timer_interval=200,
+                # mmap channel output (only option for UST)
+                output=lttngpy.LTTNG_EVENT_MMAP,
+            )
             _enable_events(
                 session_name=session_name,
                 domain_type=domain_type,
                 event_type=lttngpy.LTTNG_EVENT_TRACEPOINT,
                 channel_name=channel_name,
-                events=kernel_events,
+                events=channel_events,
             )
-        if syscalls:
-            _enable_events(
+            _add_contexts(
                 session_name=session_name,
                 domain_type=domain_type,
-                event_type=lttngpy.LTTNG_EVENT_SYSCALL,
                 channel_name=channel_name,
-                events=syscalls,
+                context_fields=contexts_dict.get(domain),
             )
-        _add_contexts(
-            session_name=session_name,
-            domain_type=domain_type,
-            channel_name=channel_name,
-            context_fields=contexts_dict.get(domain),
-        )
+    if kernel_enabled:
+        domain = DOMAIN_TYPE_KERNEL
+        domain_type = lttngpy.LTTNG_DOMAIN_KERNEL
+        for channel_name, channel_events in kernel_events.items():
+            if len(kernel_events) == 1:
+                channel_name = default_channel_name_kernel
+            else:
+                channel_name = f'({default_channel_name_kernel}){channel_name}'
+            _enable_channel(
+                session_name=session_name,
+                domain_type=domain_type,
+                # Global buffer (only option for kernel domain)
+                buffer_type=lttngpy.LTTNG_BUFFER_GLOBAL,
+                channel_name=channel_name,
+                # Overwrite if snapshot mode, otherwise discard
+                overwrite=int(snapshot_mode),
+                # We use 2 sub-buffers in normal mode because the number of sub-buffers is pointless in
+                # discard mode, and switching between sub-buffers introduces noticeable CPU overhead.
+                # In snapshot mode, we use 4 sub-buffers to lose less data when sub-buffers are over-
+                # written, because when all sub-buffers are full the oldest one is discarded entirely.
+                # See: https://lttng.org/docs/v2.13/#doc-channel-subbuf-size-vs-subbuf-count
+                subbuf_size=subbuffer_size_kernel,
+                num_subbuf=4 if snapshot_mode else 2,
+                # Ignore switch timer interval and use read timer instead
+                switch_timer_interval=0,
+                read_timer_interval=200,
+                # mmap channel output instead of splice
+                output=lttngpy.LTTNG_EVENT_MMAP,
+            )
+            if channel_events:
+                _enable_events(
+                    session_name=session_name,
+                    domain_type=domain_type,
+                    event_type=lttngpy.LTTNG_EVENT_TRACEPOINT,
+                    channel_name=channel_name,
+                    events=channel_events,
+                )
+            if syscalls:
+                _enable_events(
+                    session_name=session_name,
+                    domain_type=domain_type,
+                    event_type=lttngpy.LTTNG_EVENT_SYSCALL,
+                    channel_name=channel_name,
+                    events=syscalls,
+                )
+            _add_contexts(
+                session_name=session_name,
+                domain_type=domain_type,
+                channel_name=channel_name,
+                context_fields=contexts_dict.get(domain),
+            )
 
     return full_path
 

--- a/tracetools_trace/tracetools_trace/tools/lttng_impl.py
+++ b/tracetools_trace/tracetools_trace/tools/lttng_impl.py
@@ -228,17 +228,27 @@ def setup(
         which will be created if needed
     :param append_trace: whether to append to the trace directory if it already exists, otherwise
         an error is reported
-    :param ros_events: [TODO: change this accordingly] list of ROS events to enable
-    :param kernel_events: list of kernel events to enable
-    :param syscalls: [TODO: change this accordingly] list of syscalls to enable
+    :param ros_events: ROS UST events to enable; if a single list of events is provided,
+        then a single channel will be configured; if a dict is provided, then multiple channels
+        are created with '(ros2){key}' as channel names and the corresponding list of events in
+        values enabled for each channel
+    :param kernel_events: kernel events to enable; if a single list of events is provided,
+        then a single channel will be configured; if a dict is provided, then multiple channels
+        are created with '(kchan){key}' as channel names and the corresponding list of events in
+        values enabled for each channel
+    :param syscalls: list of syscalls to enable
         these will be part of the kernel channel
     :param context_fields: the names of context fields to enable
         if it's a list or a set, the context fields are enabled for both kernel and userspace;
         if it's a dictionary: { domain type string -> context fields list }
             with the domain type string being either `names.DOMAIN_TYPE_KERNEL` or
             `names.DOMAIN_TYPE_USERSPACE`
-    :param channel_name_ust_prefix:[TODO: change this accordingly] the UST channel name
-    :param channel_name_kernel_prefix:[TODO: change this accordingly] the kernel channel name
+    :param default_channel_name_ust: the UST channel name that will be used if ros_events is a list
+        or if a dict contains an entry with an empty string as key; this is also used as a prefix
+        for channel names when ros_events is a dict
+    :param default_channel_name_kernel: the kernel channel name that will be used if kernel_events
+        is a list or if a dict contains an entry with an empty string as key; this is also used as
+        a prefix for channel names when kernel_events is a dict
     :param subbuffer_size_ust: the size of the subbuffers for userspace events (defaults to 8 times
         the usual page size)
     :param subbuffer_size_kernel: the size of the subbuffers for kernel events (defaults to 32
@@ -360,10 +370,11 @@ def setup(
                 channel_name=channel_name,
                 # Overwrite if snapshot mode, otherwise discard
                 overwrite=int(snapshot_mode),
-                # We use 2 sub-buffers in normal mode because the number of sub-buffers is pointless in
-                # discard mode, and switching between sub-buffers introduces noticeable CPU overhead.
-                # In snapshot mode, we use 4 sub-buffers to lose less data when sub-buffers are over-
-                # written, because when all sub-buffers are full the oldest one is discarded entirely.
+                # We use 2 sub-buffers in normal mode because the number of sub-buffers is
+                # pointless in discard mode, and switching between sub-buffers introduces
+                # noticeable CPU overhead. In snapshot mode, we use 4 sub-buffers to lose less data
+                # when sub-buffers are over-written, because when all sub-buffers are full the
+                # oldest one is discarded entirely.
                 # See: https://lttng.org/docs/v2.13/#doc-channel-subbuf-size-vs-subbuf-count
                 subbuf_size=subbuffer_size_ust,
                 num_subbuf=4 if snapshot_mode else 2,
@@ -402,10 +413,11 @@ def setup(
                 channel_name=channel_name,
                 # Overwrite if snapshot mode, otherwise discard
                 overwrite=int(snapshot_mode),
-                # We use 2 sub-buffers in normal mode because the number of sub-buffers is pointless in
-                # discard mode, and switching between sub-buffers introduces noticeable CPU overhead.
-                # In snapshot mode, we use 4 sub-buffers to lose less data when sub-buffers are over-
-                # written, because when all sub-buffers are full the oldest one is discarded entirely.
+                # We use 2 sub-buffers in normal mode because the number of sub-buffers is
+                # pointless in discard mode, and switching between sub-buffers introduces
+                # noticeable CPU overhead. In snapshot mode, we use 4 sub-buffers to lose less data
+                # when sub-buffers are over-written, because when all sub-buffers are full the
+                # oldest one is discarded entirely.
                 # See: https://lttng.org/docs/v2.13/#doc-channel-subbuf-size-vs-subbuf-count
                 subbuf_size=subbuffer_size_kernel,
                 num_subbuf=4 if snapshot_mode else 2,

--- a/tracetools_trace/tracetools_trace/trace.py
+++ b/tracetools_trace/tracetools_trace/trace.py
@@ -23,6 +23,7 @@ from typing import Callable
 from typing import List
 from typing import Optional
 from typing import Tuple
+from typing import Union
 
 from tracetools_trace.tools import args
 from tracetools_trace.tools import lttng
@@ -38,24 +39,38 @@ def _assert_lttng_installed() -> None:
 
 def _display_info(
     *,
-    ros_events: List[str],
-    kernel_events: List[str],
+    ros_events: dict[str, List[str]],
+    kernel_events: dict[str, List[str]],
     syscalls: List[str],
     context_fields: List[str],
     display_list: bool,
 ) -> None:
     if ros_events:
-        event_str = 'events' if len(ros_events) > 1 else 'event'
-        print(f'userspace tracing enabled ({len(ros_events)} {event_str})')
-        if display_list:
-            print_names_list(ros_events)
+        channel_str = 'channels' if len(ros_events) > 1 else 'channel'
+        print(f'userspace tracing enabled ({len(ros_events)} {channel_str})')
+        for channel_name, channel_events in ros_events.items():
+            if len(ros_events) == 1:
+                channel_name = 'ros2'
+            else:
+                channel_name = f'(ros2){channel_name}'
+            event_str = 'events' if len(channel_events) > 1 else 'event'
+            print(f'\tchannel "{channel_name}": {len(channel_events)} {event_str}')
+            if display_list:
+                print_names_list(channel_events, prefix='\t\t')
     else:
         print('userspace tracing disabled')
     if kernel_events:
-        event_str = 'events' if len(kernel_events) > 1 else 'event'
-        print(f'kernel tracing enabled ({len(kernel_events)} {event_str})')
-        if display_list:
-            print_names_list(kernel_events)
+        channel_str = 'channels' if len(kernel_events) > 1 else 'channel'
+        print(f'kernel tracing enabled ({len(kernel_events)} {channel_str})')
+        for channel_name, channel_events in kernel_events.items():
+            if len(kernel_events) == 1:
+                channel_name = 'kchan'
+            else:
+                channel_name = f'(kchan){channel_name}'
+            event_str = 'events' if len(channel_events) > 1 else 'event'
+            print(f'\tchannel "{channel_name}": {len(channel_events)} {event_str}')
+            if display_list:
+                print_names_list(channel_events, prefix='\t\t')
     else:
         print('kernel tracing disabled')
     if syscalls:
@@ -144,6 +159,9 @@ def init(
     :param interactive: whether to require user interaction to start tracing
     :return: True if successful, False otherwise
     """
+    # convert events lists to dicts
+    ros_events = {'': ros_events} if ros_events else {}
+    kernel_events = {'': kernel_events} if kernel_events else {}
     _display_info(
         ros_events=ros_events,
         kernel_events=kernel_events,

--- a/tracetools_trace/tracetools_trace/trace.py
+++ b/tracetools_trace/tracetools_trace/trace.py
@@ -23,7 +23,6 @@ from typing import Callable
 from typing import List
 from typing import Optional
 from typing import Tuple
-from typing import Union
 
 from tracetools_trace.tools import args
 from tracetools_trace.tools import lttng


### PR DESCRIPTION
## Description

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->
These changes will allow users to configure multiple [channels](https://lttng.org/docs/v2.13/#doc-channel) in a tracing session.

```python
Trace(
    session_name='single-channel-session',
    events_ust=['ros2:rcl_init', 'ros2:rcl_node_init'],
)
```
This will create one channel with the UST events `ros2:rcl_init` and `ros2:rcl_node_init` enabled. Whereas if a list of lists is provided for `events_ust`, example:

```python
Trace(
    session_name='multi-channel-session',
    events_ust=[['ros2:rcl_init', 'ros2:rcl_node_init'], ['ros2:rcl_init']],
)
```
2 channels are be created with UST events `ros2:rcl_init`,`ros2:rcl_node_init` enabled in one channels and `ros2:rcl_init` enabled in another channel.
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

Fixes #199 

### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
This PR adds this functionality only to python launch files and not to xml files, yaml files, ros2trace cli, substitutions