### PR TITLE
Revert "Skip test_ros2trace's tracing tests for now (#218)"

### DIFF
--- a/test_ros2trace/test/test_ros2trace/test_trace.py
+++ b/test_ros2trace/test/test_ros2trace/test_trace.py
@@ -74,7 +74,6 @@ def skip_if_no_kernel_tracing(func):
     return wrapper
 
 
-@unittest.skip('FIXME(christophebedard): sometimes hangs in CI (#166)')
 @unittest.skipIf(not is_lttng_installed(minimum_version='2.9.0'), 'LTTng is required')
 class TestROS2TraceCLI(unittest.TestCase):
 


### PR DESCRIPTION
## Description

Relates to #166

The issue in #166 is similar to #252, which was seemingly fixed by using `rmw` isolation in lauch tests: #253. That PR also added `rmw` isolation to the tests mentioned in #166, so I'm reverting #218 to start running the tests again and see if they're still hanging.

Once this is merged, I'll monitor nightly CI for some days and see if `test_ros2trace` tests hang. If not, I'll backport this to `lyrical` and close #166. If they do start hanging again, I'll re-apply #218 and go from there.

### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
