### PR TITLE
Work around segfault when reading trace with babeltrace1 Python API

### DIFF
--- a/tracetools_read/tracetools_read/__init__.py
+++ b/tracetools_read/tracetools_read/__init__.py
@@ -18,10 +18,6 @@ from typing import Any
 from typing import Dict
 from typing import List
 
-import babeltrace
-import babeltrace.babeltrace as _bt_impl
-
-
 # Workaround for a long-standing bug in babeltrace1's Python bindings
 # (python3-babeltrace 1.5.11) that causes a segfault on Python 3.14, see
 # https://github.com/ros2/ros2_tracing/issues/245.
@@ -31,26 +27,32 @@ import babeltrace.babeltrace as _bt_impl
 # SWIG then returns [NULL, garbage], and the upstream wrapper iterates
 # `range(garbage)` and dereferences NULL. On Python 3.12 the stack slot
 # happened to be zero; on 3.14 it isn't, so we crash.
+# Skipped on platforms without babeltrace (e.g., Windows): the rest of this
+# module works without it; only `tracetools_read.trace` actually needs it.
 # TODO(christophebedard): remove once fixed or once we migrate to bt2
-def _safe_field_list_with_scope(self: 'babeltrace.babeltrace.Event', scope: int) -> list:
-    fields: list = []
-    scope_ptr = _bt_impl._bt_ctf_get_top_level_scope(self._e, scope)
-    if scope_ptr is None:
-        return fields  # avoid the buggy C error path entirely
-    ret = _bt_impl._bt_python_field_listcaller(self._e, scope_ptr)
-    if not isinstance(ret, list):
+try:
+    import babeltrace.babeltrace as _bt_impl
+except ImportError:
+    pass
+else:
+    def _safe_field_list_with_scope(self, scope: int) -> list:
+        fields: list = []
+        scope_ptr = _bt_impl._bt_ctf_get_top_level_scope(self._e, scope)
+        if scope_ptr is None:
+            return fields  # avoid the buggy C error path entirely
+        ret = _bt_impl._bt_python_field_listcaller(self._e, scope_ptr)
+        if not isinstance(ret, list):
+            return fields
+        list_ptr, count = ret
+        if list_ptr is None:
+            return fields
+        for i in range(count):
+            definition_ptr = _bt_impl._bt_python_field_one_from_list(list_ptr, i)
+            if definition_ptr is not None:
+                fields.append(_bt_impl._Definition(definition_ptr, scope))
         return fields
-    list_ptr, count = ret
-    if list_ptr is None:
-        return fields
-    for i in range(count):
-        definition_ptr = _bt_impl._bt_python_field_one_from_list(list_ptr, i)
-        if definition_ptr is not None:
-            fields.append(_bt_impl._Definition(definition_ptr, scope))
-    return fields
 
-
-_bt_impl.Event._field_list_with_scope = _safe_field_list_with_scope
+    _bt_impl.Event._field_list_with_scope = _safe_field_list_with_scope
 
 
 DictEvent = Dict[str, Any]

--- a/tracetools_read/tracetools_read/__init__.py
+++ b/tracetools_read/tracetools_read/__init__.py
@@ -18,6 +18,40 @@ from typing import Any
 from typing import Dict
 from typing import List
 
+import babeltrace
+import babeltrace.babeltrace as _bt_impl
+
+
+# Workaround for a long-standing bug in babeltrace1's Python bindings
+# (python3-babeltrace 1.5.11) that causes a segfault on Python 3.14, see
+# https://github.com/ros2/ros2_tracing/issues/245.
+# `_bt_python_field_listcaller` in python-complements.c does not initialize
+# its `*len` OUTPUT parameter when `bt_ctf_get_field_list` returns an error
+# (e.g. when an event has no fields in a given CTF scope, like EVENT_CONTEXT).
+# SWIG then returns [NULL, garbage], and the upstream wrapper iterates
+# `range(garbage)` and dereferences NULL. On Python 3.12 the stack slot
+# happened to be zero; on 3.14 it isn't, so we crash.
+# TODO(christophebedard): remove once fixed or once we migrate to bt2
+def _safe_field_list_with_scope(self: 'babeltrace.babeltrace.Event', scope: int) -> list:
+    fields: list = []
+    scope_ptr = _bt_impl._bt_ctf_get_top_level_scope(self._e, scope)
+    if scope_ptr is None:
+        return fields  # avoid the buggy C error path entirely
+    ret = _bt_impl._bt_python_field_listcaller(self._e, scope_ptr)
+    if not isinstance(ret, list):
+        return fields
+    list_ptr, count = ret
+    if list_ptr is None:
+        return fields
+    for i in range(count):
+        definition_ptr = _bt_impl._bt_python_field_one_from_list(list_ptr, i)
+        if definition_ptr is not None:
+            fields.append(_bt_impl._Definition(definition_ptr, scope))
+    return fields
+
+
+_bt_impl.Event._field_list_with_scope = _safe_field_list_with_scope
+
 
 DictEvent = Dict[str, Any]
 


### PR DESCRIPTION
## Description

Fixes #245

I've confirmed that this works against my reproducer in #244 and that all `test_tracetools` tests pass on Ubuntu 26.04.

Explanation from Claude:

> On Python 3.14 / Ubuntu 26.04, the babeltrace1 Python bindings (python3-babeltrace 1.5.11) segfault when reading a trace.
> 
> The C helper `_bt_python_field_listcaller` in python-complements.c fails to initialize its `*len` OUTPUT parameter when the underlying `bt_ctf_get_field_list` returns an error -- which it does whenever an event has no fields in a given CTF scope (e.g. EVENT_CONTEXT). SWIG then hands Python `[NULL, garbage_count]`, and the wrapper `Event._field_list_with_scope` iterates `range(garbage_count)` and calls `_bt_python_field_one_from_list(NULL, 0)`, which dereferences NULL.
> 
> This is undefined behavior, not a Python 3.14 bug. On Python 3.12 the uninitialized stack slot happened to be zero, so the loop was a no-op; on 3.14 it contains garbage and we crash.
> 
> Work around it by monkey-patching `Event._field_list_with_scope` on import to bail out when the scope pointer is NULL (the actual trigger), with a secondary guard for a NULL list pointer. The proper fix belongs upstream in babeltrace1's python-complements.c.

### Is this user-facing behavior change?

No, just a bugfix. And note that we only read traces using babeltrace as part of tests. It's not a ROS 2 feature or anything.

### Did you use Generative AI?

This is all Claude Opus 4.7 with 1M context. The root cause of the issue seems very plausible. This workaround seems fine and definitely works.

### Additional Information

See the full explanation here: https://github.com/ros2/ros2_tracing/issues/245#issuecomment-4348396622

I will fix/report this upstream, but they might decide not to fix it (or maybe they will since it's a one-liner), since babeltrace1 has been replaced by babeltrace2. This might be a good opportunity to finally move to babeltrace2/bt2 #22.