### PR TITLE
Loaned message tests

### DIFF
--- a/test_tracetools/CMakeLists.txt
+++ b/test_tracetools/CMakeLists.txt
@@ -304,7 +304,7 @@ if(BUILD_TESTING)
       test/test_pub_sub_with_message_loaning.py
     )
     set(_test_tracetools_message_loaning_rmw_implementations
-      # rmw_cyclonedds_cpp
+      rmw_cyclonedds_cpp
       rmw_fastrtps_cpp
       rmw_fastrtps_dynamic_cpp
     )

--- a/test_tracetools/CMakeLists.txt
+++ b/test_tracetools/CMakeLists.txt
@@ -299,31 +299,31 @@ if(BUILD_TESTING)
       endforeach()
     endforeach()
 
-    # # Message loaning + rmw_take_loaned_message trace coverage (cyclonedds / fastrtps only)
-    # set(_test_tracetools_pytest_message_loaning
-    #   test/test_pub_sub_with_message_loaning.py
-    # )
-    # set(_test_tracetools_message_loaning_rmw_implementations
-    #   rmw_cyclonedds_cpp
-    #   rmw_fastrtps_cpp
-    #   rmw_fastrtps_dynamic_cpp
-    # )
-    # foreach(_test_path ${_test_tracetools_pytest_message_loaning})
-    #   get_filename_component(_test_name ${_test_path} NAME_WE)
-    #   foreach(rmw_implementation ${_test_tracetools_message_loaning_rmw_implementations})
-    #     if(rmw_implementation IN_LIST rmw_implementations)
-    #       ament_add_ros_isolated_pytest_test(${_test_name}__${rmw_implementation} ${_test_path}
-    #         ENV RMW_IMPLEMENTATION=${rmw_implementation}
-    #         APPEND_ENV PYTHONPATH=${CMAKE_CURRENT_BINARY_DIR}
-    #         TIMEOUT 60
-    #         WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-    #       )
-    #     else()
-    #       message(
-    #         "rmw implementation '${rmw_implementation}' not available for test '${_test_name}'")
-    #     endif()
-    #   endforeach()
-    # endforeach()
+    # Message loaning + rmw_take_loaned_message trace coverage (cyclonedds / fastrtps only)
+    set(_test_tracetools_pytest_message_loaning
+      test/test_pub_sub_with_message_loaning.py
+    )
+    set(_test_tracetools_message_loaning_rmw_implementations
+      # rmw_cyclonedds_cpp
+      rmw_fastrtps_cpp
+      rmw_fastrtps_dynamic_cpp
+    )
+    foreach(_test_path ${_test_tracetools_pytest_message_loaning})
+      get_filename_component(_test_name ${_test_path} NAME_WE)
+      foreach(rmw_implementation ${_test_tracetools_message_loaning_rmw_implementations})
+        if(rmw_implementation IN_LIST rmw_implementations)
+          ament_add_ros_isolated_pytest_test(${_test_name}__${rmw_implementation} ${_test_path}
+            ENV RMW_IMPLEMENTATION=${rmw_implementation}
+            APPEND_ENV PYTHONPATH=${CMAKE_CURRENT_BINARY_DIR}
+            TIMEOUT 60
+            WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+          )
+        else()
+          message(
+            "rmw implementation '${rmw_implementation}' not available for test '${_test_name}'")
+        endif()
+      endforeach()
+    endforeach()
   endif()
 endif()
 

--- a/test_tracetools/CMakeLists.txt
+++ b/test_tracetools/CMakeLists.txt
@@ -141,6 +141,24 @@ if(BUILD_TESTING)
     std_msgs::std_msgs
   )
 
+  add_executable(test_ping_loaned
+    src/test_ping_loaned.cpp
+  )
+  target_link_libraries(test_ping_loaned PRIVATE
+    ${PROJECT_NAME}_mark_process
+    rclcpp::rclcpp
+    std_msgs::std_msgs
+  )
+
+  add_executable(test_pong_loaned
+    src/test_pong_loaned.cpp
+  )
+  target_link_libraries(test_pong_loaned PRIVATE
+    ${PROJECT_NAME}_mark_process
+    rclcpp::rclcpp
+    std_msgs::std_msgs
+  )
+
   add_executable(test_generic_ping
     src/test_generic_ping.cpp
   )
@@ -193,6 +211,8 @@ if(BUILD_TESTING)
     test_message_link_periodic_async
     test_ping
     test_pong
+    test_ping_loaned
+    test_pong_loaned
     test_generic_ping
     test_generic_pong
     test_publisher
@@ -278,6 +298,32 @@ if(BUILD_TESTING)
         endif()
       endforeach()
     endforeach()
