### PR TITLE
Bump GitHub CI to Ubuntu 26.04 Resolute

### DIFF
--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -5,9 +5,9 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Set up Python 3.x
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: '3.x'
     - name: Check DCO

--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -21,7 +21,7 @@ jobs:
         distro:
           - rolling
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         path: ws/src/ros2/ros2_tracing
     - uses: ros-tooling/setup-ros@main
@@ -66,7 +66,7 @@ jobs:
         distro:
           - rolling
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         path: ws/src/ros2/ros2_tracing
     - uses: ros-tooling/setup-ros@main

--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -30,8 +30,8 @@ jobs:
         use-ros2-testing: true
     - name: Install other dependencies
       run: |
-        sudo apt-get update
-        sudo apt-get install -y -q ros-${{ matrix.distro }}-*tracetools* babeltrace
+        sudo apt update
+        sudo apt install -y -q ros-${{ matrix.distro }}-*tracetools* babeltrace
     - name: Make sure that tracing instrumentation is available
       run: |
         source /opt/ros/${{ matrix.distro }}/setup.bash
@@ -77,6 +77,7 @@ jobs:
         vcs log -l1 src/
         rosdep update
         rosdep install -r --from-paths src --ignore-src -y --rosdistro ${{ matrix.distro }} --skip-keys "fastcdr rti-connext-dds-7.7.0 urdfdom_headers"
+        sudo apt install -y -q babeltrace
         colcon build --packages-up-to tracetools ros2run ros2launch demo_nodes_cpp tracetools_launch test_tracetools
     - name: Make sure that tracing instrumentation is available
       run: |
@@ -100,7 +101,7 @@ jobs:
         (! ros2 run tracetools status)
     - name: Remove LTTng-UST
       run: |
-        sudo apt-get purge -y liblttng-ust-dev
+        sudo apt purge -y liblttng-ust-dev
     - name: Make sure building tracetools without LTTng fails
       run: |
         cd $GITHUB_WORKSPACE/ws

--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -13,7 +13,7 @@ jobs:
   binary:
     runs-on: ubuntu-latest
     container:
-      image: ubuntu:24.04
+      image: ubuntu:26.04
     continue-on-error: true
     strategy:
       fail-fast: false
@@ -58,7 +58,7 @@ jobs:
   source:
     runs-on: ubuntu-latest
     container:
-      image: ubuntu:24.04
+      image: ubuntu:26.04
     continue-on-error: true
     strategy:
       fail-fast: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,7 +46,7 @@ jobs:
     env:
       ROS2_REPOS_FILE_URL: 'https://raw.githubusercontent.com/ros2/ros2/${{ matrix.distro }}/ros2.repos'
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - uses: ros-tooling/setup-ros@main
       with:
         required-ros-distributions: ${{ matrix.build-type == 'binary' && matrix.distro || '' }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,6 +51,21 @@ jobs:
       with:
         required-ros-distributions: ${{ matrix.build-type == 'binary' && matrix.distro || '' }}
         use-ros2-testing: true
+    # Pin Fast-DDS to a known-good commit to work around a GCC 15 -Werror=maybe-uninitialized
+    # build failure introduced by https://github.com/eProsima/Fast-DDS/pull/6370 on the 3.6.x branch.
+    - name: Pin Fast-DDS commit
+      if: matrix.build-type == 'source'
+      run: |
+        curl -sL "${ROS2_REPOS_FILE_URL}" -o ros2.repos.upstream
+        python3 - <<'PY'
+        import yaml
+        with open('ros2.repos.upstream') as f:
+            data = yaml.safe_load(f)
+        data['repositories']['eProsima/Fast-DDS']['version'] = '621f6d8267708d6ca311af880ad3f6820271e6a4'
+        with open('ros2.repos.pinned', 'w') as f:
+            yaml.safe_dump(data, f)
+        PY
+        echo "ROS2_REPOS_FILE_URL=${GITHUB_WORKSPACE}/ros2.repos.pinned" >> "${GITHUB_ENV}"
     - uses: ros-tooling/action-ros-ci@main
       with:
         package-name: >

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,25 +20,25 @@ jobs:
       matrix:
         include:
           # Normal build (binary)
-          - os: ubuntu:24.04
+          - os: ubuntu:26.04
             distro: rolling
             build-type: binary
             instrumentation: instr-enabled
             tracepoints: tp-included
           # Normal build (source)
-          - os: ubuntu:24.04
+          - os: ubuntu:26.04
             distro: rolling
             build-type: source
             instrumentation: instr-enabled
             tracepoints: tp-included
           # Build with instrumentation disabled
-          - os: ubuntu:24.04
+          - os: ubuntu:26.04
             distro: rolling
             build-type: source
             instrumentation: instr-disabled
             tracepoints: tp-included
           # Normal build with tracepoints excluded
-          - os: ubuntu:24.04
+          - os: ubuntu:26.04
             distro: rolling
             build-type: source
             instrumentation: instr-enabled

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,21 +51,6 @@ jobs:
       with:
         required-ros-distributions: ${{ matrix.build-type == 'binary' && matrix.distro || '' }}
         use-ros2-testing: true
-    # Pin Fast-DDS to a known-good commit to work around a GCC 15 -Werror=maybe-uninitialized
-    # build failure introduced by https://github.com/eProsima/Fast-DDS/pull/6370 on the 3.6.x branch.
-    - name: Pin Fast-DDS commit
-      if: matrix.build-type == 'source'
-      run: |
-        curl -sL "${ROS2_REPOS_FILE_URL}" -o ros2.repos.upstream
-        python3 - <<'PY'
-        import yaml
-        with open('ros2.repos.upstream') as f:
-            data = yaml.safe_load(f)
-        data['repositories']['eProsima/Fast-DDS']['version'] = '621f6d8267708d6ca311af880ad3f6820271e6a4'
-        with open('ros2.repos.pinned', 'w') as f:
-            yaml.safe_dump(data, f)
-        PY
-        echo "ROS2_REPOS_FILE_URL=${GITHUB_WORKSPACE}/ros2.repos.pinned" >> "${GITHUB_ENV}"
     - uses: ros-tooling/action-ros-ci@main
       with:
         package-name: >


### PR DESCRIPTION
## Description

Rolling has migrated to Ubuntu 26.04 Resolute. Also, bump some action versions.

Also, explicitly install babeltrace CLI for Resolute source sanity check job. lttng-tools gets installed by rosdep because it's a dependency of tracetools. In [24.04 and older](https://packages.ubuntu.com/noble/lttng-tools), it also depends on babeltrace (the CLI), but [on 26.04](https://packages.ubuntu.com/resolute/lttng-tools), it switched to depending on babeltrace2. We need to switch to babeltrace2, but for now just explicitly install babeltrace in the source sanity check job.

### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->

Backport to Lyrical. We will separately need to change "rolling" to "lyrical" in the CI config matrices for it.