### PR TITLE
Handle SIGTERM and gracefully stop tracing in interactive tracing mode

### DIFF
--- a/tracetools_trace/tracetools_trace/tools/signals.py
+++ b/tracetools_trace/tracetools_trace/tools/signals.py
@@ -114,3 +114,30 @@ def execute_and_handle_sigint(
             run_function()
         except SignalHandledException:
             pass
+
+
+def execute_and_handle_signals(
+    run_function: Callable[[], None],
+    fini_function: Optional[Callable[[], None]] = None,
+    signals: List[int] = [signal.SIGINT, signal.SIGTERM],
+) -> None:
+    """
+    Execute a task and handle the given signals to always finalize cleanly.
+
+    The main task function is interrupted on the given signals.
+    The finalization function (if provided) is always executed, either
+    after the main task function is done or after it is interrupted.
+
+    :param run_function: the task function, which may be interrupted
+    :param fini_function: the optional finalization/cleanup function
+    :param signals: the list of signals to handle
+    """
+    with SignalHandlerUtil(
+        release_callback=fini_function,
+        raise_after_signal=True,
+        signals=signals,
+    ):
+        try:
+            run_function()
+        except SignalHandledException:
+            pass

--- a/tracetools_trace/tracetools_trace/trace.py
+++ b/tracetools_trace/tracetools_trace/trace.py
@@ -217,7 +217,7 @@ def fini(
             session_name=session_name + (path.RUNTIME_SESSION_SUFFIX if dual_session else '')
         )
 
-    signals.execute_and_handle_sigint(_run, _fini)
+    signals.execute_and_handle_signals(_run, _fini)
 
 
 def cleanup(


### PR DESCRIPTION
## Description

Gracefully shutting down is important here to properly stop tracing. It currently only handles SIGINT; make it handle SIGTERM too.

### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
