### PR TITLE
Add exec_depend on procps to tracetools_trace for ps command

### DIFF
--- a/tracetools_trace/package.xml
+++ b/tracetools_trace/package.xml
@@ -13,6 +13,7 @@
   <author email="fixed-term.christophe.bourquebedard@de.bosch.com">Christophe Bedard</author>
 
   <exec_depend>lttngpy</exec_depend>
+  <exec_depend>procps</exec_depend>
 
   <test_depend>ament_copyright</test_depend>
   <test_depend>ament_flake8</test_depend>


### PR DESCRIPTION
## Description

`lttng_impl.is_session_daemon_unreachable()` runs the `ps` command through `subprocess`, so it should declare an `exec_depend` on it.

Fixes #226

Requires https://github.com/ros/rosdistro/pull/49427 for RHEL

### Is this user-facing behavior change?

no

### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

### Additional Information

Run tests again on RHEL 10 after/with this PR: https://github.com/ros2/ci/pull/833

`ps` has been used here since #66, so this should be backported to Kilted and Jazzy.