### PR TITLE
Use <lttng/lttng.h> in lttngpy and clean up includes

### DIFF
--- a/lttngpy/src/lttngpy/channel.cpp
+++ b/lttngpy/src/lttngpy/channel.cpp
@@ -12,20 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Include lttng-error.h before channel.h, otherwise lttng_error_code isn't known
-// TODO(mosfet80): order it alphabetically once liblttng-ctl 2.14+ is fixed:
-// https://review.lttng.org/c/lttng-tools/+/15165
-#include <lttng/lttng-error.h>
-#include <lttng/channel.h>
-#include <lttng/constant.h>
-#include <lttng/domain.h>
-#include <lttng/event.h>
-#include <lttng/handle.h>
+#include "lttngpy/channel.hpp"
 
 #include <optional>
 #include <string>
-
-#include "lttngpy/channel.hpp"
 
 namespace lttngpy
 {

--- a/lttngpy/src/lttngpy/channel.cpp
+++ b/lttngpy/src/lttngpy/channel.cpp
@@ -12,10 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "lttngpy/channel.hpp"
+#include <lttng/lttng.h>
 
 #include <optional>
 #include <string>
+
+#include "lttngpy/channel.hpp"
 
 namespace lttngpy
 {

--- a/lttngpy/src/lttngpy/channel.hpp
+++ b/lttngpy/src/lttngpy/channel.hpp
@@ -16,6 +16,7 @@
 #define LTTNGPY__CHANNEL_HPP_
 
 #include <lttng/lttng.h>
+
 #include <optional>
 #include <string>
 

--- a/lttngpy/src/lttngpy/channel.hpp
+++ b/lttngpy/src/lttngpy/channel.hpp
@@ -15,8 +15,8 @@
 #ifndef LTTNGPY__CHANNEL_HPP_
 #define LTTNGPY__CHANNEL_HPP_
 
-#include <lttng/domain.h>
-
+#include <lttng/lttng.h>
+#include <optional>
 #include <string>
 
 namespace lttngpy

--- a/lttngpy/src/lttngpy/context_app.cpp
+++ b/lttngpy/src/lttngpy/context_app.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <lttng/lttng-error.h>
+#include <lttng/lttng.h>
 
 #include <string>
 #include <variant>

--- a/lttngpy/src/lttngpy/context_lttng.cpp
+++ b/lttngpy/src/lttngpy/context_lttng.cpp
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <lttng/event.h>
-
 #include <map>
 #include <optional>
 #include <string>

--- a/lttngpy/src/lttngpy/context_lttng.cpp
+++ b/lttngpy/src/lttngpy/context_lttng.cpp
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <lttng/lttng.h>
+
 #include <map>
 #include <optional>
 #include <string>

--- a/lttngpy/src/lttngpy/context_lttng.hpp
+++ b/lttngpy/src/lttngpy/context_lttng.hpp
@@ -15,7 +15,7 @@
 #ifndef LTTNGPY__CONTEXT_LTTNG_HPP_
 #define LTTNGPY__CONTEXT_LTTNG_HPP_
 
-#include <lttng/event.h>
+#include <lttng/lttng.h>
 
 #include <optional>
 #include <string>

--- a/lttngpy/src/lttngpy/context_perf.cpp
+++ b/lttngpy/src/lttngpy/context_perf.cpp
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <lttng/lttng.h>
+
 #include <algorithm>
 #include <map>
 #include <string>

--- a/lttngpy/src/lttngpy/context_perf.cpp
+++ b/lttngpy/src/lttngpy/context_perf.cpp
@@ -12,9 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <lttng/event.h>
-#include <lttng/lttng-error.h>
-
 #include <algorithm>
 #include <map>
 #include <string>

--- a/lttngpy/src/lttngpy/context_perf.hpp
+++ b/lttngpy/src/lttngpy/context_perf.hpp
@@ -15,7 +15,7 @@
 #ifndef LTTNGPY__CONTEXT_PERF_HPP_
 #define LTTNGPY__CONTEXT_PERF_HPP_
 
-#include <lttng/event.h>
+#include <lttng/lttng.h>
 
 #include <string>
 #include <variant>

--- a/lttngpy/src/lttngpy/event.cpp
+++ b/lttngpy/src/lttngpy/event.cpp
@@ -12,9 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <lttng/domain.h>
-#include <lttng/event.h>
-#include <lttng/lttng-error.h>
 #include <string.h>
 
 #include <map>

--- a/lttngpy/src/lttngpy/event.cpp
+++ b/lttngpy/src/lttngpy/event.cpp
@@ -14,6 +14,8 @@
 
 #include <string.h>
 
+#include <lttng/lttng.h>
+
 #include <map>
 #include <optional>
 #include <set>

--- a/lttngpy/src/lttngpy/event.cpp
+++ b/lttngpy/src/lttngpy/event.cpp
@@ -12,9 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <string.h>
-
 #include <lttng/lttng.h>
+#include <string.h>
 
 #include <map>
 #include <optional>

--- a/lttngpy/src/lttngpy/event.hpp
+++ b/lttngpy/src/lttngpy/event.hpp
@@ -15,8 +15,7 @@
 #ifndef LTTNGPY__EVENT_HPP_
 #define LTTNGPY__EVENT_HPP_
 
-#include <lttng/domain.h>
-#include <lttng/event.h>
+#include <lttng/lttng.h>
 
 #include <set>
 #include <string>

--- a/lttngpy/src/lttngpy/session.cpp
+++ b/lttngpy/src/lttngpy/session.cpp
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <lttng/lttng-error.h>
-#include <lttng/session.h>
+#include <lttng/lttng.h>
 
 #include <set>
 #include <string>

--- a/lttngpy/src/lttngpy/snapshot.cpp
+++ b/lttngpy/src/lttngpy/snapshot.cpp
@@ -12,10 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <lttng/clear.h>
-#include <lttng/clear-handle.h>
-#include <lttng/lttng-error.h>
-#include <lttng/snapshot.h>
+#include <lttng/lttng.h>
 
 #include <string>
 

--- a/lttngpy/src/lttngpy/snapshot.cpp
+++ b/lttngpy/src/lttngpy/snapshot.cpp
@@ -62,7 +62,7 @@ int record_snapshot(const std::string & session_name)
   }
 
   // Clear the session after recording the snapshot
-  lttng_clear_handle *handle;
+  lttng_clear_handle * handle;
   ret = lttng_clear_session(session_name.c_str(), &handle);
   if (0 > ret) {
     lttng_clear_handle_destroy(handle);


### PR DESCRIPTION
## Description

This PR updates lttngpy to use the recommended umbrella LTTng header:

    #include <lttng/lttng.h>

instead of including individual LTTng headers (domain.h, event.h, lttng-error.h, etc.).

Changes:
- Replace groups of LTTng includes in lttngpy .cpp files with <lttng/lttng.h>.
- Clean up redundant includes in corresponding .cpp files.
- Fix uncrustify style in snapshot.cpp so lttngpy tests pass.

No functional behavior changes are intended; this is an include/style cleanup.

Fixes #220

### Is this user-facing behavior change?

### Did you use Generative AI?

### Additional Information
