### PR TITLE
Use rmw isolation in test_tracetools_launch & test_ros2trace tests

### DIFF
--- a/test_ros2trace/package.xml
+++ b/test_ros2trace/package.xml
@@ -18,6 +18,7 @@
   <test_depend>ament_xmllint</test_depend>
   <test_depend>launch</test_depend>
   <test_depend>launch_ros</test_depend>
+  <test_depend>launch_testing_ros</test_depend>
   <test_depend>lttngpy</test_depend>
   <test_depend>python3-pytest</test_depend>
   <test_depend>ros2run</test_depend>

--- a/test_ros2trace/test/test_ros2trace/test_trace.py
+++ b/test_ros2trace/test/test_ros2trace/test_trace.py
@@ -27,6 +27,7 @@ import unittest
 from launch import LaunchDescription
 from launch import LaunchService
 from launch_ros.actions import Node
+from launch_testing_ros.actions import EnableRmwIsolation
 from lttngpy import impl as lttngpy
 from tracetools_read import get_event_name
 from tracetools_test.mark_process import get_corresponding_trace_test_events
@@ -290,7 +291,8 @@ class TestROS2TraceCLI(unittest.TestCase):
                 additional_env=additional_env,
             ),
         ]
-        ld = LaunchDescription(nodes)
+        # Explicitly order EnableRmwIsolation first so it executes before nodes
+        ld = LaunchDescription([EnableRmwIsolation(), *nodes])
         ls = LaunchService()
         ls.include_launch_description(ld)
         exit_code = ls.run()

--- a/test_tracetools_launch/package.xml
+++ b/test_tracetools_launch/package.xml
@@ -19,6 +19,7 @@
   <test_depend>ament_xmllint</test_depend>
   <test_depend>launch</test_depend>
   <test_depend>launch_ros</test_depend>
+  <test_depend>launch_testing_ros</test_depend>
   <test_depend>launch_xml</test_depend>
   <test_depend>launch_yaml</test_depend>
   <test_depend>python3-pytest</test_depend>

--- a/test_tracetools_launch/test/test_tracetools_launch/test_trace_action.py
+++ b/test_tracetools_launch/test/test_tracetools_launch/test_trace_action.py
@@ -38,6 +38,7 @@ from launch.substitutions import TextSubstitution
 from launch.utilities import perform_substitutions
 from launch.utilities.type_utils import perform_typed_substitution
 from launch_ros.actions import Node
+from launch_testing_ros.actions import EnableRmwIsolation
 
 from tracetools_launch.action import Trace
 from tracetools_trace.tools.lttng import is_lttng_installed
@@ -59,7 +60,8 @@ class TestTraceAction(unittest.TestCase):
             del os.environ['LD_PRELOAD']
 
     def _assert_launch(self, actions: List[Action]) -> Tuple[int, LaunchContext]:
-        ld = LaunchDescription(actions)
+        # Explicitly order EnableRmwIsolation first so it executes before nodes, if any
+        ld = LaunchDescription([EnableRmwIsolation(), *actions])
         ls = LaunchService(debug=True)
         ls.include_launch_description(ld)
         return ls.run(), ls.context
@@ -78,7 +80,9 @@ class TestTraceAction(unittest.TestCase):
         root_entity, parser = Parser.load(file)
         ld = parser.parse_description(root_entity)
         ls = LaunchService()
-        ls.include_launch_description(ld)
+        # Explicitly order EnableRmwIsolation first so it executes before nodes, if any
+        ls.include_launch_description(
+            LaunchDescription([EnableRmwIsolation(), *ld.entities]))
         self.assertEqual(0, ls.run(), 'expected no errors')
         trace_action = next(
             (action for action in ld.entities if isinstance(action, Trace)),


### PR DESCRIPTION
## Description

The goal is to fix `test_tracetools_launch`'s `test_trace_action` hanging (#252). If this works, I might re-enable `test_ros2trace`'s `test_trace` and see if #166 still happens (see #218).

`test_tracetools` tests already use `rmw` isolation through `ament_add_ros_isolated_pytest_test()`.

### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?

Yes, Claude Opus 4.7 with 1M context to search for `rmw` isolation examples.

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