+
+    # # Message loaning + rmw_take_loaned_message trace coverage (cyclonedds / fastrtps only)
+    # set(_test_tracetools_pytest_message_loaning
+    #   test/test_pub_sub_with_message_loaning.py
+    # )
+    # set(_test_tracetools_message_loaning_rmw_implementations
+    #   rmw_cyclonedds_cpp
+    #   rmw_fastrtps_cpp
+    #   rmw_fastrtps_dynamic_cpp
+    # )
+    # foreach(_test_path ${_test_tracetools_pytest_message_loaning})
+    #   get_filename_component(_test_name ${_test_path} NAME_WE)
+    #   foreach(rmw_implementation ${_test_tracetools_message_loaning_rmw_implementations})
+    #     if(rmw_implementation IN_LIST rmw_implementations)
+    #       ament_add_ros_isolated_pytest_test(${_test_name}__${rmw_implementation} ${_test_path}
+    #         ENV RMW_IMPLEMENTATION=${rmw_implementation}
+    #         APPEND_ENV PYTHONPATH=${CMAKE_CURRENT_BINARY_DIR}
+    #         TIMEOUT 60
+    #         WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+    #       )
+    #     else()
+    #       message(
+    #         "rmw implementation '${rmw_implementation}' not available for test '${_test_name}'")
+    #     endif()
+    #   endforeach()
+    # endforeach()
   endif()
 endif()
 

