### PR TITLE
Ignore rti-connext-dds-7.7.0 in sanity check CI job

### DIFF
--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -76,7 +76,7 @@ jobs:
         vcs import src/ --input https://raw.githubusercontent.com/ros2/ros2/${{ matrix.distro }}/ros2.repos --skip-existing
         vcs log -l1 src/
         rosdep update
-        rosdep install -r --from-paths src --ignore-src -y --rosdistro ${{ matrix.distro }} --skip-keys "fastcdr rti-connext-dds-7.3.0 urdfdom_headers"
+        rosdep install -r --from-paths src --ignore-src -y --rosdistro ${{ matrix.distro }} --skip-keys "fastcdr rti-connext-dds-7.7.0 urdfdom_headers"
         colcon build --packages-up-to tracetools ros2run ros2launch demo_nodes_cpp tracetools_launch test_tracetools
     - name: Make sure that tracing instrumentation is available
       run: |


### PR DESCRIPTION
Connext was bumped from 7.3.0 to 7.7.0, so update the ignored rosdep key.

## Description

Fixes this in the sanity check CI job: https://github.com/ros2/ros2_tracing/actions/runs/25181821412/job/73828733417?pr=244

```
ERROR: the following rosdeps failed to install
  apt: command [apt-get install -y rti-connext-dds-7.7.0-ros] failed
  apt: Failed to detect successful installation of [rti-connext-dds-7.7.0-ros]
```

Connext was bumped from 7.3.0 to 7.7.0, so update the ignored rosdep key.

### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

### Additional Information

Should be backported to Lyrical (which will need an update to its CI config anyway).