### PR TITLE
Isolate tracing tests with private LTTng homes

### DIFF
--- a/test_ros2trace/package.xml
+++ b/test_ros2trace/package.xml
@@ -29,12 +29,6 @@
   <test_depend>tracetools_test</test_depend>
   <test_depend>tracetools_trace</test_depend>
 
-  <!-- TODO(clalancette): This is actually a false dependency,
-	  but we add it here to ensure that we don't run multiple
-	  tracing tests in parallel, which often ends up crashing.
-  -->
-  <test_depend>test_tracetools_launch</test_depend>
-
   <export>
     <build_type>ament_python</build_type>
   </export>

--- a/test_ros2trace/test/conftest.py
+++ b/test_ros2trace/test/conftest.py
@@ -1,0 +1,25 @@
+# Copyright 2026 Sylvester Kaczmarek
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Iterator
+
+import pytest
+from tracetools_test.lttng import isolated_lttng_home
+
+
+@pytest.fixture(scope='session', autouse=True)
+def isolate_lttng_session_daemon() -> Iterator[None]:
+    """Keep this package's tracing tests on their own LTTng session daemon."""
+    with isolated_lttng_home(prefix='test-ros2trace-'):
+        yield

--- a/test_tracetools_launch/package.xml
+++ b/test_tracetools_launch/package.xml
@@ -25,6 +25,7 @@
   <test_depend>python3-pytest</test_depend>
   <test_depend>test_tracetools</test_depend>
   <test_depend>tracetools_launch</test_depend>
+  <test_depend>tracetools_test</test_depend>
   <test_depend>tracetools_trace</test_depend>
 
   <export>

--- a/test_tracetools_launch/test/conftest.py
+++ b/test_tracetools_launch/test/conftest.py
@@ -1,0 +1,25 @@
+# Copyright 2026 Sylvester Kaczmarek
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Iterator
+
+import pytest
+from tracetools_test.lttng import isolated_lttng_home
+
+
+@pytest.fixture(scope='session', autouse=True)
+def isolate_lttng_session_daemon() -> Iterator[None]:
+    """Keep this package's tracing tests on their own LTTng session daemon."""
+    with isolated_lttng_home(prefix='test-tracetools-launch-'):
+        yield

--- a/tracetools_test/test/test_lttng.py
+++ b/tracetools_test/test/test_lttng.py
@@ -1,0 +1,57 @@
+# Copyright 2026 Sylvester Kaczmarek
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+from pathlib import Path
+import signal
+
+from tracetools_test.lttng import isolated_lttng_home
+
+
+def test_isolated_lttng_home_restores_existing_value(monkeypatch):
+    monkeypatch.setenv('LTTNG_HOME', '/original/lttng/home')
+
+    with isolated_lttng_home() as lttng_home:
+        assert os.environ['LTTNG_HOME'] == lttng_home
+        assert Path(lttng_home).is_dir()
+
+    assert os.environ['LTTNG_HOME'] == '/original/lttng/home'
+    assert not Path(lttng_home).exists()
+
+
+def test_isolated_lttng_home_restores_unset_value(monkeypatch):
+    monkeypatch.delenv('LTTNG_HOME', raising=False)
+
+    with isolated_lttng_home() as lttng_home:
+        assert os.environ['LTTNG_HOME'] == lttng_home
+
+    assert 'LTTNG_HOME' not in os.environ
+
+
+def test_isolated_lttng_home_stops_private_session_daemon(monkeypatch):
+    calls = []
+
+    def kill(pid, sig):
+        calls.append((pid, sig))
+        if sig == 0:
+            raise ProcessLookupError
+
+    monkeypatch.setattr(os, 'kill', kill)
+
+    with isolated_lttng_home() as lttng_home:
+        lttng_dir = Path(lttng_home) / '.lttng'
+        lttng_dir.mkdir()
+        (lttng_dir / 'lttng-sessiond.pid').write_text('12345')
+
+    assert calls == [(12345, signal.SIGTERM), (12345, 0)]

--- a/tracetools_test/tracetools_test/lttng.py
+++ b/tracetools_test/tracetools_test/lttng.py
@@ -1,0 +1,92 @@
+# Copyright 2026 Sylvester Kaczmarek
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from contextlib import contextmanager
+import os
+import shutil
+import signal
+import tempfile
+import time
+from typing import Iterator
+from typing import Optional
+
+
+_SESSION_DAEMON_STOP_TIMEOUT = 5.0
+_SESSION_DAEMON_STOP_POLL_INTERVAL = 0.05
+
+
+def _get_session_daemon_pid(lttng_home: str) -> Optional[int]:
+    pid_path = os.path.join(lttng_home, '.lttng', 'lttng-sessiond.pid')
+    if not os.path.isfile(pid_path):
+        return None
+    try:
+        with open(pid_path, 'r') as pid_file:
+            pid = pid_file.read().strip()
+    except OSError:
+        return None
+    if not pid.isdigit():
+        return None
+    return int(pid)
+
+
+def _process_exists(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    return True
+
+
+def _stop_session_daemon(lttng_home: str) -> None:
+    pid = _get_session_daemon_pid(lttng_home)
+    if pid is None:
+        return
+
+    try:
+        os.kill(pid, signal.SIGTERM)
+    except ProcessLookupError:
+        return
+
+    deadline = time.monotonic() + _SESSION_DAEMON_STOP_TIMEOUT
+    process_exists = _process_exists(pid)
+    while process_exists and time.monotonic() < deadline:
+        time.sleep(_SESSION_DAEMON_STOP_POLL_INTERVAL)
+        process_exists = _process_exists(pid)
+
+    if process_exists:
+        try:
+            os.kill(pid, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+
+
+@contextmanager
+def isolated_lttng_home(*, prefix: str = 'tracetools-test-') -> Iterator[str]:
+    """Use a private LTTng home and clean up its session daemon afterwards."""
+    previous_lttng_home = os.environ.get('LTTNG_HOME')
+    lttng_home = tempfile.mkdtemp(prefix=prefix)
+    os.environ['LTTNG_HOME'] = lttng_home
+    try:
+        yield lttng_home
+    finally:
+        try:
+            _stop_session_daemon(lttng_home)
+        finally:
+            if previous_lttng_home is None:
+                os.environ.pop('LTTNG_HOME', None)
+            else:
+                os.environ['LTTNG_HOME'] = previous_lttng_home
+            shutil.rmtree(lttng_home, ignore_errors=True)


### PR DESCRIPTION
## Description

Remove the serialization workaround between `test_ros2trace` and `test_tracetools_launch` by giving each package its own LTTng control state.

- add `tracetools_test.isolated_lttng_home()` to create a private `LTTNG_HOME`
- use session-scoped autouse fixtures in both tracing-test packages
- stop only the private session daemon during teardown, restore the previous environment, and remove the temporary home
- remove the false `test_ros2trace` dependency on `test_tracetools_launch`

This allows the build farm to schedule the two packages in parallel without sharing the same LTTng session daemon.

Fixes #99

### Is this user-facing behavior change?

### Did you use Generative AI?

Yes. AI was used to assist with tests.

### Additional Information

Testing performed:

- `PYTHONPATH=tracetools_test pytest -q tracetools_test/test/test_lttng.py` → 3 passed
- Python syntax checks for the added helper and fixtures
- package XML parsing
- `git diff --check`