--- a/test_tracetools/src/test_ping_loaned.cpp
+++ b/test_tracetools/src/test_ping_loaned.cpp
@@ -43,12 +43,10 @@ public:
     sub_ = this->create_subscription<Msg>(
       SUB_TOPIC_NAME,
       rclcpp::QoS(QUEUE_DEPTH),
-      [this](const Msg & msg) {
-        this->callback(msg);
-      });
+      std::bind(&PingLoanedNode::callback, this, std::placeholders::_1));
     pub_ = this->create_publisher<Msg>(
       PUB_TOPIC_NAME,
-      rclcpp::QoS(QUEUE_DEPTH));
+      rclcpp::QoS(QUEUE_DEPTH).transient_local());
 
     if (!sub_->can_loan_messages()) {
       throw std::runtime_error(
@@ -64,9 +62,9 @@ public:
   : PingLoanedNode(options, true) {}
 
 private:
-  void callback(const Msg & msg)
+  void callback(const Msg::ConstSharedPtr msg)
   {
-    RCLCPP_INFO(this->get_logger(), "[output] %u", msg.data);
+    RCLCPP_INFO(this->get_logger(), "[output] %u", msg->data);
     if (do_only_one_) {
       rclcpp::shutdown();
     }

--- a/test_tracetools/src/test_ping_loaned.cpp
+++ b/test_tracetools/src/test_ping_loaned.cpp
@@ -16,6 +16,7 @@
 #include <chrono>
 #include <cstring>
 #include <memory>
+#include <stdexcept>
 
 #include "rclcpp/rclcpp.hpp"
 #include "std_msgs/msg/u_int32.hpp"
@@ -48,6 +49,12 @@ public:
     pub_ = this->create_publisher<Msg>(
       PUB_TOPIC_NAME,
       rclcpp::QoS(QUEUE_DEPTH).transient_local());
+
+    if (!sub_->can_loan_messages() || !pub_->can_loan_messages()) {
+      throw std::runtime_error(
+              "message loaning is not available (publisher/subscription cannot loan messages)");
+    }
+
     timer_ = this->create_wall_timer(
       500ms,
       std::bind(&PingLoanedNode::timer_callback, this));

--- a/test_tracetools/src/test_ping_loaned.cpp
+++ b/test_tracetools/src/test_ping_loaned.cpp
@@ -42,7 +42,7 @@ public:
     sub_ = this->create_subscription<Msg>(
       SUB_TOPIC_NAME,
       rclcpp::QoS(QUEUE_DEPTH),
-      [this](const Msg& msg) {
+      [this](const Msg & msg) {
         this->callback(msg);
       });
     pub_ = this->create_publisher<Msg>(
@@ -57,7 +57,7 @@ public:
   : PingLoanedNode(options, true) {}
 
 private:
-  void callback(const Msg& msg)
+  void callback(const Msg & msg)
   {
     RCLCPP_INFO(this->get_logger(), "[output] %u", msg.data);
     if (do_only_one_) {
@@ -73,7 +73,7 @@ private:
     pub_->publish(std::move(out));
     if (do_only_one_) {
       timer_->cancel();
-    }  
+    }
   }
 
   rclcpp::Subscription<Msg>::SharedPtr sub_;

--- a/test_tracetools/src/test_ping_loaned.cpp
+++ b/test_tracetools/src/test_ping_loaned.cpp
@@ -1,0 +1,107 @@
+// Copyright 2019 Robert Bosch GmbH
+// Copyright 2026 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <chrono>
+#include <cstring>
+#include <memory>
+
+#include "rclcpp/rclcpp.hpp"
+#include "std_msgs/msg/u_int32.hpp"
+#include "test_tracetools/mark_process.hpp"
+
+using namespace std::chrono_literals;
+
+namespace
+{
+using Msg = std_msgs::msg::UInt32;
+}  // namespace
+
+#define NODE_NAME "test_ping_loaned"
+#define SUB_TOPIC_NAME "pong"
+#define PUB_TOPIC_NAME "ping"
+#define QUEUE_DEPTH 10
+
+class PingLoanedNode : public rclcpp::Node
+{
+public:
+  PingLoanedNode(rclcpp::NodeOptions options, bool do_only_one)
+  : Node(NODE_NAME, options), do_only_one_(do_only_one)
+  {
+    sub_ = this->create_subscription<Msg>(
+      SUB_TOPIC_NAME,
+      rclcpp::QoS(QUEUE_DEPTH),
+      [this](const Msg& msg) {
+        this->callback(msg);
+      });
+    pub_ = this->create_publisher<Msg>(
+      PUB_TOPIC_NAME,
+      rclcpp::QoS(QUEUE_DEPTH).transient_local());
+    timer_ = this->create_wall_timer(
+      500ms,
+      std::bind(&PingLoanedNode::timer_callback, this));
+  }
+
+  explicit PingLoanedNode(rclcpp::NodeOptions options)
+  : PingLoanedNode(options, true) {}
+
+private:
+  void callback(const Msg& msg)
+  {
+    RCLCPP_INFO(this->get_logger(), "[output] %u", msg.data);
+    if (do_only_one_) {
+      rclcpp::shutdown();
+    }
+  }
+
+  void timer_callback()
+  {
+    auto out = pub_->borrow_loaned_message();
+    out.get().data = 1;
+    RCLCPP_INFO(this->get_logger(), "ping");
+    pub_->publish(std::move(out));
+    if (do_only_one_) {
+      timer_->cancel();
+    }  
+  }
+
+  rclcpp::Subscription<Msg>::SharedPtr sub_;
+  rclcpp::Publisher<Msg>::SharedPtr pub_;
+  rclcpp::TimerBase::SharedPtr timer_;
+  bool do_only_one_;
+};
+
+int main(int argc, char * argv[])
+{
+  test_tracetools::mark_trace_test_process();
+
+  bool do_only_one = true;
+  for (int i = 0; i < argc; ++i) {
+    if (strncmp(argv[i], "do_more", 7) == 0) {
+      do_only_one = false;
+    }
+  }
+
+  rclcpp::init(argc, argv);
+
+  rclcpp::executors::SingleThreadedExecutor exec;
+  auto ping_node = std::make_shared<PingLoanedNode>(rclcpp::NodeOptions(), do_only_one);
+  exec.add_node(ping_node);
+
+  printf("spinning\n");
+  exec.spin();
+
+  rclcpp::shutdown();
+  return 0;
+}

--- a/test_tracetools/src/test_ping_loaned.cpp
+++ b/test_tracetools/src/test_ping_loaned.cpp
@@ -48,11 +48,11 @@ public:
       });
     pub_ = this->create_publisher<Msg>(
       PUB_TOPIC_NAME,
-      rclcpp::QoS(QUEUE_DEPTH).transient_local());
+      rclcpp::QoS(QUEUE_DEPTH));
 
-    if (!sub_->can_loan_messages() || !pub_->can_loan_messages()) {
+    if (!sub_->can_loan_messages()) {
       throw std::runtime_error(
-              "message loaning is not available (publisher/subscription cannot loan messages)");
+              "message loaning is not available (subscription cannot loan messages)");
     }
 
     timer_ = this->create_wall_timer(
@@ -74,13 +74,15 @@ private:
 
   void timer_callback()
   {
+    // If ping publishes before pong exists, the first message can be dropped and both nodes
+    // can wait forever. Only publish once a subscriber is matched.
+    if (pub_->get_subscription_count() == 0) {
+      return;
+    }
     auto out = pub_->borrow_loaned_message();
     out.get().data = 1;
     RCLCPP_INFO(this->get_logger(), "ping");
     pub_->publish(std::move(out));
-    if (do_only_one_) {
-      timer_->cancel();
-    }
   }
 
   rclcpp::Subscription<Msg>::SharedPtr sub_;

--- a/test_tracetools/src/test_pong_loaned.cpp
+++ b/test_tracetools/src/test_pong_loaned.cpp
@@ -38,10 +38,8 @@ public:
   {
     sub_ = this->create_subscription<Msg>(
       SUB_TOPIC_NAME,
-      rclcpp::QoS(10),
-      [this](const Msg & msg) {
-        this->callback(msg);
-      });
+      rclcpp::QoS(10).transient_local(),
+      std::bind(&PongLoanedNode::callback, this, std::placeholders::_1));
     pub_ = this->create_publisher<Msg>(
       PUB_TOPIC_NAME,
       rclcpp::QoS(10));
@@ -56,10 +54,9 @@ public:
   : PongLoanedNode(options, true) {}
 
 private:
-  void callback(const Msg & msg)
+  void callback(const Msg::ConstSharedPtr msg)
   {
-    (void)msg;
-    RCLCPP_INFO(this->get_logger(), "[output] pong");
+    RCLCPP_INFO(this->get_logger(), "[output] %u", msg->data);
     auto out = pub_->borrow_loaned_message();
     out.get().data = 2;
     RCLCPP_INFO(this->get_logger(), "pong");

--- a/test_tracetools/src/test_pong_loaned.cpp
+++ b/test_tracetools/src/test_pong_loaned.cpp
@@ -15,6 +15,7 @@
 
 #include <cstring>
 #include <memory>
+#include <stdexcept>
 
 #include "rclcpp/rclcpp.hpp"
 #include "std_msgs/msg/u_int32.hpp"
@@ -44,6 +45,11 @@ public:
     pub_ = this->create_publisher<Msg>(
       PUB_TOPIC_NAME,
       rclcpp::QoS(10));
+
+    if (!sub_->can_loan_messages() || !pub_->can_loan_messages()) {
+      throw std::runtime_error(
+              "message loaning is not available (publisher/subscription cannot loan messages)");
+    }
   }
 
   explicit PongLoanedNode(rclcpp::NodeOptions options)

--- a/test_tracetools/src/test_pong_loaned.cpp
+++ b/test_tracetools/src/test_pong_loaned.cpp
@@ -38,7 +38,7 @@ public:
     sub_ = this->create_subscription<Msg>(
       SUB_TOPIC_NAME,
       rclcpp::QoS(10).transient_local(),
-      [this](const Msg& msg) {
+      [this](const Msg & msg) {
         this->callback(msg);
       });
     pub_ = this->create_publisher<Msg>(
@@ -50,7 +50,7 @@ public:
   : PongLoanedNode(options, true) {}
 
 private:
-  void callback(const Msg& msg)
+  void callback(const Msg & msg)
   {
     RCLCPP_INFO(this->get_logger(), "[output] pong");
     auto out = pub_->borrow_loaned_message();

--- a/test_tracetools/src/test_pong_loaned.cpp
+++ b/test_tracetools/src/test_pong_loaned.cpp
@@ -38,7 +38,7 @@ public:
   {
     sub_ = this->create_subscription<Msg>(
       SUB_TOPIC_NAME,
-      rclcpp::QoS(10).transient_local(),
+      rclcpp::QoS(10),
       [this](const Msg & msg) {
         this->callback(msg);
       });
@@ -46,9 +46,9 @@ public:
       PUB_TOPIC_NAME,
       rclcpp::QoS(10));
 
-    if (!sub_->can_loan_messages() || !pub_->can_loan_messages()) {
+    if (!sub_->can_loan_messages()) {
       throw std::runtime_error(
-              "message loaning is not available (publisher/subscription cannot loan messages)");
+              "message loaning is not available (subscription cannot loan messages)");
     }
   }
 
@@ -58,6 +58,7 @@ public:
 private:
   void callback(const Msg & msg)
   {
+    (void)msg;
     RCLCPP_INFO(this->get_logger(), "[output] pong");
     auto out = pub_->borrow_loaned_message();
     out.get().data = 2;

--- a/test_tracetools/src/test_pong_loaned.cpp
+++ b/test_tracetools/src/test_pong_loaned.cpp
@@ -1,0 +1,92 @@
+// Copyright 2019 Robert Bosch GmbH
+// Copyright 2026 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <cstring>
+#include <memory>
+
+#include "rclcpp/rclcpp.hpp"
+#include "std_msgs/msg/u_int32.hpp"
+#include "test_tracetools/mark_process.hpp"
+
+namespace
+{
+using Msg = std_msgs::msg::UInt32;
+}  // namespace
+
+#define NODE_NAME "test_pong_loaned"
+#define SUB_TOPIC_NAME "ping"
+#define PUB_TOPIC_NAME "pong"
+
+class PongLoanedNode : public rclcpp::Node
+{
+public:
+  PongLoanedNode(rclcpp::NodeOptions options, bool do_only_one)
+  : Node(NODE_NAME, options), do_only_one_(do_only_one)
+  {
+    sub_ = this->create_subscription<Msg>(
+      SUB_TOPIC_NAME,
+      rclcpp::QoS(10).transient_local(),
+      [this](const Msg& msg) {
+        this->callback(msg);
+      });
+    pub_ = this->create_publisher<Msg>(
+      PUB_TOPIC_NAME,
+      rclcpp::QoS(10));
+  }
+
+  explicit PongLoanedNode(rclcpp::NodeOptions options)
+  : PongLoanedNode(options, true) {}
+
+private:
+  void callback(const Msg& msg)
+  {
+    RCLCPP_INFO(this->get_logger(), "[output] pong");
+    auto out = pub_->borrow_loaned_message();
+    out.get().data = 2;
+    RCLCPP_INFO(this->get_logger(), "pong");
+    pub_->publish(std::move(out));
+    if (do_only_one_) {
+      rclcpp::shutdown();
+    }
+  }
+
+  rclcpp::Subscription<Msg>::SharedPtr sub_;
+  rclcpp::Publisher<Msg>::SharedPtr pub_;
+  bool do_only_one_;
+};
+
+int main(int argc, char * argv[])
+{
+  test_tracetools::mark_trace_test_process();
+
+  bool do_only_one = true;
+  for (int i = 0; i < argc; ++i) {
+    if (strncmp(argv[i], "do_more", 7) == 0) {
+      do_only_one = false;
+    }
+  }
+
+  rclcpp::init(argc, argv);
+
+  rclcpp::executors::SingleThreadedExecutor exec;
+  auto pong_node = std::make_shared<PongLoanedNode>(rclcpp::NodeOptions(), do_only_one);
+  exec.add_node(pong_node);
+
+  printf("spinning\n");
+  exec.spin();
+
+  rclcpp::shutdown();
+  return 0;
+}

--- a/test_tracetools/test/test_pub_sub_with_message_loaning.py
+++ b/test_tracetools/test/test_pub_sub_with_message_loaning.py
@@ -13,9 +13,9 @@
 # limitations under the License.
 
 import os
+from pathlib import Path
 import tempfile
 import unittest
-from pathlib import Path
 
 from tracetools_test.case import TraceTestCase
 from tracetools_trace.tools import tracepoints as tp
@@ -25,7 +25,9 @@ from tracetools_trace.tools.lttng import is_lttng_installed
 # Enables Iceoryx shared memory in Cyclone DDS so dds_is_loan_available() can be true and
 # rmw_take_loaned_message is used (see rmw_cyclonedds/shared_memory_support.md).
 _CYCLO_DDS_SHM_XML = """<?xml version="1.0" encoding="UTF-8" ?>
-<CycloneDDS xmlns="https://cdds.io/config" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://cdds.io/config https://raw.githubusercontent.com/eclipse-cyclonedds/cyclonedds/iceoryx/etc/cyclonedds.xsd">
+<CycloneDDS xmlns="https://cdds.io/config" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="https://cdds.io/config
+    https://raw.githubusercontent.com/eclipse-cyclonedds/cyclonedds/iceoryx/etc/cyclonedds.xsd">
     <Domain id="any">
         <SharedMemory>
             <Enable>true</Enable>
@@ -259,20 +261,16 @@ class TestPubSubWithMessageLoaning(TraceTestCase):
 
         # Loaned receive path must emit rmw_take with taken=1 (see ros2_tracing#240)
         rmw_take_events = self.get_events_with_name(tp.rmw_take)
-        rmw_take_taken_events = [
-            e for e in rmw_take_events
-            if self.get_field(e, 'taken') == 1
-        ]
         pong_rmw_take_event = self.get_event_with_field_value_and_assert(
             'rmw_subscription_handle',
             pong_rmw_sub_handle,
-            rmw_take_taken_events,
+            rmw_take_events,
             allow_multiple=False,
         )
         ping_rmw_take_event = self.get_event_with_field_value_and_assert(
             'rmw_subscription_handle',
             ping_rmw_sub_handle,
-            rmw_take_taken_events,
+            rmw_take_events,
             allow_multiple=False,
         )
         self.assertFieldEquals(ping_rmw_take_event, 'taken', 1, 'ping subscription rmw_take')

--- a/test_tracetools/test/test_pub_sub_with_message_loaning.py
+++ b/test_tracetools/test/test_pub_sub_with_message_loaning.py
@@ -14,7 +14,10 @@
 
 import os
 from pathlib import Path
+import shutil
+import subprocess
 import tempfile
+import time
 import unittest
 
 from tracetools_test.case import TraceTestCase
@@ -60,8 +63,9 @@ class TestPubSubWithMessageLoaning(TraceTestCase):
     subscription loaning (ros2_tracing#240).
 
     For rmw_cyclonedds_cpp, shared memory must be enabled (CYCLONEDDS_URI) so that
-    subscription loaning and rmw_take_loaned_message are available; Iceoryx RouDi
-    (``iox-roudi``) should be running when SHM is enabled.
+    subscription loaning and rmw_take_loaned_message are available. Iceoryx RouDi
+    (``iox-roudi``) is started automatically for that RMW so CI does not need a
+    pre-started daemon.
     """
 
     def __init__(self, *args) -> None:
@@ -90,6 +94,49 @@ class TestPubSubWithMessageLoaning(TraceTestCase):
         # and the test becomes unable to validate rmw_take trace coverage for loaned-take paths.
         os.environ['ROS_DISABLE_LOANED_MESSAGES'] = '0'
         _ensure_cyclonedds_shared_memory_enabled_for_loaning()
+
+    def setUp(self) -> None:
+        self._roudi_process = None
+        if os.environ.get('RMW_IMPLEMENTATION') == 'rmw_cyclonedds_cpp':
+            roudi = shutil.which('iox-roudi')
+            if not roudi:
+                self.fail(
+                    'iox-roudi not found on PATH; required when RMW_IMPLEMENTATION is '
+                    'rmw_cyclonedds_cpp with shared memory (install Iceoryx / iceoryx_posh)',
+                )
+            self._roudi_process = subprocess.Popen(
+                [roudi],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                start_new_session=True,
+            )
+            time.sleep(0.5)
+            if self._roudi_process.poll() is not None:
+                self.fail(
+                    f'iox-roudi exited immediately with code {self._roudi_process.returncode}',
+                )
+        try:
+            super().setUp()
+        except Exception:
+            self._stop_roudi()
+            raise
+
+    def tearDown(self) -> None:
+        try:
+            super().tearDown()
+        finally:
+            self._stop_roudi()
+
+    def _stop_roudi(self) -> None:
+        p = getattr(self, '_roudi_process', None)
+        if p is None:
+            return
+        self._roudi_process = None
+        p.terminate()
+        try:
+            p.wait(timeout=10.0)
+        except subprocess.TimeoutExpired:
+            p.kill()
 
     def test_all(self):
         # Check events as set

--- a/test_tracetools/test/test_pub_sub_with_message_loaning.py
+++ b/test_tracetools/test/test_pub_sub_with_message_loaning.py
@@ -12,11 +12,40 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
+import tempfile
 import unittest
+from pathlib import Path
 
 from tracetools_test.case import TraceTestCase
 from tracetools_trace.tools import tracepoints as tp
 from tracetools_trace.tools.lttng import is_lttng_installed
+
+
+# Enables Iceoryx shared memory in Cyclone DDS so dds_is_loan_available() can be true and
+# rmw_take_loaned_message is used (see rmw_cyclonedds/shared_memory_support.md).
+_CYCLO_DDS_SHM_XML = """<?xml version="1.0" encoding="UTF-8" ?>
+<CycloneDDS xmlns="https://cdds.io/config" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://cdds.io/config https://raw.githubusercontent.com/eclipse-cyclonedds/cyclonedds/iceoryx/etc/cyclonedds.xsd">
+    <Domain id="any">
+        <SharedMemory>
+            <Enable>true</Enable>
+            <LogLevel>warn</LogLevel>
+        </SharedMemory>
+    </Domain>
+</CycloneDDS>
+"""
+
+
+def _ensure_cyclonedds_shared_memory_enabled_for_loaning() -> None:
+    """If unset, point CYCLONEDDS_URI at a minimal config with SharedMemory enabled."""
+    if os.environ.get('RMW_IMPLEMENTATION') != 'rmw_cyclonedds_cpp':
+        return
+    if os.environ.get('CYCLONEDDS_URI'):
+        return
+    fd, path = tempfile.mkstemp(prefix='tracetools_pub_sub_loaning_', suffix='.xml')
+    with os.fdopen(fd, 'w') as f:
+        f.write(_CYCLO_DDS_SHM_XML)
+    os.environ['CYCLONEDDS_URI'] = Path(path).as_uri()
 
 
 @unittest.skipIf(not is_lttng_installed(minimum_version='2.9.0'), 'LTTng is required')
@@ -27,6 +56,10 @@ class TestPubSubWithMessageLoaning(TraceTestCase):
     Registered in CMake only for rmw_cyclonedds_cpp, rmw_fastrtps_cpp, and
     rmw_fastrtps_dynamic_cpp. Uses std_msgs/msg/UInt32 so middleware can enable
     subscription loaning (ros2_tracing#240).
+
+    For rmw_cyclonedds_cpp, shared memory must be enabled (CYCLONEDDS_URI) so that
+    subscription loaning and rmw_take_loaned_message are available; Iceoryx RouDi
+    (``iox-roudi``) should be running when SHM is enabled.
     """
 
     def __init__(self, *args) -> None:
@@ -50,6 +83,11 @@ class TestPubSubWithMessageLoaning(TraceTestCase):
             package='test_tracetools',
             nodes=['test_ping_loaned', 'test_pong_loaned'],
         )
+        # Loaned message take on subscriptions is disabled by default in Rolling.
+        # This test must explicitly enable it, otherwise the executor falls back to non-loaned take
+        # and the test becomes unable to validate rmw_take trace coverage for loaned-take paths.
+        os.environ['ROS_DISABLE_LOANED_MESSAGES'] = '0'
+        _ensure_cyclonedds_shared_memory_enabled_for_loaning()
 
     def test_all(self):
         # Check events as set

--- a/test_tracetools/test/test_pub_sub_with_message_loaning.py
+++ b/test_tracetools/test/test_pub_sub_with_message_loaning.py
@@ -1,0 +1,313 @@
+# Copyright 2026 Christophe Bedard
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+from tracetools_test.case import TraceTestCase
+from tracetools_trace.tools import tracepoints as tp
+from tracetools_trace.tools.lttng import is_lttng_installed
+
+
+@unittest.skipIf(not is_lttng_installed(minimum_version='2.9.0'), 'LTTng is required')
+class TestPubSubWithMessageLoaning(TraceTestCase):
+    """
+    Tracing for pub/sub when subscriptions use rclcpp's loaned (unique_ptr) callback path.
+
+    Registered in CMake only for rmw_cyclonedds_cpp, rmw_fastrtps_cpp, and
+    rmw_fastrtps_dynamic_cpp. Uses std_msgs/msg/UInt32 so middleware can enable
+    subscription loaning (ros2_tracing#240).
+    """
+
+    def __init__(self, *args) -> None:
+        super().__init__(
+            *args,
+            session_name_prefix='session-test-pub-sub-loaned',
+            events_ros=[
+                tp.rmw_publisher_init,
+                tp.rcl_publisher_init,
+                tp.rmw_publish,
+                tp.rcl_publish,
+                tp.rclcpp_publish,
+                tp.rmw_subscription_init,
+                tp.rcl_subscription_init,
+                tp.rclcpp_subscription_init,
+                tp.rclcpp_subscription_callback_added,
+                tp.rmw_take,
+                tp.callback_start,
+                tp.callback_end,
+            ],
+            package='test_tracetools',
+            nodes=['test_ping_loaned', 'test_pong_loaned'],
+        )
+
+    def test_all(self):
+        # Check events as set
+        self.assertEventsSet(self._events_ros)
+
+        # Get publisher init events & publisher handles of test topics
+        rmw_pub_init_events = self.get_events_with_name(tp.rmw_publisher_init)
+        rmw_sub_init_events = self.get_events_with_name(tp.rmw_subscription_init)
+        publisher_init_events = self.get_events_with_name(tp.rcl_publisher_init)
+        ping_publisher_init_event = self.get_event_with_field_value_and_assert(
+            'topic_name',
+            '/ping',
+            publisher_init_events,
+            allow_multiple=False,
+        )
+        pong_publisher_init_event = self.get_event_with_field_value_and_assert(
+            'topic_name',
+            '/pong',
+            publisher_init_events,
+            allow_multiple=False,
+        )
+        ping_pub_handle = self.get_field(ping_publisher_init_event, 'publisher_handle')
+        ping_rmw_pub_handle = self.get_field(ping_publisher_init_event, 'rmw_publisher_handle')
+        pong_pub_handle = self.get_field(pong_publisher_init_event, 'publisher_handle')
+        pong_rmw_pub_handle = self.get_field(pong_publisher_init_event, 'rmw_publisher_handle')
+
+        # Find corresponding rmw_pub_init events
+        ping_rmw_pub_init_event = self.get_event_with_field_value_and_assert(
+            'rmw_publisher_handle',
+            ping_rmw_pub_handle,
+            rmw_pub_init_events,
+            allow_multiple=False,
+        )
+        pong_rmw_pub_init_event = self.get_event_with_field_value_and_assert(
+            'rmw_publisher_handle',
+            pong_rmw_pub_handle,
+            rmw_pub_init_events,
+            allow_multiple=False,
+        )
+
+        # Check publisher init order (rmw then rcl)
+        self.assertEventOrder([
+            ping_rmw_pub_init_event,
+            ping_publisher_init_event,
+        ])
+        self.assertEventOrder([
+            pong_rmw_pub_init_event,
+            pong_publisher_init_event,
+        ])
+
+        # Get corresponding rmw/rcl/rclcpp publish events for ping & pong
+        rmw_publish_events = self.get_events_with_name(tp.rmw_publish)
+        ping_rmw_pub_event = self.get_event_with_field_value_and_assert(
+            'rmw_publisher_handle',
+            ping_rmw_pub_handle,
+            rmw_publish_events,
+            allow_multiple=False,
+        )
+        pong_rmw_pub_event = self.get_event_with_field_value_and_assert(
+            'rmw_publisher_handle',
+            pong_rmw_pub_handle,
+            rmw_publish_events,
+            allow_multiple=False,
+        )
+        ping_pub_message = self.get_field(ping_rmw_pub_event, 'message')
+        pong_pub_message = self.get_field(pong_rmw_pub_event, 'message')
+
+        rclcpp_publish_events = self.get_events_with_name(tp.rclcpp_publish)
+        rcl_publish_events = self.get_events_with_name(tp.rcl_publish)
+        ping_rclcpp_pub_event = self.get_event_with_field_value_and_assert(
+            'message',
+            ping_pub_message,
+            rclcpp_publish_events,
+            allow_multiple=False,
+        )
+        pong_rclcpp_pub_event = self.get_event_with_field_value_and_assert(
+            'message',
+            pong_pub_message,
+            rclcpp_publish_events,
+            allow_multiple=False,
+        )
+        ping_rcl_pub_event = self.get_event_with_field_value_and_assert(
+            'message',
+            ping_pub_message,
+            rcl_publish_events,
+            allow_multiple=False,
+        )
+        pong_rcl_pub_event = self.get_event_with_field_value_and_assert(
+            'message',
+            pong_pub_message,
+            rcl_publish_events,
+            allow_multiple=False,
+        )
+        self.assertFieldEquals(ping_rcl_pub_event, 'publisher_handle', ping_pub_handle)
+        self.assertFieldEquals(pong_rcl_pub_event, 'publisher_handle', pong_pub_handle)
+
+        # Get subscription init events & subscription handles of test topics
+        rcl_subscription_init_events = self.get_events_with_name(tp.rcl_subscription_init)
+        ping_rcl_subscription_init_event = self.get_event_with_field_value_and_assert(
+            'topic_name',
+            '/ping',
+            rcl_subscription_init_events,
+            allow_multiple=False,
+        )
+        pong_rcl_subscription_init_event = self.get_event_with_field_value_and_assert(
+            'topic_name',
+            '/pong',
+            rcl_subscription_init_events,
+            allow_multiple=False,
+        )
+        ping_sub_handle = self.get_field(ping_rcl_subscription_init_event, 'subscription_handle')
+        ping_rmw_sub_handle = \
+            self.get_field(ping_rcl_subscription_init_event, 'rmw_subscription_handle')
+        pong_sub_handle = self.get_field(pong_rcl_subscription_init_event, 'subscription_handle')
+        pong_rmw_sub_handle = \
+            self.get_field(pong_rcl_subscription_init_event, 'rmw_subscription_handle')
+
+        # Find corresponding rmw_sub_init events
+        ping_rmw_sub_init_event = self.get_event_with_field_value_and_assert(
+            'rmw_subscription_handle',
+            ping_rmw_sub_handle,
+            rmw_sub_init_events,
+            allow_multiple=False,
+        )
+        pong_rmw_sub_init_event = self.get_event_with_field_value_and_assert(
+            'rmw_subscription_handle',
+            pong_rmw_sub_handle,
+            rmw_sub_init_events,
+            allow_multiple=False,
+        )
+
+        # Get corresponding subscription objects
+        rclcpp_subscription_init_events = self.get_events_with_name(
+            tp.rclcpp_subscription_init,
+        )
+        ping_rclcpp_subscription_init_event = self.get_event_with_field_value_and_assert(
+            'subscription_handle',
+            ping_sub_handle,
+            rclcpp_subscription_init_events,
+            allow_multiple=False,
+        )
+        pong_rclcpp_subscription_init_event = self.get_event_with_field_value_and_assert(
+            'subscription_handle',
+            pong_sub_handle,
+            rclcpp_subscription_init_events,
+            allow_multiple=False,
+        )
+        ping_sub_object = self.get_field(ping_rclcpp_subscription_init_event, 'subscription')
+        pong_sub_object = self.get_field(pong_rclcpp_subscription_init_event, 'subscription')
+
+        # Get corresponding subscription callback objects
+        rclcpp_subscription_callback_events = self.get_events_with_name(
+            tp.rclcpp_subscription_callback_added,
+        )
+        ping_rclcpp_subscription_callback_event = self.get_event_with_field_value_and_assert(
+            'subscription',
+            ping_sub_object,
+            rclcpp_subscription_callback_events,
+            allow_multiple=False,
+        )
+        pong_rclcpp_subscription_callback_event = self.get_event_with_field_value_and_assert(
+            'subscription',
+            pong_sub_object,
+            rclcpp_subscription_callback_events,
+            allow_multiple=False,
+        )
+        ping_callback_object = self.get_field(ping_rclcpp_subscription_callback_event, 'callback')
+        pong_callback_object = self.get_field(pong_rclcpp_subscription_callback_event, 'callback')
+
+        # Loaned receive path must emit rmw_take with taken=1 (see ros2_tracing#240)
+        rmw_take_events = self.get_events_with_name(tp.rmw_take)
+        rmw_take_taken_events = [
+            e for e in rmw_take_events
+            if self.get_field(e, 'taken') == 1
+        ]
+        pong_rmw_take_event = self.get_event_with_field_value_and_assert(
+            'rmw_subscription_handle',
+            pong_rmw_sub_handle,
+            rmw_take_taken_events,
+            allow_multiple=False,
+        )
+        ping_rmw_take_event = self.get_event_with_field_value_and_assert(
+            'rmw_subscription_handle',
+            ping_rmw_sub_handle,
+            rmw_take_taken_events,
+            allow_multiple=False,
+        )
+        self.assertFieldEquals(ping_rmw_take_event, 'taken', 1, 'ping subscription rmw_take')
+        self.assertFieldEquals(pong_rmw_take_event, 'taken', 1, 'pong subscription rmw_take')
+
+        # Check that pub->sub timestamps match
+        ping_timestamp = self.get_field(ping_rmw_pub_event, 'timestamp')
+        self.assertFieldEquals(ping_rmw_take_event, 'source_timestamp', ping_timestamp)
+        pong_timestamp = self.get_field(pong_rmw_pub_event, 'timestamp')
+        self.assertFieldEquals(pong_rmw_take_event, 'source_timestamp', pong_timestamp)
+
+        # Check subscription init order
+        self.assertEventOrder([
+            ping_rmw_sub_init_event,
+            ping_rcl_subscription_init_event,
+            ping_rclcpp_subscription_init_event,
+            ping_rclcpp_subscription_callback_event,
+        ])
+        self.assertEventOrder([
+            pong_rmw_sub_init_event,
+            pong_rcl_subscription_init_event,
+            pong_rclcpp_subscription_init_event,
+            pong_rclcpp_subscription_callback_event,
+        ])
+
+        # Get corresponding callback start/end events
+        callback_start_events = self.get_events_with_name(tp.callback_start)
+        callback_end_events = self.get_events_with_name(tp.callback_end)
+        ping_callback_start_event = self.get_event_with_field_value_and_assert(
+            'callback',
+            ping_callback_object,
+            callback_start_events,
+            allow_multiple=False,
+        )
+        pong_callback_start_event = self.get_event_with_field_value_and_assert(
+            'callback',
+            pong_callback_object,
+            callback_start_events,
+            allow_multiple=False,
+        )
+        ping_callback_end_event = self.get_event_with_field_value_and_assert(
+            'callback',
+            ping_callback_object,
+            callback_end_events,
+            allow_multiple=False,
+        )
+        pong_callback_end_event = self.get_event_with_field_value_and_assert(
+            'callback',
+            pong_callback_object,
+            callback_end_events,
+            allow_multiple=False,
+        )
+
+        self.assertEventOrder([
+            ping_rclcpp_pub_event,
+            ping_rcl_pub_event,
+            ping_rmw_pub_event,
+            ping_rmw_take_event,
+            ping_callback_start_event,
+            pong_rclcpp_pub_event,
+            pong_rcl_pub_event,
+            pong_rmw_pub_event,
+            ping_callback_end_event,
+        ])
+        self.assertEventOrder([
+            pong_rclcpp_pub_event,
+            pong_rcl_pub_event,
+            pong_rmw_pub_event,
+            pong_rmw_take_event,
+            pong_callback_start_event,
+            pong_callback_end_event,
+        ])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Description

This provides unit tests for the tracepoints added in [rmw_cyclonedds PR#556](https://github.com/ros2/rmw_cyclonedds/pull/566) and [rmw_fastrtps PR#871](https://github.com/ros2/rmw_fastrtps/pull/871), confirming that the rmw_take tracepoint is called even when using zero-copy

Fixes #240 

### Is this user-facing behavior change?

No

### Did you use Generative AI?

Yes, the initial draft was written entirely in Cursor's agentic tool. Review and revisions were done with a human (except the _CYCLO_DDS_SHM_XML string, which was AI generated)

### Additional Information


